### PR TITLE
Update deprecated typing

### DIFF
--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -46,7 +46,7 @@ from homeassistant.helpers.event import (
     EventStateChangedData,
     async_track_state_change_event,
 )
-from homeassistant.helpers.typing import EventType
+from homeassistant.core import Event
 from homeassistant.util import Throttle, slugify
 from homeassistant.util.location import distance
 from urllib3.exceptions import NewConnectionError
@@ -579,7 +579,7 @@ class Places(SensorEntity):
 
     @Throttle(MIN_THROTTLE_INTERVAL)
     @core.callback
-    def async_tsc_update(self, event: EventType[EventStateChangedData]):
+    def async_tsc_update(self, event: Event[EventStateChangedData]):
         """Call the do_update function based on the TSC (track state change) event"""
         # _LOGGER.debug(f"({self.get_attr(CONF_NAME)}) [TSC Update] event: {event}")
         new_state = event.data["new_state"]


### PR DESCRIPTION
I update sensor.py and change `homeassistant.helpers.typing.EventType` to `homeassistant.core.Event` because it was deprecated in 2025.5 in accordance with what is published here [HA core update](https://developers.home-assistant.io/blog/2024/04/08/deprecated-backports-and-typing-aliases/)
And resolve this issus https://github.com/custom-components/places/issues/275

My log show : 
`EventType was used from places, this is a deprecated alias which will be removed in HA Core 2025.5. Use homeassistant.core.Event instead, please report it to the author of the 'places' custom integration`

