### PR TITLE
Fix advanced display option validation

### DIFF
--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -240,36 +240,44 @@ def _validate_option_names(display_options: str, errors: dict[str, Any]) -> bool
 
 def _validate_known_options(display_options: str, errors: dict[str, Any]) -> bool:
     valid_options = set(DISPLAY_OPTIONS_MAP.keys())
+    stack: list[str] = []
     i = 0
     token = ""
+
+    def validate_token(option_name: str) -> bool:
+        option_name = option_name.strip()
+        if option_name and option_name not in valid_options and option_name not in ("-", "+"):
+            _LOGGER.error("Invalid option name '%s' in '%s'.", option_name, display_options)
+            errors["base"] = "invalid_option"
+            return False
+        return True
+
     while i < len(display_options):
         c = display_options[i]
         if c in "[(":
-            # Check the token before the bracket/paren
-            t = token.strip()
-            if t and t not in valid_options and not re.match(r"[-+]", t):
-                _LOGGER.error("Invalid option name '%s' in '%s'.", t, display_options)
-                errors["base"] = "invalid_option"
+            if not validate_token(token):
                 return False
+            stack.append(c)
             token = ""
         elif c == ",":
-            # Check top-level comma-separated tokens
-            t = token.strip()
-            if t and t not in valid_options and not re.match(r"[-+]", t):
-                _LOGGER.error("Invalid option name '%s' in '%s'.", t, display_options)
-                errors["base"] = "invalid_option"
+            if (not stack or stack[-1] != "(") and not validate_token(token):
                 return False
             token = ""
-        elif c in "])":
+        elif c == "]":
+            if not validate_token(token):
+                return False
+            if stack:
+                stack.pop()
+            token = ""
+        elif c == ")":
+            if stack:
+                stack.pop()
             token = ""
         else:
             token += c
         i += 1
     # Check last token
-    t = token.strip()
-    if t and t not in valid_options and not re.match(r"[-+]", t):
-        _LOGGER.error("Invalid option name '%s' in '%s'.", t, display_options)
-        errors["base"] = "invalid_option"
+    if (not stack or stack[-1] != "(") and not validate_token(token):
         return False
     return True
 

--- a/prek.toml
+++ b/prek.toml
@@ -38,7 +38,7 @@ additional_dependencies = ["tomli"]
 
 [[repos]]
 repo = "https://github.com/pre-commit/mirrors-mypy"
-rev = "v1.20.0"
+rev = "v2.1.0"
 
 [[repos.hooks]]
 id = "mypy"
@@ -64,7 +64,7 @@ additional_dependencies = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.15.8"
+rev = "v0.15.12"
 
 [[repos.hooks]]
 id = "ruff-check"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,7 +11,6 @@ from custom_components.places.config_flow import (
     PlacesOptionsFlowHandler,
     _validate_brackets,
     _validate_comma_syntax,
-    _validate_known_options,
     _validate_option_names,
     get_devicetracker_id_entities,
     get_home_zone_entities,
@@ -325,60 +324,116 @@ def test_validate_brackets(display_options, expected):
     assert result is expected
 
 
-@pytest.mark.parametrize(
-    "display_options,expected",
-    [
-        ("zone,place", False),  # Should be invalid
-        ("zone,unknown", False),  # 'unknown' not in DISPLAY_OPTIONS_MAP
-        ("zone,[place,unknown]", False),
-        ("zone,[place],unknown", False),  # Invalid last token after bracket group
-        ("unknown", False),  # Single invalid token
-    ],
-)
-def test_validate_known_options(display_options, expected):
-    """Test the _validate_known_options function to ensure it correctly validates known display options.
-
-    Parameters:
-        display_options (str): The display options string to validate.
-        expected (bool): The expected result of the validation.
-
-    """
-    errors = {}
-    result = _validate_known_options(display_options, errors)
-    assert result is expected
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "display_options,has_error",
+    ("display_options", "expected_errors"),
     [
-        ("zone,place", False),  # Valid
-        ("zone,[place,(zone)]", True),  # Invalid
-        ("zone,[place,(zone]", True),  # Invalid
-        # ("zone,,place", False),  # Valid (your logic does not catch double comma)
-        # ("zone name,place", False),  # Valid (your logic does not catch space in option name)
-        # ("zone,unknown", False),  # Valid (your logic does not catch unknown option)
+        pytest.param("zone,place", {}, id="basic-options-no-space"),
+        pytest.param("zone, place", {}, id="basic-options-skip-advanced-validation"),
+        pytest.param("zone,unknown", {}, id="basic-unknown-option-skips-advanced-validation"),
+        pytest.param("unknown", {}, id="single-unknown-option-skips-advanced-validation"),
+        pytest.param("name_no_dupe[type(-, unclassified)]", {}, id="simple-exclude-values"),
+        pytest.param(
+            "type(house, category(highway))",
+            {},
+            id="implicit-include-literal-with-attribute-filter",
+        ),
+        pytest.param(
+            "route_number(type(+, motorway, trunk))",
+            {},
+            id="simple-include-values",
+        ),
+        pytest.param("city_clean[county]", {}, id="single-fallback-option"),
+        pytest.param("street[route_number]", {}, id="simple-nested-option"),
+        pytest.param(
+            "name_no_dupe[type(house, category(highway))]",
+            {},
+            id="fallback-filter-implicit-include-literal-with-attribute-filter",
+        ),
+        pytest.param(
+            "driving, name_no_dupe[type(-, unclassified, category(-, highway))"
+            "[category(-, highway)], house_number, route_number(type(+, motorway, trunk))"
+            "[street[route_number]], neighborhood(type(house))], city_clean[county], "
+            "state_abbr",
+            {},
+            id="complex-nested-advanced-options",
+        ),
+        pytest.param(
+            "zone,[place](zone)",
+            {"base": "invalid_syntax"},
+            id="bracket-group-followed-by-paren-group",
+        ),
+        pytest.param(
+            "zone,[place,unknown]",
+            {"base": "invalid_syntax"},
+            id="comma-before-bracket-with-unknown-option",
+        ),
+        pytest.param(
+            "zone,[place],unknown",
+            {"base": "invalid_syntax"},
+            id="comma-before-bracket-then-trailing-unknown-option",
+        ),
+        pytest.param(
+            "zone,[place,(zone)]",
+            {"base": "invalid_syntax"},
+            id="mismatched-nested-paren-and-bracket",
+        ),
+        pytest.param(
+            "zone,[place,(zone]",
+            {"base": "invalid_syntax"},
+            id="unclosed-nested-paren",
+        ),
+        pytest.param(
+            "name_no_dupe[type(-, unclassified)",
+            {"base": "bracket_mismatch"},
+            id="unmatched-bracket",
+        ),
+        pytest.param(
+            "route_number(type(+, motorway, trunk,))",
+            {"base": "invalid_syntax"},
+            id="trailing-comma-in-parens",
+        ),
+        pytest.param(
+            "city_clean[county,,state]",
+            {"base": "invalid_syntax"},
+            id="empty-bracketed-option",
+        ),
+        pytest.param(
+            "city clean[county]",
+            {"base": "invalid_syntax"},
+            id="space-in-option-name",
+        ),
+        pytest.param(
+            "city_clean[unknown_option]",
+            {"base": "invalid_option"},
+            id="unknown-bracketed-option",
+        ),
+        pytest.param(
+            "+foo[place]",
+            {"base": "invalid_option"},
+            id="prefixed-plus-token-is-invalid",
+        ),
+        pytest.param(
+            "-bar[place]",
+            {"base": "invalid_option"},
+            id="prefixed-minus-token-is-invalid",
+        ),
+        pytest.param(
+            "zone_name[county],unknown",
+            {"base": "invalid_option"},
+            id="unknown-option-after-valid-advanced-option",
+        ),
     ],
 )
-async def test_validate_display_options(display_options, has_error):
-    """Test the validate_display_options function to ensure it returns errors for invalid display option syntax.
+async def test_validate_display_options_accepts_advanced_options(
+    display_options: str, expected_errors: dict[str, str]
+) -> None:
+    """Validate advanced display option strings across simple and complex permutations."""
+    errors: dict[str, str] = {}
 
-    Parameters:
-        display_options (str): The display options string to validate.
-        has_error (bool): Whether an error is expected for the given input.
-
-    """
-    errors = {}
     result = await validate_display_options(display_options, errors)
-    assert (result != {}) is has_error
 
-
-@pytest.mark.asyncio
-async def test_validate_display_options_brackets_then_paren_invalid():
-    """Advanced validation fails for bracket group directly followed by paren group."""
-    errors = {}
-    result = await validate_display_options("zone,[place](zone)", errors)
-    assert result != {}
+    assert result == expected_errors
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Fixes advanced display option validation so documented include/exclude filters with literal OSM values can be saved through the config and options flows.

## What Changed
- Updated advanced display option validation to track bracket/parenthesis context.
- Continued validating display option identifiers against `DISPLAY_OPTIONS_MAP`.
- Allowed literal include/exclude values inside parentheses, such as `unclassified`, `highway`, `motorway`, `trunk`, and `house`.
- Added regression coverage for the advanced options string reported in issue #409.

## Why
The advanced options parser supports literal include/exclude values inside parentheses, and the README documents this usage. The config flow validator was treating those literal values as display option names, causing valid advanced options to be rejected with `invalid_option`.

## Related Issues
Closes #409
