### PR TITLE
Improve City, Postal Town and Neightbourhood logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ zone_name[driving, name_no_dupe[type(-, unclassified, category(-, highway))[cate
 * `city`
 * `city_clean`
   * _`city` but removes "Township" and moves "City" to the end if it starts with "City of"_
-* `postal_town`
+* `postal_town` (Synonyms: `borough`, `suburb`)
 * `state` (Synonym: `region`)
 * `state_abbr`
 * `county`

--- a/custom_components/places/const.py
+++ b/custom_components/places/const.py
@@ -328,6 +328,8 @@ DISPLAY_OPTIONS_MAP = {
     "city": ATTR_CITY,
     "city_clean": ATTR_CITY_CLEAN,
     "postal_town": ATTR_POSTAL_TOWN,
+    "suburb": ATTR_POSTAL_TOWN,
+    "borough": ATTR_POSTAL_TOWN,
     "region": ATTR_REGION,
     "state": ATTR_REGION,
     "state_abbr": ATTR_STATE_ABBR,

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -1079,8 +1079,6 @@ class Places(SensorEntity):
                             .get("name:" + language),
                         )
                         break
-        # if not await self._async_in_zone() and self._get_attr(ATTR_PLACE_NAME) != "house":
-        #    self._set_attr(ATTR_NATIVE_VALUE, self._get_attr(ATTR_PLACE_NAME))
 
         if (
             "address" in (self._get_attr(ATTR_OSM_DICT))
@@ -1118,52 +1116,74 @@ class Places(SensorEntity):
                 f"{self._get_attr(ATTR_PLACE_NAME)}"
             )
 
-            if "neighbourhood" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_PLACE_NEIGHBOURHOOD,
-                    self._get_attr(ATTR_OSM_DICT).get("address").get("neighbourhood"),
-                )
-            elif "hamlet" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_PLACE_NEIGHBOURHOOD,
-                    self._get_attr(ATTR_OSM_DICT).get("address").get("hamlet"),
-                )
-            elif "residential" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_PLACE_NEIGHBOURHOOD,
-                    (self._get_attr(ATTR_OSM_DICT)).get("address").get("residential"),
-                )
+            CITY_LIST = [
+                "city",
+                "town",
+                "village",
+                "township",
+                "hamlet",
+                "city_district",
+                "municipality",
+            ]
+            POSTAL_TOWN_LIST = [
+                "city",
+                "town",
+                "village",
+                "township",
+                "hamlet",
+                "borough",
+                "suburb",
+            ]
+            NEIGHBOURHOOD_LIST = [
+                "village",
+                "township",
+                "hamlet",
+                "borough",
+                "suburb",
+                "quarter",
+                "neighbourhood",
+            ]
+            _LOGGER.debug(f"CITY_LIST: {CITY_LIST}")
+            for city_type in CITY_LIST:
+                try:
+                    POSTAL_TOWN_LIST.remove(city_type)
+                except ValueError:
+                    pass
+                try:
+                    NEIGHBOURHOOD_LIST.remove(city_type)
+                except ValueError:
+                    pass
+                if city_type in (self._get_attr(ATTR_OSM_DICT)).get("address"):
+                    self._set_attr(
+                        ATTR_CITY,
+                        (self._get_attr(ATTR_OSM_DICT)).get("address").get(city_type),
+                    )
+                    break
+            _LOGGER.debug(f"POSTAL_TOWN_LIST: {POSTAL_TOWN_LIST}")
+            for postal_town_type in POSTAL_TOWN_LIST:
+                try:
+                    NEIGHBOURHOOD_LIST.remove(postal_town_type)
+                except ValueError:
+                    pass
+                if postal_town_type in (self._get_attr(ATTR_OSM_DICT)).get("address"):
+                    self._set_attr(
+                        ATTR_POSTAL_TOWN,
+                        (self._get_attr(ATTR_OSM_DICT))
+                        .get("address")
+                        .get(postal_town_type),
+                    )
+                    break
+            _LOGGER.debug(f"NEIGHBOURHOOD_LIST: {NEIGHBOURHOOD_LIST}")
+            for neighbourhood_type in NEIGHBOURHOOD_LIST:
+                if neighbourhood_type in (self._get_attr(ATTR_OSM_DICT)).get("address"):
+                    self._set_attr(
+                        ATTR_PLACE_NEIGHBOURHOOD,
+                        (self._get_attr(ATTR_OSM_DICT))
+                        .get("address")
+                        .get(neighbourhood_type),
+                    )
+                    break
 
-            if "city" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_CITY,
-                    (self._get_attr(ATTR_OSM_DICT)).get("address").get("city"),
-                )
-            elif "town" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_CITY,
-                    (self._get_attr(ATTR_OSM_DICT)).get("address").get("town"),
-                )
-            elif "village" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_CITY,
-                    (self._get_attr(ATTR_OSM_DICT)).get("address").get("village"),
-                )
-            elif "township" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_CITY,
-                    (self._get_attr(ATTR_OSM_DICT)).get("address").get("township"),
-                )
-            elif "municipality" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_CITY,
-                    (self._get_attr(ATTR_OSM_DICT)).get("address").get("municipality"),
-                )
-            elif "city_district" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_CITY,
-                    (self._get_attr(ATTR_OSM_DICT)).get("address").get("city_district"),
-                )
             if not self._is_attr_blank(ATTR_CITY):
                 self._set_attr(
                     ATTR_CITY_CLEAN,
@@ -1175,16 +1195,6 @@ class Places(SensorEntity):
                         (self._get_attr(ATTR_CITY_CLEAN))[8:] + " City",
                     )
 
-            if "city_district" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_POSTAL_TOWN,
-                    (self._get_attr(ATTR_OSM_DICT)).get("address").get("city_district"),
-                )
-            if "suburb" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
-                self._set_attr(
-                    ATTR_POSTAL_TOWN,
-                    (self._get_attr(ATTR_OSM_DICT)).get("address").get("suburb"),
-                )
             if "state" in (self._get_attr(ATTR_OSM_DICT)).get("address"):
                 self._set_attr(
                     ATTR_REGION,


### PR DESCRIPTION
Based on the OpenStreetMap wiki on the different steps of the place key: https://wiki.openstreetmap.org/wiki/Key:place

Finds the first of these OSM place keys that is set to use for the `places` city attribute:
`city, town, village, township, hamlet, city_district, municipality`

Then finds the first of these OSM place keys that is set below the one used for city to use for the `places` postal_town attribute:
`city, town, village, township, hamlet, borough, suburb`
            
Then finds the first of these OSM place keys that is set below the one used for postal_town to use for the `places` neighbourhood attribute:
`village, township, hamlet, borough, suburb, quarter, neighbourhood`

Fixes #282 