### PR TITLE
Split Requirements and Update GitHub Actions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -24,17 +24,29 @@ jobs:
 
       - name: Setup Python 3 (with caching)
         uses: actions/setup-python@v6.0.0
+        id: setup-python
         with:
           python-version: 3.x
           cache: 'pip'
           cache-dependency-path: |
-            requirements-dev.txt
-            requirements.txt
+            requirements-lint.txt
             pyproject.toml
-            .pre-commit-config.yaml
 
-      - name: Install Requirements
-        run: python -m pip install --upgrade pip && pip install -r requirements-dev.txt
+      - name: Install Linting Requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-lint.txt
+
+      - name: Cache pre-commit and mypy
+        uses: actions/cache@v4.2.4
+        with:
+          path: |
+            ~/.cache/pre-commit
+            .mypy_cache
+            .ruff_cache
+          key: ${{ runner.os }}-lint-py${{ steps.setup-python.outputs.python-version || '3.x' }}-${{ hashFiles('**/requirements-lint.txt', '**/.pre-commit-config.yaml', '**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-lint-
 
       - name: Run pre-commit
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -37,13 +37,13 @@ jobs:
           python-version: 3.x
           cache: 'pip'
           cache-dependency-path: |
-            requirements-dev.txt
-            requirements.txt
+            requirements-pytest.txt
             pyproject.toml
-            .pre-commit-config.yaml
 
-      - name: Install Requirements
-        run: python -m pip install --upgrade pip && pip install -r requirements-dev.txt
+      - name: Install pytest Requirements
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-pytest.txt
 
       - name: Run pytest with coverage (pytest-cov)
         run: pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,20 +1,2 @@
--r requirements.txt
-homeassistant-stubs
-mypy
-pre-commit
-pytest
-pytest-asyncio
-pytest-cov
-pytest-homeassistant-custom-component
-pytest-timeout
-pytest-xdist
-ruff
-types-cachetools
-types-cffi
-types-greenlet
-types-PyMySQL
-types-pyRFC3339
-types-python-dateutil
-types-PyYAML
-types-requests
-types-setuptools
+-r requirements-lint.txt
+-r requirements-pytest.txt

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,13 @@
+homeassistant-stubs
+mypy
+pre-commit
+ruff
+types-cachetools
+types-cffi
+types-greenlet
+types-PyMySQL
+types-pyRFC3339
+types-python-dateutil
+types-PyYAML
+types-requests
+types-setuptools

--- a/requirements-pytest.txt
+++ b/requirements-pytest.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+pytest
+pytest-asyncio
+pytest-cov
+pytest-homeassistant-custom-component
+pytest-timeout


### PR DESCRIPTION
This pull request refactors the project's dependency management for development tools by splitting the previous monolithic `requirements-dev.txt` into two focused files: `requirements-lint.txt` for linting/static analysis tools and `requirements-pytest.txt` for testing dependencies. The corresponding GitHub Actions workflows for linting and testing have been updated to use these new files, improving clarity and maintainability.

Dependency management improvements:

* Split `requirements-dev.txt` into `requirements-lint.txt` (linting/static analysis dependencies) and `requirements-pytest.txt` (testing dependencies), and updated their contents accordingly. (`requirements-dev.txt` [[1]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL1-R2) `requirements-lint.txt` [[2]](diffhunk://#diff-e8c1fa419c48663db59ce9f738071365a505d5f533226940879b0202e024651cR1-R13) `requirements-pytest.txt` [[3]](diffhunk://#diff-d3faf75339b8a42e6c0991af67e63075d6a226dc88e878fc41273991691b70fbR1-R7)

CI workflow updates:

* Updated `.github/workflows/linters.yml` to install dependencies from `requirements-lint.txt` and added a cache step for `pre-commit` and `mypy` to speed up linting runs.
* Updated `.github/workflows/pytest_coverage.yml` to install dependencies from `requirements-pytest.txt` instead of the old dev requirements file.