### PR TITLE
Feat/since/optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Key | Type | Required | Description | Default |
 `map_zoom` | `number` | `False` | Level of zoom for the generated map link <1-20> | `18`
 `language` | `string` | `False` | Requested* language(s) for state and attributes. Two-Letter language code(s). | *Refer to Notes
 `options` | `string` | `False` | Display options: `zone, place, place_name, street_number, street, city, county, state, postal_code, country, formatted_address, do_not_show_not_home` | `zone, place`
+`include_start_time_in_state` | `boolean` | `False` | Whether or not to include the timestamp "(since hh:mm)" in the state so you can tell how long a person has been at a location. Some users may prefer this to be `False` so that the state at the same location is consistent. | `True`
 
 Sample attributes that can be used in notifications, alerts, automations, etc:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # places
 
-
 [![GitHub Release][releases-shield]][releases]
 [![GitHub Activity][commits-shield]][commits]
 [![License][license-shield]](LICENSE.md)
@@ -20,7 +19,7 @@ _Component to integrate with OpenStreetMap Reverse Geocode (PLACE)_
 4. Download _all_ the files from the `custom_components/places/` directory (folder) in this repository.
 5. Place the files you downloaded in the new directory (folder) you created.
 6. Add your configuration
-6. Restart Home Assistant
+7. Restart Home Assistant
 
 Using your HA configuration directory (folder) as a starting point you should now also have this:
 
@@ -81,6 +80,7 @@ Key | Type | Required | Description | Default |
 `options` | `string` | `False` | Display options: `zone, place, place_name, street_number, street, city, county, state, postal_code, country, formatted_address, do_not_show_not_home` | `zone, place`
 
 Sample attributes that can be used in notifications, alerts, automations, etc:
+
 ```json
 {
   "formatted_address": "Richmond Hill GO Station, 6, Newkirk Road, Beverley Acres, Richmond Hill, York Region, Ontario, L4C 1B3, Canada",
@@ -119,6 +119,7 @@ Sample attributes that can be used in notifications, alerts, automations, etc:
 
 Sample generic automations.yaml snippet to send an iOS notify on any device state change:
 (the only difference is the second one uses a condition to only trigger for a specific user)
+
 ```yaml
 - alias: ReverseLocateEveryone
   initial_state: 'on'
@@ -130,7 +131,7 @@ Sample generic automations.yaml snippet to send an iOS notify on any device stat
     data_template:
       title: 'ReverseLocate: {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }}) {{ trigger.event.data.place_name }}'
       message: |-
-        {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }}) 
+        {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }})
         {{ trigger.event.data.place_name }}
         {{ trigger.event.data.distance_from_home }} from home and traveling {{ trigger.event.data.direction }}
         {{ trigger.event.data.to_state }} ({{ trigger.event.data.mtime }})
@@ -152,7 +153,7 @@ Sample generic automations.yaml snippet to send an iOS notify on any device stat
     data_template:
       title: 'ReverseLocate: {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }}) {{ trigger.event.data.place_name }}'
       message: |-
-        {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }}) 
+        {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }})
         {{ trigger.event.data.place_name }}
         {{ trigger.event.data.distance_from_home }} from home and traveling {{ trigger.event.data.direction }}
         {{ trigger.event.data.to_state }} ({{ trigger.event.data.mtime }})
@@ -172,11 +173,12 @@ Sample generic automations.yaml snippet to send an iOS notify on any device stat
 * When no `language` value is given, default language will be location's local language or English. When a comma separated list of languages is provided - the component will attempt to fill each address field in desired languages by order.
 * Translations are partial in OpenStreetMap database. For each field, if a translation is missing in first requested language it will be resolved with a language following in the provided list, defaulting to local language if no matching translations were found for the list.
 * To enable detailed logging for this component, add the following to your configuration.yaml file
+
 ```yaml
   logger:
     default: warn
     logs:
-      custom_components.sensor.places: debug  
+      custom_components.sensor.places: debug
 ```
 
 Original Author: [Jim Thompson](https://github.com/tenly2000)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Key | Type | Required | Description | Default |
 `map_provider` | `string` | `False` | `google` or `apple` | `apple`
 `map_zoom` | `number` | `False` | Level of zoom for the generated map link <1-20> | `18`
 `language` | `string` | `False` | Requested* language(s) for state and attributes. Two-Letter language code(s). | *Refer to Notes
-`options` | `string` | `False` | Display options: `zone, place, place_name, street_number, street, city, county, state, postal_code, country, formatted_address, do_not_show_not_home` | `zone, place`
+`options` | `string` | `False` | How to record the state. Options: `zone, place, place_name, street_number, street, city, county, state, postal_code, country, formatted_address, do_not_show_not_home, do_not_reorder` | `zone, place`
 `include_start_time_in_state` | `boolean` | `False` | Whether or not to include the timestamp "(since hh:mm)" in the state so you can tell how long a person has been at a location. Some users may prefer this to be `False` so that the state at the same location is consistent. | `True`
 
 Sample attributes that can be used in notifications, alerts, automations, etc:

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -14,11 +14,11 @@ Current Version:  1.8  20210125 - iantrich
            - The state display string begins as a null and appends the following in order:
              - 'zone' - as defined in the device_tracker entity
              - If 'place' is included in the options string, a concatenated string is created with the following attributes
-               - place_name, 
-               - place_category, 
-               - place_type, 
-               - place_neighbourhood, 
-               - street number, 
+               - place_name,
+               - place_category,
+               - place_type,
+               - place_neighbourhood,
+               - street number,
                - street
                - If 'street_number' and 'street' are also in the options string, they are ignored
              - If 'place' is NOT included:
@@ -47,29 +47,29 @@ Current Version:  1.8  20210125 - iantrich
            - longitude
          - Added Map_link option to generate a Google or Apple Maps link to the users current location
 20180509 - Updated to support new option value of "do_not_reorder" to disable the automatic ordered display of any specified options
-         - If "do_not_reorder" appears anywhere in the list of comma delimited options, the state display will be built 
+         - If "do_not_reorder" appears anywhere in the list of comma delimited options, the state display will be built
            using the order of options as they are specified in the options config value.
-           ie:  options: street, street_number, do_not_reorder, postal_code, city, country 
-           will result in a state comprised of: 
-                <street>, <street_number>, <postal_code>, <city>, <country> 
+           ie:  options: street, street_number, do_not_reorder, postal_code, city, country
+           will result in a state comprised of:
+                <street>, <street_number>, <postal_code>, <city>, <country>
            without the "do_not_reorder" option, it would be:
                 <street_number>, <street>, <postal_code>, <city>, <country>
          - The following attributes can be specified in any order for building the display string manually:
             - do_not_reorder
             - place_type, place_name, place_category, place_neighbourhood, street_number, street, city,
             - postal_town, state, region, county, country, postal_code, formatted_address
-            Notes:  All options must be specified in lower case.  
+            Notes:  All options must be specified in lower case.
                     State and Region return the same data (so only use one of them).
          - Also added 'options' to the attribute list that gets populated by this sensor (to make it easier to see why a specific state is being generated)
 20180510 - Fixed stupid bug introduced yesterday.  Converted display options from string to list.
 
-           
+
 Description:
   Provides a sensor with a variable state consisting of reverse geocode (place) details for a linked device_tracker entity that provides GPS co-ordinates (ie owntracks, icloud)
   Optionally allows you to specify a 'home_zone' for each device and calculates distance from home and direction of travel.
   The displayed state adds a time stamp "(since hh:mm)" so you can tell how long a person has been at a location.
   Configuration Instructions are below - as well as sample automations for notifications.
-  
+
   The display options I have set for Sharon are "zone, place" so her state is displayed as:
   - not_home, Richmond Hill GO Station, building, building, Beverley Acres, 6, Newkirk Road (since 18:44)
   There are a lot of additional attributes (beyond state) that are available which can be used in notifications, alerts, etc:
@@ -142,7 +142,7 @@ sensor places_aidan:
     map_zoom: 17
     home_zone: zone.aidan_home
     api_key: !secret email_aidan
-  
+
 Sample generic automations.yaml snippet to send an iOS notify on any device state change:
 (the only difference is the second one uses a condition to only trigger for a specific user)
 
@@ -156,7 +156,7 @@ Sample generic automations.yaml snippet to send an iOS notify on any device stat
     data_template:
       title: 'ReverseLocate: {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }}) {{ trigger.event.data.place_name }}'
       message: |-
-        {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }}) 
+        {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }})
         {{ trigger.event.data.place_name }}
         {{ trigger.event.data.distance_from_home }} from home and traveling {{ trigger.event.data.direction }}
         {{ trigger.event.data.to_state }} ({{ trigger.event.data.mtime }})
@@ -178,7 +178,7 @@ Sample generic automations.yaml snippet to send an iOS notify on any device stat
     data_template:
       title: 'ReverseLocate: {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }}) {{ trigger.event.data.place_name }}'
       message: |-
-        {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }}) 
+        {{ trigger.event.data.entity }} ({{ trigger.event.data.devicetracker_zone }})
         {{ trigger.event.data.place_name }}
         {{ trigger.event.data.distance_from_home }} from home and traveling {{ trigger.event.data.direction }}
         {{ trigger.event.data.to_state }} ({{ trigger.event.data.mtime }})
@@ -206,15 +206,15 @@ Configuration.yaml:
       map_provider: [google|apple]                  (optional)
       map_zoom: <1-20>                              (optional)
       option: <zone, place, street_number, street, city, county, state, postal_code, country, formatted_address>  (optional)
-      
+
 The map link that gets generated for Google maps has a push pin marking the users location.
 The map link for Apple maps is centered on the users location - but without any marker.
-      
+
 To enable detailed logging for this component, add the following to your configuration.yaml file
   logger:
     default: warn
     logs:
-      custom_components.sensor.places: debug  
+      custom_components.sensor.places: debug
 
 """
 

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -937,9 +937,9 @@ class Places(Entity):
                     "(" + self._name + ") Building EventData for (" + new_state + ")"
                 )
                 self._state = new_state
-                self.state += (
+                self._state += (
                     " (since " + current_time + ")"
-                    if self._include_start_time_in_state
+                    if self._include_start_time_in_state == True
                     else ""
                 )
                 event_data = {}

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -232,76 +232,78 @@ from homeassistant.helpers.event import track_state_change
 from homeassistant.util import Throttle
 from homeassistant.util.location import distance
 from homeassistant.helpers.entity import Entity
-from homeassistant.const import (
-    CONF_API_KEY, CONF_NAME, CONF_SCAN_INTERVAL)
+from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
-DEPENDENCIES = ['zone', 'device_tracker']
+DEPENDENCIES = ["zone", "device_tracker"]
 
-CONF_DEVICETRACKER_ID = 'devicetracker_id'
-CONF_HOME_ZONE = 'home_zone'
-CONF_OPTIONS = 'options'
-CONF_MAP_PROVIDER = 'map_provider'
-CONF_MAP_ZOOM = 'map_zoom'
-CONF_LANGUAGE = 'language'
+CONF_DEVICETRACKER_ID = "devicetracker_id"
+CONF_HOME_ZONE = "home_zone"
+CONF_OPTIONS = "options"
+CONF_MAP_PROVIDER = "map_provider"
+CONF_MAP_ZOOM = "map_zoom"
+CONF_LANGUAGE = "language"
 
-ATTR_OPTIONS = 'options'
-ATTR_STREET_NUMBER = 'street_number'
-ATTR_STREET = 'street'
-ATTR_CITY = 'city'
-ATTR_POSTAL_TOWN = 'postal_town'
-ATTR_POSTAL_CODE = 'postal_code'
-ATTR_REGION = 'state_province'
-ATTR_COUNTRY = 'country'
-ATTR_COUNTY = 'county'
-ATTR_FORMATTED_ADDRESS = 'formatted_address'
-ATTR_PLACE_TYPE = 'place_type'
-ATTR_PLACE_NAME = 'place_name'
-ATTR_PLACE_CATEGORY = 'place_category'
-ATTR_PLACE_NEIGHBOURHOOD = 'neighbourhood'
-ATTR_DEVICETRACKER_ID = 'devicetracker_entityid'
-ATTR_DEVICETRACKER_ZONE = 'devicetracker_zone'
-ATTR_PICTURE = 'entity_picture'
-ATTR_LATITUDE_OLD = 'previous_latitude'
-ATTR_LONGITUDE_OLD = 'previous_longitude'
-ATTR_LATITUDE = 'current_latitude'
-ATTR_LONGITUDE = 'current_longitude'
-ATTR_MTIME = 'last_changed'
-ATTR_DISTANCE_KM = 'distance_from_home_km'
-ATTR_DISTANCE_M = 'distance_from_home_m'
-ATTR_HOME_ZONE = 'home_zone'
-ATTR_HOME_LATITUDE = 'home_latitude'
-ATTR_HOME_LONGITUDE = 'home_longitude'
-ATTR_LOCATION_CURRENT = 'current_location'
-ATTR_LOCATION_PREVIOUS = 'previous_location'
-ATTR_DIRECTION_OF_TRAVEL = 'direction_of_travel'
-ATTR_MAP_LINK = 'map_link'
+ATTR_OPTIONS = "options"
+ATTR_STREET_NUMBER = "street_number"
+ATTR_STREET = "street"
+ATTR_CITY = "city"
+ATTR_POSTAL_TOWN = "postal_town"
+ATTR_POSTAL_CODE = "postal_code"
+ATTR_REGION = "state_province"
+ATTR_COUNTRY = "country"
+ATTR_COUNTY = "county"
+ATTR_FORMATTED_ADDRESS = "formatted_address"
+ATTR_PLACE_TYPE = "place_type"
+ATTR_PLACE_NAME = "place_name"
+ATTR_PLACE_CATEGORY = "place_category"
+ATTR_PLACE_NEIGHBOURHOOD = "neighbourhood"
+ATTR_DEVICETRACKER_ID = "devicetracker_entityid"
+ATTR_DEVICETRACKER_ZONE = "devicetracker_zone"
+ATTR_PICTURE = "entity_picture"
+ATTR_LATITUDE_OLD = "previous_latitude"
+ATTR_LONGITUDE_OLD = "previous_longitude"
+ATTR_LATITUDE = "current_latitude"
+ATTR_LONGITUDE = "current_longitude"
+ATTR_MTIME = "last_changed"
+ATTR_DISTANCE_KM = "distance_from_home_km"
+ATTR_DISTANCE_M = "distance_from_home_m"
+ATTR_HOME_ZONE = "home_zone"
+ATTR_HOME_LATITUDE = "home_latitude"
+ATTR_HOME_LONGITUDE = "home_longitude"
+ATTR_LOCATION_CURRENT = "current_location"
+ATTR_LOCATION_PREVIOUS = "previous_location"
+ATTR_DIRECTION_OF_TRAVEL = "direction_of_travel"
+ATTR_MAP_LINK = "map_link"
 
-DEFAULT_NAME = 'places'
-DEFAULT_OPTION = 'zone, place'
-DEFAULT_HOME_ZONE = 'zone.home'
+DEFAULT_NAME = "places"
+DEFAULT_OPTION = "zone, place"
+DEFAULT_HOME_ZONE = "zone.home"
 DEFAULT_KEY = "no key"
-DEFAULT_MAP_PROVIDER = 'apple'
-DEFAULT_MAP_ZOOM = '18'
-DEFAULT_LANGUAGE = 'default'
+DEFAULT_MAP_PROVIDER = "apple"
+DEFAULT_MAP_ZOOM = "18"
+DEFAULT_LANGUAGE = "default"
 
 SCAN_INTERVAL = timedelta(seconds=30)
 THROTTLE_INTERVAL = timedelta(seconds=600)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_DEVICETRACKER_ID): cv.string,
-    vol.Optional(CONF_API_KEY, default=DEFAULT_KEY): cv.string,
-    vol.Optional(CONF_OPTIONS, default=DEFAULT_OPTION): cv.string,
-    vol.Optional(CONF_HOME_ZONE, default=DEFAULT_HOME_ZONE): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_MAP_PROVIDER, default=DEFAULT_MAP_PROVIDER): cv.string,
-    vol.Optional(CONF_MAP_ZOOM, default=DEFAULT_MAP_ZOOM): cv.string,
-    vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): cv.string,
-    vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_DEVICETRACKER_ID): cv.string,
+        vol.Optional(CONF_API_KEY, default=DEFAULT_KEY): cv.string,
+        vol.Optional(CONF_OPTIONS, default=DEFAULT_OPTION): cv.string,
+        vol.Optional(CONF_HOME_ZONE, default=DEFAULT_HOME_ZONE): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_MAP_PROVIDER, default=DEFAULT_MAP_PROVIDER): cv.string,
+        vol.Optional(CONF_MAP_ZOOM, default=DEFAULT_MAP_ZOOM): cv.string,
+        vol.Optional(CONF_LANGUAGE, default=DEFAULT_LANGUAGE): cv.string,
+        vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
+    }
+)
 
-TRACKABLE_DOMAINS = ['device_tracker']
+TRACKABLE_DOMAINS = ["device_tracker"]
+
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     """Setup the sensor platform."""
@@ -314,13 +316,38 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     map_zoom = config.get(CONF_MAP_ZOOM)
     language = config.get(CONF_LANGUAGE)
 
-    add_devices([Places(hass, devicetracker_id, name, api_key, options, home_zone, map_provider, map_zoom, language)])
+    add_devices(
+        [
+            Places(
+                hass,
+                devicetracker_id,
+                name,
+                api_key,
+                options,
+                home_zone,
+                map_provider,
+                map_zoom,
+                language,
+            )
+        ]
+    )
 
 
 class Places(Entity):
     """Representation of a Places Sensor."""
 
-    def __init__(self, hass, devicetracker_id, name, api_key, options, home_zone, map_provider, map_zoom, language):
+    def __init__(
+        self,
+        hass,
+        devicetracker_id,
+        name,
+        api_key,
+        options,
+        home_zone,
+        map_provider,
+        map_zoom,
+        language,
+    ):
         """Initialize the sensor."""
         self._hass = hass
         self._name = name
@@ -334,9 +361,13 @@ class Places(Entity):
         self._language.replace(" ", "")
         self._state = "Initializing... (since 99:99)"
 
-        home_latitude = str(hass.states.get(home_zone).attributes.get('latitude'))
-        home_longitude = str(hass.states.get(home_zone).attributes.get('longitude'))
-        self._entity_picture = hass.states.get(devicetracker_id).attributes.get('entity_picture') if hass.states.get(devicetracker_id) else None
+        home_latitude = str(hass.states.get(home_zone).attributes.get("latitude"))
+        home_longitude = str(hass.states.get(home_zone).attributes.get("longitude"))
+        self._entity_picture = (
+            hass.states.get(devicetracker_id).attributes.get("entity_picture")
+            if hass.states.get(devicetracker_id)
+            else None
+        )
         self._street_number = None
         self._street = None
         self._city = None
@@ -352,29 +383,45 @@ class Places(Entity):
         self._place_category = None
         self._place_neighbourhood = None
         self._home_latitude = home_latitude
-        self._home_longitude = home_longitude 
+        self._home_longitude = home_longitude
         self._latitude_old = home_latitude
         self._longitude_old = home_longitude
         self._latitude = home_latitude
         self._longitude = home_longitude
-        self._devicetracker_zone = 'Home'
+        self._devicetracker_zone = "Home"
         self._mtime = str(datetime.now())
         self._distance_km = 0
         self._distance_m = 0
-        self._location_current = home_latitude + ',' + home_longitude
-        self._location_previous = home_latitude + ',' + home_longitude
+        self._location_current = home_latitude + "," + home_longitude
+        self._location_previous = home_latitude + "," + home_longitude
         self._updateskipped = 0
-        self._direction = 'stationary'
+        self._direction = "stationary"
         self._map_link = None
         #'https://www.google.com/maps/@' + home_latitude + "," + home_longitude + ',19z'
 
         # Check if devicetracker_id was specified correctly
-        _LOGGER.info( "(" + self._name + ") DeviceTracker Entity ID is " + devicetracker_id.split('.', 1)[1] )
+        _LOGGER.info(
+            "("
+            + self._name
+            + ") DeviceTracker Entity ID is "
+            + devicetracker_id.split(".", 1)[1]
+        )
 
-        if devicetracker_id.split('.', 1)[0] in TRACKABLE_DOMAINS:
+        if devicetracker_id.split(".", 1)[0] in TRACKABLE_DOMAINS:
             self._devicetracker_id = devicetracker_id
-            track_state_change(hass, self._devicetracker_id, self.tsc_update, from_state=None, to_state=None)
-            _LOGGER.info( "(" + self._name + ") Now subscribed to state change events from " + self._devicetracker_id )
+            track_state_change(
+                hass,
+                self._devicetracker_id,
+                self.tsc_update,
+                from_state=None,
+                to_state=None,
+            )
+            _LOGGER.info(
+                "("
+                + self._name
+                + ") Now subscribed to state change events from "
+                + self._devicetracker_id
+            )
 
     @property
     def name(self):
@@ -394,7 +441,7 @@ class Places(Entity):
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
-        return{
+        return {
             ATTR_STREET_NUMBER: self._street_number,
             ATTR_STREET: self._street,
             ATTR_CITY: self._city,
@@ -425,17 +472,16 @@ class Places(Entity):
             ATTR_HOME_LONGITUDE: self._home_longitude,
             ATTR_DIRECTION_OF_TRAVEL: self._direction,
             ATTR_MAP_LINK: self._map_link,
-            ATTR_OPTIONS: self._options
+            ATTR_OPTIONS: self._options,
         }
 
-
     def tsc_update(self, tscarg2, tsarg3, tsarg4):
-        """ Call the do_update function based on the TSC (track state change) event    """
+        """Call the do_update function based on the TSC (track state change) event"""
         self.do_update("Track State Change")
 
     @Throttle(THROTTLE_INTERVAL)
     def update(self):
-        """ Call the do_update function based on scan interval and throttle    """
+        """Call the do_update function based on scan interval and throttle"""
         self.do_update("Scan Interval")
 
     def haversine(self, lon1, lat1, lon2, lat2):
@@ -443,15 +489,15 @@ class Places(Entity):
         Calculate the great circle distance between two points
         on the earth (specified in decimal degrees)
         """
-        # convert decimal degrees to radians 
+        # convert decimal degrees to radians
         lon1, lat1, lon2, lat2 = map(radians, [lon1, lat1, lon2, lat2])
 
-        # haversine formula 
-        dlon = lon2 - lon1 
-        dlat = lat2 - lat1 
-        a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
-        c = 2 * asin(sqrt(a)) 
-        r = 6371 # Radius of earth in kilometers. Use 3956 for miles
+        # haversine formula
+        dlon = lon2 - lon1
+        dlat = lat2 - lat1
+        a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+        c = 2 * asin(sqrt(a))
+        r = 6371  # Radius of earth in kilometers. Use 3956 for miles
         return c * r
 
     def do_update(self, reason):
@@ -461,82 +507,175 @@ class Places(Entity):
         distance_traveled = 0
         devicetracker_zone = None
 
-        _LOGGER.info( "(" + self._name + ") Calling update due to " + reason )
-        _LOGGER.info( "(" + self._name + ") Check if update req'd : " + self._devicetracker_id )
-        _LOGGER.debug( "(" + self._name + ") Previous State        : " + previous_state )
+        _LOGGER.info("(" + self._name + ") Calling update due to " + reason)
+        _LOGGER.info(
+            "(" + self._name + ") Check if update req'd : " + self._devicetracker_id
+        )
+        _LOGGER.debug("(" + self._name + ") Previous State        : " + previous_state)
 
-        if hasattr(self, '_devicetracker_id') and self.hass.states.get(self._devicetracker_id) is not None:
+        if (
+            hasattr(self, "_devicetracker_id")
+            and self.hass.states.get(self._devicetracker_id) is not None
+        ):
             now = datetime.now()
-            old_latitude    = str(self._latitude)
-            old_longitude   = str(self._longitude)
-            new_latitude    = str(self._hass.states.get(self._devicetracker_id).attributes.get('latitude'))
-            new_longitude   = str(self._hass.states.get(self._devicetracker_id).attributes.get('longitude'))
-            home_latitude   = str(self._home_latitude)
-            home_longitude  = str(self._home_longitude)
+            old_latitude = str(self._latitude)
+            old_longitude = str(self._longitude)
+            new_latitude = str(
+                self._hass.states.get(self._devicetracker_id).attributes.get("latitude")
+            )
+            new_longitude = str(
+                self._hass.states.get(self._devicetracker_id).attributes.get(
+                    "longitude"
+                )
+            )
+            home_latitude = str(self._home_latitude)
+            home_longitude = str(self._home_longitude)
             last_distance_m = self._distance_m
-            last_updated    = self._mtime
-            current_location  = new_latitude + "," + new_longitude
+            last_updated = self._mtime
+            current_location = new_latitude + "," + new_longitude
             previous_location = old_latitude + "," + old_longitude
-            home_location     = home_latitude + "," + home_longitude
-            
-            #maplink_google ='https://www.google.com/maps/@' + current_location+',' + self._map_zoom + 'z'
-            maplink_apple  = 'https://maps.apple.com/maps/?q=' + current_location + '&z=' + self._map_zoom
-            #maplink_google = 'https://www.google.com/maps/dir/?api=1&origin=' + current_location + '&destination=' + home_location + '&travelmode=driving&layer=traffic'
-            maplink_google = 'https://www.google.com/maps/search/?api=1&basemap=roadmap&layer=traffic&query=' + current_location
-            if (new_latitude != 'None' and new_longitude != 'None' and
-                    home_latitude != 'None' and home_longitude != 'None'):
-              distance_m = distance(float(new_latitude), float(new_longitude), float(home_latitude), float(home_longitude))
-              distance_km = round(distance_m / 1000, 2)
-              distance_from_home = str(distance_km)+' km'
+            home_location = home_latitude + "," + home_longitude
 
-              deviation = self.haversine(float(old_latitude), float(old_longitude), float(new_latitude), float(new_longitude))
-              if deviation <= 0.2: # in kilometers
-                direction = "stationary"
-              elif last_distance_m > distance_m:
-                direction = "towards home"
-              elif last_distance_m < distance_m:
-                direction = "away from home"
-              else:
-                direction = "stationary"
+            # maplink_google ='https://www.google.com/maps/@' + current_location+',' + self._map_zoom + 'z'
+            maplink_apple = (
+                "https://maps.apple.com/maps/?q="
+                + current_location
+                + "&z="
+                + self._map_zoom
+            )
+            # maplink_google = 'https://www.google.com/maps/dir/?api=1&origin=' + current_location + '&destination=' + home_location + '&travelmode=driving&layer=traffic'
+            maplink_google = (
+                "https://www.google.com/maps/search/?api=1&basemap=roadmap&layer=traffic&query="
+                + current_location
+            )
+            if (
+                new_latitude != "None"
+                and new_longitude != "None"
+                and home_latitude != "None"
+                and home_longitude != "None"
+            ):
+                distance_m = distance(
+                    float(new_latitude),
+                    float(new_longitude),
+                    float(home_latitude),
+                    float(home_longitude),
+                )
+                distance_km = round(distance_m / 1000, 2)
+                distance_from_home = str(distance_km) + " km"
 
-              _LOGGER.debug( "(" + self._name + ") Previous Location: " + previous_location)
-              _LOGGER.debug( "(" + self._name + ") Current Location : " + current_location)
-              _LOGGER.debug( "(" + self._name + ") Home Location    : " + home_location)
-              _LOGGER.info( "(" + self._name + ") Distance from home : (" + (self._home_zone).split(".")[1] + "): " + distance_from_home )
-              _LOGGER.info( "(" + self._name + ") Travel Direction   :(" + direction + ")" )
-           
-              """Update if location has changed."""
+                deviation = self.haversine(
+                    float(old_latitude),
+                    float(old_longitude),
+                    float(new_latitude),
+                    float(new_longitude),
+                )
+                if deviation <= 0.2:  # in kilometers
+                    direction = "stationary"
+                elif last_distance_m > distance_m:
+                    direction = "towards home"
+                elif last_distance_m < distance_m:
+                    direction = "away from home"
+                else:
+                    direction = "stationary"
 
-              devicetracker_zone = self.hass.states.get(self._devicetracker_id).state
-              distance_traveled = distance(float(new_latitude), float(new_longitude), float(old_latitude), float(old_longitude))
+                _LOGGER.debug(
+                    "(" + self._name + ") Previous Location: " + previous_location
+                )
+                _LOGGER.debug(
+                    "(" + self._name + ") Current Location : " + current_location
+                )
+                _LOGGER.debug(
+                    "(" + self._name + ") Home Location    : " + home_location
+                )
+                _LOGGER.info(
+                    "("
+                    + self._name
+                    + ") Distance from home : ("
+                    + (self._home_zone).split(".")[1]
+                    + "): "
+                    + distance_from_home
+                )
+                _LOGGER.info(
+                    "(" + self._name + ") Travel Direction   :(" + direction + ")"
+                )
 
-              _LOGGER.info( "(" + self._name + ") DeviceTracker Zone (before update): " + devicetracker_zone )
-              _LOGGER.info( "(" + self._name + ") Meters traveled since last update: " + str(round(distance_traveled)) )
+                """Update if location has changed."""
+
+                devicetracker_zone = self.hass.states.get(self._devicetracker_id).state
+                distance_traveled = distance(
+                    float(new_latitude),
+                    float(new_longitude),
+                    float(old_latitude),
+                    float(old_longitude),
+                )
+
+                _LOGGER.info(
+                    "("
+                    + self._name
+                    + ") DeviceTracker Zone (before update): "
+                    + devicetracker_zone
+                )
+                _LOGGER.info(
+                    "("
+                    + self._name
+                    + ") Meters traveled since last update: "
+                    + str(round(distance_traveled))
+                )
 
         proceed_with_update = True
 
         if current_location == previous_location:
-            _LOGGER.debug( "(" + self._name + ") Skipping update because co-ordinates are identical" )
+            _LOGGER.debug(
+                "("
+                + self._name
+                + ") Skipping update because co-ordinates are identical"
+            )
             proceed_with_update = False
         elif int(distance_traveled) > 0 and self._updateskipped > 3:
             proceed_with_update = True
-            _LOGGER.debug( "(" + self._name + ") Allowing update after 3 skips even with distance traveled < 10m" )            
+            _LOGGER.debug(
+                "("
+                + self._name
+                + ") Allowing update after 3 skips even with distance traveled < 10m"
+            )
         elif int(distance_traveled) < 10:
             self._updateskipped = self._updateskipped + 1
-            _LOGGER.debug( "(" + self._name + ") Skipping update because location changed " + str(distance_traveled) + " < 10m  (" + str(self._updateskipped) + ")" )
+            _LOGGER.debug(
+                "("
+                + self._name
+                + ") Skipping update because location changed "
+                + str(distance_traveled)
+                + " < 10m  ("
+                + str(self._updateskipped)
+                + ")"
+            )
             proceed_with_update = False
-        
-        if previous_state == 'Initializing...':
-            _LOGGER.debug( "(" + self._name + ") Peforming Initial Update for user at home..." )
+
+        if previous_state == "Initializing...":
+            _LOGGER.debug(
+                "(" + self._name + ") Peforming Initial Update for user at home..."
+            )
             proceed_with_update = True
 
         if proceed_with_update and devicetracker_zone:
-            _LOGGER.debug( "(" + self._name + ") Proceeding with update for " + self._devicetracker_id )
+            _LOGGER.debug(
+                "("
+                + self._name
+                + ") Proceeding with update for "
+                + self._devicetracker_id
+            )
             self._devicetracker_zone = devicetracker_zone
-            _LOGGER.info( "(" + self._name + ") DeviceTracker Zone (current) " + self._devicetracker_zone + " Skipped Updates: " + str(self._updateskipped))
+            _LOGGER.info(
+                "("
+                + self._name
+                + ") DeviceTracker Zone (current) "
+                + self._devicetracker_zone
+                + " Skipped Updates: "
+                + str(self._updateskipped)
+            )
 
             self._reset_attributes()
-            
+
             self._latitude = new_latitude
             self._longitude = new_longitude
             self._latitude_old = old_latitude
@@ -548,42 +687,73 @@ class Places(Entity):
             self._distance_m = distance_m
             self._direction = direction
 
-            if self._map_provider == 'google':
-                _LOGGER.debug( "(" + self._name + ") Google Map Link requested for: [" + self._map_provider + "]")
+            if self._map_provider == "google":
+                _LOGGER.debug(
+                    "("
+                    + self._name
+                    + ") Google Map Link requested for: ["
+                    + self._map_provider
+                    + "]"
+                )
                 self._map_link = maplink_google
             else:
-                _LOGGER.debug( "(" + self._name + ") Apple Map Link requested for: [" + self._map_provider + "]")
+                _LOGGER.debug(
+                    "("
+                    + self._name
+                    + ") Apple Map Link requested for: ["
+                    + self._map_provider
+                    + "]"
+                )
                 self._map_link = maplink_apple
-                
-            _LOGGER.debug( "(" + self._name + ") Map Link generated: " + self._map_link )
 
-            osm_url = "https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=" + self._latitude + "&lon=" + self._longitude + ("&accept-language=" + self._language if self._language != DEFAULT_LANGUAGE else "") + "&addressdetails=1&namedetails=1&zoom=18&limit=1" + ("&email=" + self._api_key if self._api_key != DEFAULT_KEY else "")
+            _LOGGER.debug("(" + self._name + ") Map Link generated: " + self._map_link)
+
+            osm_url = (
+                "https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat="
+                + self._latitude
+                + "&lon="
+                + self._longitude
+                + (
+                    "&accept-language=" + self._language
+                    if self._language != DEFAULT_LANGUAGE
+                    else ""
+                )
+                + "&addressdetails=1&namedetails=1&zoom=18&limit=1"
+                + ("&email=" + self._api_key if self._api_key != DEFAULT_KEY else "")
+            )
 
             osm_decoded = {}
-            _LOGGER.info( "(" + self._name + ") OpenStreetMap request sent with lat=" + self._latitude + " and lon=" + self._longitude)
-            _LOGGER.debug( "(" + self._name + ") url - " + osm_url)
+            _LOGGER.info(
+                "("
+                + self._name
+                + ") OpenStreetMap request sent with lat="
+                + self._latitude
+                + " and lon="
+                + self._longitude
+            )
+            _LOGGER.debug("(" + self._name + ") url - " + osm_url)
             osm_response = get(osm_url)
             osm_json_input = osm_response.text
-            _LOGGER.debug( "(" + self._name + ") response - " + osm_json_input)
+            _LOGGER.debug("(" + self._name + ") response - " + osm_json_input)
             osm_decoded = json.loads(osm_json_input)
             decoded = osm_decoded
 
             place_options = self._options.lower()
-            place_type = '-'
-            place_name = '-'
-            place_category = '-'
-            place_neighbourhood = '-'
-            street_number = ''
-            street = 'Unnamed Road'
-            city = '-'
-            postal_town = '-'
-            region = '-'
-            county = '-'
-            country = '-'
-            postal_code = ''
-            formatted_address = ''
-            target_option = ''
-            
+            place_type = "-"
+            place_name = "-"
+            place_category = "-"
+            place_neighbourhood = "-"
+            street_number = ""
+            street = "Unnamed Road"
+            city = "-"
+            postal_town = "-"
+            region = "-"
+            county = "-"
+            country = "-"
+            postal_code = ""
+            formatted_address = ""
+            target_option = ""
+
             if "place" in self._options:
                 place_type = osm_decoded["type"]
                 if place_type == "yes":
@@ -596,15 +766,15 @@ class Places(Entity):
                         place_name = osm_decoded["address"][place_category]
                 if "name" in osm_decoded["namedetails"]:
                     place_name = osm_decoded["namedetails"]["name"]
-                for language in self._language.split(','):
+                for language in self._language.split(","):
                     if "name:" + language in osm_decoded["namedetails"]:
                         place_name = osm_decoded["namedetails"]["name:" + language]
                         break
                 if "neighbourhood" in osm_decoded["address"]:
                     place_neighbourhood = osm_decoded["address"]["neighbourhood"]
-                if self._devicetracker_zone == 'not_home' and place_name != 'house':
+                if self._devicetracker_zone == "not_home" and place_name != "house":
                     new_state = place_name
-                    
+
             if "house_number" in osm_decoded["address"]:
                 street_number = osm_decoded["address"]["house_number"]
             if "road" in osm_decoded["address"]:
@@ -634,7 +804,7 @@ class Places(Entity):
             self._place_category = place_category
             self._place_neighbourhood = place_neighbourhood
             self._place_name = place_name
-            
+
             self._street_number = street_number
             self._street = street
             self._city = city
@@ -645,28 +815,38 @@ class Places(Entity):
             self._postal_code = postal_code
             self._formatted_address = formatted_address
             self._mtime = str(datetime.now())
-            
-            if 'error_message' in osm_decoded:
-                new_state = osm_decoded['error_message']
-                _LOGGER.info( "(" + self._name + ") An error occurred contacting the web service")
+
+            if "error_message" in osm_decoded:
+                new_state = osm_decoded["error_message"]
+                _LOGGER.info(
+                    "(" + self._name + ") An error occurred contacting the web service"
+                )
             elif self._devicetracker_zone == "not_home":
-                if city == '-':
+                if city == "-":
                     city = postal_town
-                    if city == '-':
+                    if city == "-":
                         city = county
 
                 # Options:  "zone, place, street_number, street, city, county, state, postal_code, country, formatted_address"
 
-                _LOGGER.debug( "(" + self._name + ") Building State from Display Options: " + self._options)
+                _LOGGER.debug(
+                    "("
+                    + self._name
+                    + ") Building State from Display Options: "
+                    + self._options
+                )
 
                 display_options = []
-                options_array = self._options.split(',')
+                options_array = self._options.split(",")
                 for option in options_array:
                     display_options.append(option.strip())
-                    
+
                 user_display = []
 
-                if "zone" in display_options and ("do_not_show_not_home" not in display_options and self._devicetracker_zone != "not_home"):
+                if "zone" in display_options and (
+                    "do_not_show_not_home" not in display_options
+                    and self._devicetracker_zone != "not_home"
+                ):
                     zone = self._devicetracker_zone
                     user_display.append(zone)
                 if "place_name" in display_options:
@@ -712,43 +892,59 @@ class Places(Entity):
                             target_option = "place_neighbourhood"
                         if option in locals():
                             user_display.append(target_option)
-                            
 
                 if not user_display:
                     user_display = self._devicetracker_zone
                     user_display.append(street)
                     user_display.append(city)
 
-                new_state = ', '.join( item for item in user_display )
-                _LOGGER.debug( "(" + self._name + ") New State built from Display Options will be: " + new_state )
+                new_state = ", ".join(item for item in user_display)
+                _LOGGER.debug(
+                    "("
+                    + self._name
+                    + ") New State built from Display Options will be: "
+                    + new_state
+                )
             else:
                 new_state = devicetracker_zone
-                _LOGGER.debug( "(" + self._name + ") New State from DeviceTracker set to: " + new_state)
+                _LOGGER.debug(
+                    "("
+                    + self._name
+                    + ") New State from DeviceTracker set to: "
+                    + new_state
+                )
 
             current_time = "%02d:%02d" % (now.hour, now.minute)
-            
+
             if previous_state != new_state:
-                _LOGGER.info( "(" + self._name + ") New state built using options: " + self._options)
-                _LOGGER.debug( "(" + self._name + ") Building EventData for (" + new_state +")")
+                _LOGGER.info(
+                    "("
+                    + self._name
+                    + ") New state built using options: "
+                    + self._options
+                )
+                _LOGGER.debug(
+                    "(" + self._name + ") Building EventData for (" + new_state + ")"
+                )
                 self._state = new_state + " (since " + current_time + ")"
                 event_data = {}
-                event_data['entity'] = self._name
-                event_data['place_name'] = place_name
-                event_data['from_state'] = previous_state
-                event_data['to_state'] = new_state
-                event_data['distance_from_home'] = distance_from_home
-                event_data['direction'] = direction
-                event_data['devicetracker_zone'] = devicetracker_zone
-                event_data['latitude'] = self._latitude
-                event_data['longitude'] = self._longitude
-                event_data['previous_latitude'] = self._latitude_old
-                event_data['previous_longitude'] = self._longitude_old
-                event_data['map'] = self._map_link
-                event_data['mtime'] = current_time
-                #_LOGGER.debug( "(" + self._name + ") Event Data: " + event_data )
-                #self._hass.bus.fire(DEFAULT_NAME+'_state_update', { 'entity': self._name, 'place_name': place_name, 'from_state': previous_state, 'to_state': new_state, 'distance_from_home': distance_from_home, 'direction': direction, 'devicetracker_zone': devicetracker_zone, 'mtime': current_time, 'latitude': self._latitude, 'longitude': self._longitude, 'map': self._map_link })
-                self._hass.bus.fire(DEFAULT_NAME+'_state_update', event_data )
-                _LOGGER.debug( "(" + self._name + ") Update complete...")
+                event_data["entity"] = self._name
+                event_data["place_name"] = place_name
+                event_data["from_state"] = previous_state
+                event_data["to_state"] = new_state
+                event_data["distance_from_home"] = distance_from_home
+                event_data["direction"] = direction
+                event_data["devicetracker_zone"] = devicetracker_zone
+                event_data["latitude"] = self._latitude
+                event_data["longitude"] = self._longitude
+                event_data["previous_latitude"] = self._latitude_old
+                event_data["previous_longitude"] = self._longitude_old
+                event_data["map"] = self._map_link
+                event_data["mtime"] = current_time
+                # _LOGGER.debug( "(" + self._name + ") Event Data: " + event_data )
+                # self._hass.bus.fire(DEFAULT_NAME+'_state_update', { 'entity': self._name, 'place_name': place_name, 'from_state': previous_state, 'to_state': new_state, 'distance_from_home': distance_from_home, 'direction': direction, 'devicetracker_zone': devicetracker_zone, 'mtime': current_time, 'latitude': self._latitude, 'longitude': self._longitude, 'map': self._map_link })
+                self._hass.bus.fire(DEFAULT_NAME + "_state_update", event_data)
+                _LOGGER.debug("(" + self._name + ") Update complete...")
 
     def _reset_attributes(self):
         """Resets attributes."""


### PR DESCRIPTION
## What

This makes the `since (hh:mm)` text in the state optional. 

## How

There is a new configuration called `include_start_time_in_state` which is defaulted to `True` (current behavior)

## Why

I prefer to have the state not include metadata like start time time. This makes automations based off this state easier and makes the history graph's color coding more useful.

## Notes
I also ran black as per `contributions.md` and ran some other minor linting such as removing trailing whitespace.

## Testing
Ran it with `include_start_time_in_state` not set at all in the yaml, with it set to `true`, and it set to `false`. 
![image](https://user-images.githubusercontent.com/45444205/174498492-80df8b3c-9138-443b-a3f9-ca4754df3560.png)
