### PR TITLE
Small linter CI tweak

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,7 +3,9 @@ name: Linters
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request updates the workflow configuration for linters to ensure it runs on both the `main` and `master` branches, instead of just `main`.

Workflow configuration update:

* [`.github/workflows/linters.yml`](diffhunk://#diff-c94729f5aa1afabfd250d3a929cdc840199d92facd4c83fcbc37b661d784d4acL6-R8): Modified the `push` trigger to include both `main` and `master` branches, ensuring the linter workflow runs on pushes to either branch.