### PR TITLE
Standardize from patch to monkeypatch

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from contextlib import contextmanager, suppress
 from typing import cast
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -373,7 +373,10 @@ def stub_in_zone(obj, return_value: bool):
         with stub_in_zone(sensor, False):
             await sensor.process_display_options()
     """
-    return patch.object(obj, "in_zone", AsyncMock(return_value=return_value))
+    # Use the generic stub_method helper to provide a context manager that
+    # temporarily replaces `in_zone` with an AsyncMock and restores the
+    # original attribute on exit.
+    return stub_method(obj, "in_zone", return_value=return_value)
 
 
 def stub_method(

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -1,7 +1,7 @@
 """Unit tests for AdvancedOptionsParser in custom_components.places.advanced_options."""
 
 import logging
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -274,17 +274,21 @@ async def test_build_from_advanced_options_not_none_calls_normal(sensor):
 
 
 @pytest.mark.asyncio
-async def test_build_from_advanced_options_processed_options(sensor):
+async def test_build_from_advanced_options_processed_options(sensor, monkeypatch):
     """Return early and log error when curr_options already processed."""
     sensor.attrs = {}
     parser = AdvancedOptionsParser(sensor, "zone_name")
     parser._processed_options.add("zone_name")
-    with patch.object(
-        logging.getLogger("custom_components.places.advanced_options"), "error"
-    ) as mock_log:
-        await parser.build_from_advanced_options("zone_name")
-        mock_log.assert_called()
-        assert parser.state_list == []
+    mock_log = MagicMock()
+    monkeypatch.setattr(
+        logging.getLogger("custom_components.places.advanced_options"),
+        "error",
+        mock_log,
+        raising=False,
+    )
+    await parser.build_from_advanced_options("zone_name")
+    mock_log.assert_called()
+    assert parser.state_list == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This pull request refactors the test suite to use `monkeypatch` instead of `patch` for mocking and stubbing, resulting in more consistent and reliable test behavior. It also removes unused imports of `patch` across multiple test files. The most significant changes are the replacement of `patch` with `monkeypatch` for mocking methods, properties, and classes within test cases, and the corresponding update of test signatures to accept the `monkeypatch` fixture.

**Test mocking and stubbing improvements:**

* Replaced usage of `patch` with `monkeypatch` for mocking methods, properties, and classes in test cases across `tests/test_config_flow.py`, `tests/test_sensor.py`, `tests/test_display_options_integration.py`, `tests/test_update_sensor.py`, and `tests/test_advanced_options.py`. This includes updating test signatures to accept the `monkeypatch` fixture and using `monkeypatch.setattr` for stubbing. [[1]](diffhunk://#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667L129-R139) [[2]](diffhunk://#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667L242-R268) [[3]](diffhunk://#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667L268-R290) [[4]](diffhunk://#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667L406-R430) [[5]](diffhunk://#diff-220f6e60122c69d6e4b02508630ee3895e8fc9f06ca9650d7011f70314e97365L141-R141) [[6]](diffhunk://#diff-220f6e60122c69d6e4b02508630ee3895e8fc9f06ca9650d7011f70314e97365L172-R174) [[7]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L118-R138) [[8]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L519-R526) [[9]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L733-R744) [[10]](diffhunk://#diff-e05f330948e1d2186187a899bc32405e09b6d19d7bbf24f26e7c4a3b63f46354L788-R790) [[11]](diffhunk://#diff-e05f330948e1d2186187a899bc32405e09b6d19d7bbf24f26e7c4a3b63f46354L822-R838) [[12]](diffhunk://#diff-e05f330948e1d2186187a899bc32405e09b6d19d7bbf24f26e7c4a3b63f46354L973-R977) [[13]](diffhunk://#diff-e05f330948e1d2186187a899bc32405e09b6d19d7bbf24f26e7c4a3b63f46354R991-L992) [[14]](diffhunk://#diff-e05f330948e1d2186187a899bc32405e09b6d19d7bbf24f26e7c4a3b63f46354L1201-L1207) [[15]](diffhunk://#diff-16921665c241b2da34186e29dc707a26aaea7cefca7cb4d1420a9736c000a0c6L277-R288)

* Updated helper functions such as `stub_in_zone` in `tests/conftest.py` to use a generic stub method helper compatible with `monkeypatch`-based stubbing.

**Code cleanup:**

* Removed unused imports of `patch` from all test files, including `tests/conftest.py`, `tests/test_advanced_options.py`, `tests/test_config_flow.py`, `tests/test_display_options_integration.py`, `tests/test_sensor.py`, and `tests/test_update_sensor.py`. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128L5-R5) [[2]](diffhunk://#diff-16921665c241b2da34186e29dc707a26aaea7cefca7cb4d1420a9736c000a0c6L4-R4) [[3]](diffhunk://#diff-3e0062aab0171da6d72888d9668e1fa5449b7ceafdcffbe6f55d4b5e96032667L3-R3) [[4]](diffhunk://#diff-220f6e60122c69d6e4b02508630ee3895e8fc9f06ca9650d7011f70314e97365L6-R6) [[5]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L4-R4) [[6]](diffhunk://#diff-e05f330948e1d2186187a899bc32405e09b6d19d7bbf24f26e7c4a3b63f46354L6-R6)

These changes improve test reliability and maintainability by using the recommended pytest `monkeypatch` fixture for mocking and stubbing.