### PR TITLE
Limit state to 255 characters

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -730,6 +730,7 @@ class Places(Entity):
             if previous_state != new_state:
                 _LOGGER.info( "(" + self._name + ") New state built using options: " + self._options)
                 _LOGGER.debug( "(" + self._name + ") Building EventData for (" + new_state +")")
+                new_state = new_state[:(255-14)]
                 self._state = new_state + " (since " + current_time + ")"
                 event_data = {}
                 event_data['entity'] = self._name


### PR DESCRIPTION
Truncate the state to 255-14 characters. The 14 is for the " (since xx:yy)" added to the end of the state.

Fixes: #44 