### PR TITLE
Fix more devicetracker_id selector issues

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -65,7 +65,10 @@ def get_devicetracker_id_entities(
         clean_list.append(current_entity)
     clean_list = [*set(clean_list)]
     clean_list.sort()
-    # _LOGGER.debug("Devicetracker entities with lat/long: " + str(clean_list))
+    _LOGGER.debug(
+        "Devicetracker_id entities including sensors with lat/long: " +
+        str(clean_list)
+    )
     return clean_list
 
 
@@ -206,7 +209,8 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
             for m in dict(user_input).keys():
                 if not user_input.get(m):
                     user_input.pop(m)
-            _LOGGER.debug("[Options Update] user_input: " + str(user_input))
+            _LOGGER.debug(
+                "[Options Update] updated config: " + str(user_input))
 
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=user_input, options=self.config_entry.options
@@ -220,7 +224,8 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
             else None,
         )
         # _LOGGER.debug(
-        #    "Devicetracker entities with lat/long: " + str(devicetracker_id_list)
+        #    "Devicetracker_id entities including sensors with lat/long: "
+        #    + str(devicetracker_id_list)
         # )
         OPTIONS_SCHEMA = vol.Schema(
             {
@@ -318,6 +323,9 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
                 ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             }
         )
+
+        _LOGGER.debug("[Options Update] initial config: " +
+                      str(self.config_entry.data))
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -5,7 +5,13 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries, core
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_NAME,
+    Platform,
+)
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 
@@ -41,17 +47,23 @@ COMPONENT_CONFIG_URL = (
 # https://developers.home-assistant.io/docs/config_entries_config_flow_handler/#translations
 
 
-def get_devicetracker_id_entities(hass: core.HomeAssistant) -> list[str]:
-    """Get the list of valid entities (ones with latitude and longitude attributes) for the devicetracker selector"""
+def get_devicetracker_id_entities(
+    hass: core.HomeAssistant, current_entity=None
+) -> list[str]:
+    """Get the list of valid entities. For sensors, only include ones with latitude and longitude attributes. For the devicetracker selector"""
     clean_list = []
     for dom in TRACKING_DOMAINS:
         # _LOGGER.debug("Geting entities for domain: " + str(dom))
         for ent in hass.states.async_all(dom):
-            if (
+            if dom not in [Platform.SENSOR] or (
                 CONF_LATITUDE in hass.states.get(ent.entity_id).attributes
                 and CONF_LONGITUDE in hass.states.get(ent.entity_id).attributes
             ):
                 clean_list.append(str(ent.entity_id))
+    # Optional: Include the current entity in the list as well.
+    if current_entity is not None:
+        clean_list.append(current_entity)
+    clean_list = [*set(clean_list)]
     clean_list.sort()
     # _LOGGER.debug("Devicetracker entities with lat/long: " + str(clean_list))
     return clean_list
@@ -200,7 +212,10 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
                 self.config_entry, data=user_input, options=self.config_entry.options
             )
             return self.async_create_entry(title="", data={})
-        devicetracker_id_list = get_devicetracker_id_entities(self.hass)
+        # Include the current entity in the list as well. Although it may still fail in validation checking.
+        devicetracker_id_list = get_devicetracker_id_entities(
+            self.hass, user_input.get(CONF_DEVICETRACKER_ID)
+        )
         # _LOGGER.debug(
         #    "Devicetracker entities with lat/long: " + str(devicetracker_id_list)
         # )

--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -214,7 +214,10 @@ class PlacesOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_create_entry(title="", data={})
         # Include the current entity in the list as well. Although it may still fail in validation checking.
         devicetracker_id_list = get_devicetracker_id_entities(
-            self.hass, user_input.get(CONF_DEVICETRACKER_ID)
+            self.hass,
+            self.config_entry.data[CONF_DEVICETRACKER_ID]
+            if CONF_DEVICETRACKER_ID in self.config_entry.data
+            else None,
         )
         # _LOGGER.debug(
         #    "Devicetracker entities with lat/long: " + str(devicetracker_id_list)

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -205,7 +205,7 @@ async def async_setup_platform(
             )
         )
     )
-    if not (
+    if import_config[CONF_DEVICETRACKER_ID].split(".")[0] not in [Places.SENSOR] and not (
         CONF_LATITUDE
         in hass.states.get(import_config[CONF_DEVICETRACKER_ID]).attributes
         and CONF_LONGITUDE

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -32,6 +32,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     EVENT_HOMEASSISTANT_START,
+    Platform,
 )
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -206,7 +207,7 @@ async def async_setup_platform(
         )
     )
     if import_config[CONF_DEVICETRACKER_ID].split(".")[0] not in [
-        Places.SENSOR
+        Platform.SENSOR
     ] and not (
         CONF_LATITUDE
         in hass.states.get(import_config[CONF_DEVICETRACKER_ID]).attributes

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -205,7 +205,9 @@ async def async_setup_platform(
             )
         )
     )
-    if import_config[CONF_DEVICETRACKER_ID].split(".")[0] not in [Places.SENSOR] and not (
+    if import_config[CONF_DEVICETRACKER_ID].split(".")[0] not in [
+        Places.SENSOR
+    ] and not (
         CONF_LATITUDE
         in hass.states.get(import_config[CONF_DEVICETRACKER_ID]).attributes
         and CONF_LONGITUDE


### PR DESCRIPTION
* When updating options, add current entity to devicetracker_id list to prevent User input malformed error. (May still fail validation checking if sensor doesn't have lat/long attributes).
* Change selector to show all device_tracker and person entities and only require sensor entities to have lat/long attributes