### PR TITLE
add `inlang` to make the contribution of translations easier

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,16 @@
+export async function defineConfig(env) {
+	const { default: pluginJson } = await env.$import(
+		'https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json@2/dist/index.js'
+	);
+
+	const { default: standardLintRules } = await env.$import(
+		'https://cdn.jsdelivr.net/gh/inlang/standard-lint-rules@2/dist/index.js'
+	);
+
+	return {
+		referenceLanguage: 'en',
+		plugins: [pluginJson({ 
+			pathPattern: './custom_components/places/translations/{language}.json'
+		}), standardLintRules()]
+	};
+}


### PR DESCRIPTION
Let me know what changes you request for merging this PR.

### Description
This pull request adds the possibility for contributors and translators to manage translations in a UI instead of files with no overhead for the maintainers.

To get a UI for translations contained in this repository, an [inlang.config.js](https://inlang.com/documentation) has been created at the root of the repository. Furthermore, I added the few missing translations. If you want, I can add a small i18n section to the documentation on the [README](https://github.com/custom-components/places).

### Overview
The changes of this PR and a live instance of the editor can be previewed with the following link https://inlang.com/editor/github.com/felixhaeberle/places.
Note: This link should be changed to point to `custom-components` instead of `felixhaeberle` after this PR has been merged.

<!-- ### Badge
Also, a dynamic badge can be added to the documentation to show the current state of translations. It will work after the configuration is merged. You can see a demo badge rendered based on my fork.

[![translation badge](https://inlang.com/badge?url=github.com/felixhaeberle/places)](https://inlang.com/editor/github.com/felixhaeberle/places?ref=badge) -->

### Limitations
Certain actions are slow
Inlang is running entirely on git, giving tremendous CI/CD and contribution power to localization. That means that the whole `places` repo is cloned into the browser which makes certain actions like the initial load and pushing changes slow. Those limitations will be fixed with future releases and require no input from `places`.

![232016041-ec0c3da3-94a9-4492-85dd-d8478c66d945 (1)](https://user-images.githubusercontent.com/34959078/234024186-ffdd8966-f9e6-4506-b138-ba03ddaa7c20.jpeg)


### Preview
Preview the messages on https://inlang.com/editor/github.com/felixhaeberle/places.