### PR TITLE
Direction of travel accuracy improvements

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -2930,8 +2930,8 @@ class Places(SensorEntity):
                         + self.get_attr(CONF_NAME)
                         + ") Reverting attributes back to before the update started"
                     )
-                    if proceed_with_update == 2:
-                        # 0: False. 1: True. 2: False, but set direction of travel to stationary
+
+                    if self.get_attr(ATTR_DIRECTION_OF_TRAVEL) != "stationary":
                         self.set_attr(ATTR_DIRECTION_OF_TRAVEL, "stationary")
                         _LOGGER.debug(
                             "("
@@ -2945,7 +2945,10 @@ class Places(SensorEntity):
                 + self.get_attr(CONF_NAME)
                 + ") Reverting attributes back to before the update started"
             )
-            if proceed_with_update == 2:
+            if (
+                proceed_with_update == 2
+                and self.get_attr(ATTR_DIRECTION_OF_TRAVEL) != "stationary"
+            ):
                 # 0: False. 1: True. 2: False, but set direction of travel to stationary
                 self.set_attr(ATTR_DIRECTION_OF_TRAVEL, "stationary")
                 _LOGGER.debug(

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -2933,6 +2933,7 @@ class Places(SensorEntity):
 
                     if self.get_attr(ATTR_DIRECTION_OF_TRAVEL) != "stationary":
                         self.set_attr(ATTR_DIRECTION_OF_TRAVEL, "stationary")
+                        self.write_sensor_to_json()
                         _LOGGER.debug(
                             "("
                             + self.get_attr(CONF_NAME)
@@ -2951,6 +2952,7 @@ class Places(SensorEntity):
             ):
                 # 0: False. 1: True. 2: False, but set direction of travel to stationary
                 self.set_attr(ATTR_DIRECTION_OF_TRAVEL, "stationary")
+                self.write_sensor_to_json()
                 _LOGGER.debug(
                     "("
                     + self.get_attr(CONF_NAME)


### PR DESCRIPTION
Missed a couple of code changes on the last PR #139 
Refined the direction of travel to actually be more sensitive to changes, but since the status only updates if the state changes, it does not appear to cause erratic changes but more accurately reflects the direction.