### PR TITLE
Refactor Places integration internals

### DIFF
--- a/custom_components/places/advanced_options.py
+++ b/custom_components/places/advanced_options.py
@@ -77,10 +77,11 @@ class AdvancedOptionsParser:
 
     async def build_next_option(self, next_opt: str | None) -> None:
         """Continue parsing after a comma-prefixed next expression."""
-        if next_opt and len(next_opt) > 1 and next_opt[0] == ",":
-            next_opt = next_opt[1:]
+        if not next_opt or len(next_opt) <= 1 or next_opt[0] != ",":
+            return
+        next_opt = next_opt[1:].strip()
         if next_opt:
-            await self.build_from_advanced_options(next_opt.strip())
+            await self.build_from_advanced_options(next_opt)
 
     async def do_brackets_and_parens_count_match(self, curr_options: str) -> bool:
         """Check whether an option expression has balanced delimiters.
@@ -246,7 +247,8 @@ class AdvancedOptionsParser:
                 if ret_state:
                     self.state_list.append(ret_state)
             next_opt = curr_options[(comma_num + 1) :]
-            await self.build_next_option(next_opt)
+            if next_opt:
+                await self.build_from_advanced_options(next_opt.strip())
             return
 
         # Bracket is first symbol

--- a/custom_components/places/advanced_options.py
+++ b/custom_components/places/advanced_options.py
@@ -75,6 +75,13 @@ class AdvancedOptionsParser:
             return
         await self.process_single_term(curr_options)
 
+    async def build_next_option(self, next_opt: str | None) -> None:
+        """Continue parsing after a comma-prefixed next expression."""
+        if next_opt and len(next_opt) > 1 and next_opt[0] == ",":
+            next_opt = next_opt[1:]
+        if next_opt:
+            await self.build_from_advanced_options(next_opt.strip())
+
     async def do_brackets_and_parens_count_match(self, curr_options: str) -> bool:
         """Check whether an option expression has balanced delimiters.
 
@@ -239,8 +246,7 @@ class AdvancedOptionsParser:
                 if ret_state:
                     self.state_list.append(ret_state)
             next_opt = curr_options[(comma_num + 1) :]
-            if next_opt:
-                await self.build_from_advanced_options(next_opt.strip())
+            await self.build_next_option(next_opt)
             return
 
         # Bracket is first symbol
@@ -265,10 +271,7 @@ class AdvancedOptionsParser:
                     self.state_list.append(ret_state)
                 elif none_opt:
                     await self.build_from_advanced_options(none_opt.strip())
-            if next_opt and len(next_opt) > 1 and next_opt[0] == ",":
-                next_opt = next_opt[1:]
-                if next_opt:
-                    await self.build_from_advanced_options(next_opt.strip())
+            await self.build_next_option(next_opt)
             return
 
         # Parenthesis is first symbol
@@ -292,10 +295,7 @@ class AdvancedOptionsParser:
                     self.state_list.append(ret_state)
                 elif none_opt:
                     await self.build_from_advanced_options(none_opt.strip())
-            if next_opt and len(next_opt) > 1 and next_opt[0] == ",":
-                next_opt = next_opt[1:]
-                if next_opt:
-                    await self.build_from_advanced_options(next_opt.strip())
+            await self.build_next_option(next_opt)
 
     async def process_only_commas(self, curr_options: str) -> None:
         """Append values for a comma-separated list of simple options.

--- a/custom_components/places/attributes.py
+++ b/custom_components/places/attributes.py
@@ -27,7 +27,7 @@ class PlacesAttributes:
         Args:
             initial: Initial mutable attribute mapping used for in-place storage.
         """
-        self._internal_attr: MutableMapping[str, Any] = initial or {}
+        self._internal_attr: MutableMapping[str, Any] = initial if initial is not None else {}
 
     @property
     def data(self) -> MutableMapping[str, Any]:

--- a/custom_components/places/attributes.py
+++ b/custom_components/places/attributes.py
@@ -1,0 +1,178 @@
+"""Attribute helpers used by Places entities.
+
+This module owns the mutable internal attribute mapping and associated utility
+helpers that were previously implemented directly on ``Places``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any, SupportsFloat, SupportsIndex, TypeVar
+
+from .const import CONFIG_ATTRIBUTES_LIST, JSON_ATTRIBUTE_LIST, JSON_IGNORE_ATTRIBUTE_LIST
+
+_AttrT = TypeVar("_AttrT", default=Any)
+
+
+class PlacesAttributes:
+    """Mutable container for Places internal attributes and helper accessors.
+
+    The class centralizes value storage and conversion helpers while preserving
+    the historic behavior currently relied upon by ``Places``.
+    """
+
+    def __init__(self, initial: MutableMapping[str, Any] | None = None) -> None:
+        """Create a new attribute store.
+
+        Args:
+            initial: Initial mutable attribute mapping used for in-place storage.
+        """
+        self._internal_attr: MutableMapping[str, Any] = initial or {}
+
+    @property
+    def data(self) -> MutableMapping[str, Any]:
+        """Return the backing mutable attribute mapping."""
+        return self._internal_attr
+
+    @data.setter
+    def data(self, value: MutableMapping[str, Any]) -> None:
+        """Replace the backing mapping for rollback and restore flows."""
+        self._internal_attr = value
+
+    def set(self, attr: str, value: object | None = None) -> None:
+        """Store a key/value pair in the backing mapping.
+
+        Args:
+            attr: Attribute key to store.
+            value: Value for the attribute.
+        """
+        if attr:
+            self._internal_attr.update({attr: value})
+
+    def clear(self, attr: str) -> None:
+        """Drop a key from the backing mapping.
+
+        Args:
+            attr: Attribute key to remove.
+        """
+        self._internal_attr.pop(attr, None)
+
+    def is_blank(self, attr: str) -> bool:
+        """Return whether a value is considered blank.
+
+        Args:
+            attr: Attribute key to evaluate.
+
+        Returns:
+            ``True`` for missing values, ``None`` and empty string values. Numeric
+            zero is treated as non-blank for compatibility with prior behavior.
+        """
+        if self._internal_attr.get(attr) or self._internal_attr.get(attr) == 0:
+            return False
+        return True
+
+    def get(self, attr: str | None, default: _AttrT | None = None) -> _AttrT | None:
+        """Return a stored value with optional fallback and blank handling.
+
+        Args:
+            attr: Attribute key to read. ``None`` returns ``None``.
+            default: Optional fallback when the key is not present.
+
+        Returns:
+            Stored value, ``default`` when provided, or ``None`` when blank.
+        """
+        if attr is None or (default is None and self.is_blank(attr)):
+            return None
+        return self._internal_attr.get(attr, default)
+
+    def safe_str(self, attr: str | None, default: object | None = None) -> str:
+        """Return a safe string representation for an attribute value.
+
+        Args:
+            attr: Attribute key to convert.
+            default: Optional fallback when missing.
+
+        Returns:
+            String value, or ``""`` on missing values or conversion failures.
+        """
+        value = self.get(attr) if default is None else self.get(attr, default)
+        if value is not None:
+            try:
+                return str(value)
+            except ValueError, TypeError:
+                return ""
+        return ""
+
+    def safe_float(self, attr: str | None, default: object | None = None) -> float:
+        """Return a safe float for a stored attribute value.
+
+        Args:
+            attr: Attribute key to convert.
+            default: Optional fallback when missing.
+
+        Returns:
+            Float conversion result, or ``0.0`` when conversion is not possible.
+        """
+        value: object | None = self.get(attr) if default is None else self.get(attr, default)
+        if value is None:
+            return 0.0
+        if not isinstance(value, str | bytes | bytearray | SupportsFloat | SupportsIndex):
+            return 0.0
+        try:
+            return float(value)
+        except TypeError, ValueError:
+            return 0.0
+
+    def safe_list(self, attr: str | None, default: object | None = None) -> list:
+        """Return a list value or an empty list fallback.
+
+        Args:
+            attr: Attribute key to read.
+            default: Optional fallback used only when missing.
+
+        Returns:
+            Stored list value, or ``[]`` when conversion is not possible.
+        """
+        value = self.get(attr) if default is None else self.get(attr, default)
+        if not isinstance(value, list):
+            return []
+        return value
+
+    def safe_dict(
+        self, attr: str | None, default: MutableMapping[str, _AttrT] | None = None
+    ) -> MutableMapping[str, _AttrT]:
+        """Return a mutable mapping for an attribute or an empty mapping.
+
+        Args:
+            attr: Attribute key to read.
+            default: Optional fallback value.
+
+        Returns:
+            Stored mapping or ``{}`` when not available.
+        """
+        value = self.get(attr) if default is None else self.get(attr, default)
+        if not isinstance(value, MutableMapping):
+            return {}
+        return value
+
+    def cleanup(self) -> None:
+        """Remove blank values from the internal mapping."""
+        for attr in list(self._internal_attr):
+            if self.is_blank(attr):
+                self.clear(attr)
+
+    def import_json_attributes(self, json_attr: MutableMapping[str, Any]) -> None:
+        """Populate runtime attributes from JSON while removing filtered keys.
+
+        This performs the existing JSON import filtering contract used by
+        ``Places.import_attributes_from_json``.
+
+        Args:
+            json_attr: Mutable mapping loaded from sensor JSON persistence.
+        """
+        for attr in JSON_ATTRIBUTE_LIST:
+            if attr in json_attr:
+                self.set(attr, json_attr.pop(attr, None))
+        for attr in CONFIG_ATTRIBUTES_LIST + JSON_IGNORE_ATTRIBUTE_LIST:
+            if attr in json_attr:
+                json_attr.pop(attr, None)

--- a/custom_components/places/attributes.py
+++ b/custom_components/places/attributes.py
@@ -67,9 +67,8 @@ class PlacesAttributes:
             ``True`` for missing values, ``None`` and empty string values. Numeric
             zero is treated as non-blank for compatibility with prior behavior.
         """
-        if self._internal_attr.get(attr) or self._internal_attr.get(attr) == 0:
-            return False
-        return True
+        val = self._internal_attr.get(attr)
+        return not (val or val == 0)
 
     def get(self, attr: str | None, default: _AttrT | None = None) -> _AttrT | None:
         """Return a stored value with optional fallback and blank handling.

--- a/custom_components/places/basic_options.py
+++ b/custom_components/places/basic_options.py
@@ -32,7 +32,7 @@ class BasicOptionsParser:
         self._internal_attr = internal_attr
         self.display_options = display_options
 
-    def add_to_display(
+    def _add_to_display(
         self,
         user_display: list[str],
         attr_key: str,
@@ -40,7 +40,16 @@ class BasicOptionsParser:
         condition: bool = True,
         require_in_display_options: bool = True,
     ) -> None:
-        """Append an attribute value when the display rules allow it."""
+        """Append an attribute value when the display rules allow it.
+
+        Args:
+            user_display: Mutable list to which the display value is appended.
+            attr_key: Attribute name to check and append.
+            option_key: Display option key that gates inclusion.
+            condition: Additional condition required before adding the value.
+            require_in_display_options: When true, require ``option_key`` to be
+                present in display options.
+        """
         if (
             (not require_in_display_options or option_key in self.display_options)
             and not self.sensor.is_attr_blank(attr_key)
@@ -58,62 +67,62 @@ class BasicOptionsParser:
         user_display: list[str] = []
 
         # Add basic options
-        self.add_to_display(user_display, "driving", option_key="driving")
-        self.add_to_display(
+        self._add_to_display(user_display, "driving", option_key="driving")
+        self._add_to_display(
             user_display,
             attr_key="devicetracker_zone_name",
             option_key="zone_name",
             condition=await self.sensor.in_zone()
             or "do_not_show_not_home" not in self.display_options,
         )
-        self.add_to_display(
+        self._add_to_display(
             user_display,
             attr_key="devicetracker_zone",
             option_key="zone",
             condition=await self.sensor.in_zone()
             or "do_not_show_not_home" not in self.display_options,
         )
-        self.add_to_display(user_display, "place_name", option_key="place_name")
+        self._add_to_display(user_display, "place_name", option_key="place_name")
 
         # Handle "place" and its sub-options
         if "place" in self.display_options:
-            self.add_to_display(
+            self._add_to_display(
                 user_display,
                 attr_key="place_name",
                 condition=self._internal_attr.get("place_name")
                 != self._internal_attr.get("street"),
                 require_in_display_options=False,
             )
-            self.add_to_display(
+            self._add_to_display(
                 user_display,
                 attr_key="place_category",
                 condition=self.sensor.get_attr_safe_str("place_category").lower() != "place",
                 require_in_display_options=False,
             )
-            self.add_to_display(
+            self._add_to_display(
                 user_display,
                 attr_key="place_type",
                 condition=self.sensor.get_attr_safe_str("place_type").lower() != "yes",
                 require_in_display_options=False,
             )
-            self.add_to_display(
+            self._add_to_display(
                 user_display,
                 attr_key="place_neighbourhood",
                 require_in_display_options=False,
             )
-            self.add_to_display(
+            self._add_to_display(
                 user_display,
                 attr_key="street_number",
                 require_in_display_options=False,
             )
-            self.add_to_display(
+            self._add_to_display(
                 user_display,
                 attr_key="street",
                 require_in_display_options=False,
             )
         else:
-            self.add_to_display(user_display, "street_number", option_key="street_number")
-            self.add_to_display(user_display, "street", option_key="street")
+            self._add_to_display(user_display, "street_number", option_key="street_number")
+            self._add_to_display(user_display, "street", option_key="street")
 
         # Add remaining location details
         for option_key, attr_key in {
@@ -125,7 +134,7 @@ class BasicOptionsParser:
             "country": "country",
             "formatted_address": "formatted_address",
         }.items():
-            self.add_to_display(user_display, attr_key, option_key=option_key)
+            self._add_to_display(user_display, attr_key, option_key=option_key)
 
         # Handle "do_not_reorder" option
         if "do_not_reorder" in self.display_options:

--- a/custom_components/places/basic_options.py
+++ b/custom_components/places/basic_options.py
@@ -32,6 +32,22 @@ class BasicOptionsParser:
         self._internal_attr = internal_attr
         self.display_options = display_options
 
+    def add_to_display(
+        self,
+        user_display: list[str],
+        attr_key: str,
+        option_key: str | None = None,
+        condition: bool = True,
+        require_in_display_options: bool = True,
+    ) -> None:
+        """Append an attribute value when the display rules allow it."""
+        if (
+            (not require_in_display_options or option_key in self.display_options)
+            and not self.sensor.is_attr_blank(attr_key)
+            and condition
+        ):
+            user_display.append(self.sensor.get_attr_safe_str(attr_key))
+
     async def build_display(self) -> str:
         """Build a comma-separated state string from basic display options.
 
@@ -41,77 +57,63 @@ class BasicOptionsParser:
         """
         user_display: list[str] = []
 
-        def add_to_display(
-            attr_key: str,
-            option_key: str | None = None,
-            condition: bool = True,
-            require_in_display_options: bool = True,
-        ) -> None:
-            """Append an attribute value when the display rules allow it.
-
-            Args:
-                attr_key: Sensor attribute whose string value should be added.
-                option_key: Display option that enables the attribute.
-                condition: Scenario-specific gate for including the value.
-                require_in_display_options: Whether ``option_key`` must be
-                    present in the configured display options.
-            """
-            if (
-                (not require_in_display_options or option_key in self.display_options)
-                and not self.sensor.is_attr_blank(attr_key)
-                and condition
-            ):
-                user_display.append(self.sensor.get_attr_safe_str(attr_key))
-
         # Add basic options
-        add_to_display(option_key="driving", attr_key="driving")
-        add_to_display(
-            option_key="zone_name",
+        self.add_to_display(user_display, "driving", option_key="driving")
+        self.add_to_display(
+            user_display,
             attr_key="devicetracker_zone_name",
+            option_key="zone_name",
             condition=await self.sensor.in_zone()
             or "do_not_show_not_home" not in self.display_options,
         )
-        add_to_display(
-            option_key="zone",
+        self.add_to_display(
+            user_display,
             attr_key="devicetracker_zone",
+            option_key="zone",
             condition=await self.sensor.in_zone()
             or "do_not_show_not_home" not in self.display_options,
         )
-        add_to_display("place_name", "place_name")
+        self.add_to_display(user_display, "place_name", option_key="place_name")
 
         # Handle "place" and its sub-options
         if "place" in self.display_options:
-            add_to_display(
+            self.add_to_display(
+                user_display,
                 attr_key="place_name",
                 condition=self._internal_attr.get("place_name")
                 != self._internal_attr.get("street"),
                 require_in_display_options=False,
             )
-            add_to_display(
+            self.add_to_display(
+                user_display,
                 attr_key="place_category",
                 condition=self.sensor.get_attr_safe_str("place_category").lower() != "place",
                 require_in_display_options=False,
             )
-            add_to_display(
+            self.add_to_display(
+                user_display,
                 attr_key="place_type",
                 condition=self.sensor.get_attr_safe_str("place_type").lower() != "yes",
                 require_in_display_options=False,
             )
-            add_to_display(
+            self.add_to_display(
+                user_display,
                 attr_key="place_neighbourhood",
                 require_in_display_options=False,
             )
-            add_to_display(
+            self.add_to_display(
+                user_display,
                 attr_key="street_number",
                 require_in_display_options=False,
             )
-            add_to_display(
+            self.add_to_display(
+                user_display,
                 attr_key="street",
                 require_in_display_options=False,
             )
         else:
-            add_to_display(option_key="street_number", attr_key="street_number")
-            add_to_display(option_key="street", attr_key="street")
+            self.add_to_display(user_display, "street_number", option_key="street_number")
+            self.add_to_display(user_display, "street", option_key="street")
 
         # Add remaining location details
         for option_key, attr_key in {
@@ -123,7 +125,7 @@ class BasicOptionsParser:
             "country": "country",
             "formatted_address": "formatted_address",
         }.items():
-            add_to_display(option_key=option_key, attr_key=attr_key)
+            self.add_to_display(user_display, attr_key, option_key=option_key)
 
         # Handle "do_not_reorder" option
         if "do_not_reorder" in self.display_options:

--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -19,6 +19,14 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import selector
 import voluptuous as vol
 
+from .config_schema import (
+    DATE_FORMAT_OPTIONS,
+    MAP_PROVIDER_OPTIONS,
+    MAP_ZOOM_MAX,
+    MAP_ZOOM_MIN,
+    STATE_OPTIONS,
+    user_schema,
+)
 from .const import (
     CONF_DATE_FORMAT,
     CONF_DEVICETRACKER_ID,
@@ -33,7 +41,6 @@ from .const import (
     DEFAULT_DATE_FORMAT,
     DEFAULT_DISPLAY_OPTIONS,
     DEFAULT_EXTENDED_ATTR,
-    DEFAULT_HOME_ZONE,
     DEFAULT_MAP_PROVIDER,
     DEFAULT_MAP_ZOOM,
     DEFAULT_SHOW_TIME,
@@ -46,11 +53,6 @@ from .const import (
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
-MAP_PROVIDER_OPTIONS: list[str] = ["apple", "google", "osm"]
-STATE_OPTIONS: list[str] = ["zone, place", "formatted_place", "zone_name, place"]
-DATE_FORMAT_OPTIONS: list[str] = ["mm/dd", "dd/mm"]
-MAP_ZOOM_MIN: int = 1
-MAP_ZOOM_MAX: int = 20
 COMPONENT_CONFIG_URL: str = "https://github.com/custom-components/places#configuration-options"
 
 # Note the input displayed to the user will be translated. See the
@@ -408,75 +410,7 @@ class PlacesConfigFlow(ConfigFlow, domain=DOMAIN):
         )
         zone_list = get_home_zone_entities(self.hass)
         # _LOGGER.debug("Trackable entities with lat/long: %s", devicetracker_id_list)
-        data_schema: vol.Schema = vol.Schema(
-            {
-                vol.Required(CONF_NAME): str,
-                vol.Required(CONF_DEVICETRACKER_ID): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=devicetracker_id_list,
-                        multiple=False,
-                        custom_value=False,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    )
-                ),
-                vol.Optional(CONF_API_KEY): str,
-                vol.Optional(
-                    CONF_DISPLAY_OPTIONS, default=DEFAULT_DISPLAY_OPTIONS
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=STATE_OPTIONS,
-                        multiple=False,
-                        custom_value=True,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    )
-                ),
-                vol.Optional(CONF_HOME_ZONE, default=DEFAULT_HOME_ZONE): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=zone_list,
-                        multiple=False,
-                        custom_value=False,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    )
-                ),
-                vol.Optional(
-                    CONF_MAP_PROVIDER, default=DEFAULT_MAP_PROVIDER
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=MAP_PROVIDER_OPTIONS,
-                        multiple=False,
-                        custom_value=False,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    )
-                ),
-                vol.Optional(CONF_MAP_ZOOM, default=int(DEFAULT_MAP_ZOOM)): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=MAP_ZOOM_MIN,
-                        max=MAP_ZOOM_MAX,
-                        mode=selector.NumberSelectorMode.BOX,
-                    )
-                ),
-                vol.Optional(CONF_LANGUAGE): str,
-                vol.Optional(CONF_USE_GPS, default=DEFAULT_USE_GPS): selector.BooleanSelector(
-                    selector.BooleanSelectorConfig()
-                ),
-                vol.Optional(
-                    CONF_EXTENDED_ATTR, default=DEFAULT_EXTENDED_ATTR
-                ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
-                vol.Optional(CONF_SHOW_TIME, default=DEFAULT_SHOW_TIME): selector.BooleanSelector(
-                    selector.BooleanSelectorConfig()
-                ),
-                vol.Optional(
-                    CONF_DATE_FORMAT, default=DEFAULT_DATE_FORMAT
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=DATE_FORMAT_OPTIONS,
-                        multiple=False,
-                        custom_value=False,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                    )
-                ),
-            }
-        )
+        data_schema: vol.Schema = user_schema(devicetracker_id_list, zone_list)
         return self.async_show_form(
             step_id="user",
             data_schema=data_schema,

--- a/custom_components/places/config_schema.py
+++ b/custom_components/places/config_schema.py
@@ -1,0 +1,119 @@
+"""Schema helpers used by the Places config flow."""
+
+from __future__ import annotations
+
+from homeassistant.helpers import selector
+import voluptuous as vol
+
+from .const import (
+    CONF_API_KEY,
+    CONF_DATE_FORMAT,
+    CONF_DEVICETRACKER_ID,
+    CONF_DISPLAY_OPTIONS,
+    CONF_EXTENDED_ATTR,
+    CONF_HOME_ZONE,
+    CONF_LANGUAGE,
+    CONF_MAP_PROVIDER,
+    CONF_MAP_ZOOM,
+    CONF_NAME,
+    CONF_SHOW_TIME,
+    CONF_USE_GPS,
+    DEFAULT_DATE_FORMAT,
+    DEFAULT_DISPLAY_OPTIONS,
+    DEFAULT_EXTENDED_ATTR,
+    DEFAULT_HOME_ZONE,
+    DEFAULT_MAP_PROVIDER,
+    DEFAULT_MAP_ZOOM,
+    DEFAULT_SHOW_TIME,
+    DEFAULT_USE_GPS,
+)
+
+MAP_PROVIDER_OPTIONS: list[str] = ["apple", "google", "osm"]
+"""Available map provider values for the config flow selector."""
+
+STATE_OPTIONS: list[str] = ["zone, place", "formatted_place", "zone_name, place"]
+"""Display options supported by the Places integration."""
+
+DATE_FORMAT_OPTIONS: list[str] = ["mm/dd", "dd/mm"]
+"""Date-format dropdown values for the config flow selector."""
+
+MAP_ZOOM_MIN: int = 1
+"""Minimum map zoom level allowed by the number selector."""
+
+MAP_ZOOM_MAX: int = 20
+"""Maximum map zoom level allowed by the number selector."""
+
+
+def select_schema(
+    options: list[str] | list[selector.SelectOptionDict], *, custom_value: bool
+) -> selector.SelectSelector:
+    """Create a dropdown select selector for Places config flows.
+
+    Args:
+        options: Selector option values or option dictionaries.
+        custom_value: Whether users can enter values not listed in ``options``.
+
+    Returns:
+        A dropdown-style select selector configured for single selection.
+    """
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=options,
+            multiple=False,
+            custom_value=custom_value,
+            mode=selector.SelectSelectorMode.DROPDOWN,
+        )
+    )
+
+
+def user_schema(
+    devicetracker_options: list[selector.SelectOptionDict],
+    zone_options: list[selector.SelectOptionDict],
+) -> vol.Schema:
+    """Build the schema used by ``PlacesConfigFlow.async_step_user``.
+
+    Args:
+        devicetracker_options: Selectable devicetracker entities.
+        zone_options: Selectable zone entities.
+
+    Returns:
+        The user config flow schema with matching defaults and selectors.
+    """
+    return vol.Schema(
+        {
+            vol.Required(CONF_NAME): str,
+            vol.Required(CONF_DEVICETRACKER_ID): select_schema(
+                devicetracker_options, custom_value=False
+            ),
+            vol.Optional(CONF_API_KEY): str,
+            vol.Optional(CONF_DISPLAY_OPTIONS, default=DEFAULT_DISPLAY_OPTIONS): select_schema(
+                STATE_OPTIONS, custom_value=True
+            ),
+            vol.Optional(CONF_HOME_ZONE, default=DEFAULT_HOME_ZONE): select_schema(
+                zone_options, custom_value=False
+            ),
+            vol.Optional(CONF_MAP_PROVIDER, default=DEFAULT_MAP_PROVIDER): select_schema(
+                MAP_PROVIDER_OPTIONS, custom_value=False
+            ),
+            vol.Optional(CONF_MAP_ZOOM, default=int(DEFAULT_MAP_ZOOM)): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=MAP_ZOOM_MIN,
+                    max=MAP_ZOOM_MAX,
+                    mode=selector.NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Optional(CONF_LANGUAGE): str,
+            vol.Optional(CONF_USE_GPS, default=DEFAULT_USE_GPS): selector.BooleanSelector(
+                selector.BooleanSelectorConfig()
+            ),
+            vol.Optional(
+                CONF_EXTENDED_ATTR, default=DEFAULT_EXTENDED_ATTR
+            ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+            vol.Optional(CONF_SHOW_TIME, default=DEFAULT_SHOW_TIME): selector.BooleanSelector(
+                selector.BooleanSelectorConfig()
+            ),
+            vol.Optional(CONF_DATE_FORMAT, default=DEFAULT_DATE_FORMAT): select_schema(
+                DATE_FORMAT_OPTIONS, custom_value=False
+            ),
+        }
+    )

--- a/custom_components/places/location.py
+++ b/custom_components/places/location.py
@@ -21,7 +21,7 @@ class CoordinatePair:
         return f"{self.latitude},{self.longitude}"
 
 
-@dataclass
+@dataclass(slots=True)
 class LocationSnapshot:
     """Derived-location snapshot used by the Places updater."""
 

--- a/custom_components/places/location.py
+++ b/custom_components/places/location.py
@@ -1,0 +1,92 @@
+"""Location snapshot and distance helper objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.util.location import distance
+
+from .const import METERS_PER_MILE
+
+
+@dataclass(slots=True)
+class CoordinatePair:
+    """Simple latitude and longitude container."""
+
+    latitude: float
+    longitude: float
+
+    def as_location(self) -> str:
+        """Render location as ``lat,lon``."""
+        return f"{self.latitude},{self.longitude}"
+
+
+@dataclass
+class LocationSnapshot:
+    """Derived-location snapshot used by the Places updater."""
+
+    current: CoordinatePair | None = None
+    previous: CoordinatePair | None = None
+    home: CoordinatePair | None = None
+    distance_from_home_m: float | None = None
+    distance_traveled_m: float | None = None
+
+    def calculate(self) -> None:
+        """Calculate supported distance values for this snapshot."""
+        if self.current is not None and self.home is not None:
+            self.distance_from_home_m = distance(
+                self.current.latitude,
+                self.current.longitude,
+                self.home.latitude,
+                self.home.longitude,
+            )
+        if self.current is not None and self.previous is not None:
+            self.distance_traveled_m = distance(
+                self.current.latitude,
+                self.current.longitude,
+                self.previous.latitude,
+                self.previous.longitude,
+            )
+
+    @property
+    def distance_from_home_km(self) -> float | None:
+        """Distance from home in kilometers."""
+        if self.distance_from_home_m is None:
+            return None
+        return round(self.distance_from_home_m / 1000, 3)
+
+    @property
+    def distance_from_home_mi(self) -> float | None:
+        """Distance from home in miles."""
+        if self.distance_from_home_m is None:
+            return None
+        return round(self.distance_from_home_m / METERS_PER_MILE, 3)
+
+    @property
+    def distance_traveled_mi(self) -> float | None:
+        """Distance traveled from previous sample in miles."""
+        if self.distance_traveled_m is None:
+            return None
+        return round(self.distance_traveled_m / METERS_PER_MILE, 3)
+
+
+def direction_of_travel(
+    previous_distance_from_home_m: float | None, distance_from_home_m: float | None
+) -> str:
+    """Compare home-distance snapshots and return a user-facing direction string.
+
+    Args:
+        previous_distance_from_home_m: Prior distance from home.
+        distance_from_home_m: New distance from home.
+
+    Returns:
+        ``towards home``, ``away from home``, or ``stationary``.
+    """
+    if previous_distance_from_home_m is None or distance_from_home_m is None:
+        return "stationary"
+
+    if previous_distance_from_home_m > distance_from_home_m:
+        return "towards home"
+    if previous_distance_from_home_m < distance_from_home_m:
+        return "away from home"
+    return "stationary"

--- a/custom_components/places/osm_client.py
+++ b/custom_components/places/osm_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Mapping, MutableMapping
+from collections.abc import Mapping, MutableMapping, MutableSequence
 import json
 import logging
 from typing import Any
@@ -75,12 +75,16 @@ class OSMClient:
         Returns:
             Fully encoded OSM lookup URL.
         """
-        return (
-            "https://nominatim.openstreetmap.org/lookup?osm_ids="
-            f"{osm_type_abbr}{osm_id}"
-            "&format=json&addressdetails=1&extratags=1&namedetails=1"
-            f"&email={email or ''}&accept-language={language or ''}"
-        )
+        params = {
+            "osm_ids": f"{osm_type_abbr}{osm_id}",
+            "format": "json",
+            "addressdetails": "1",
+            "extratags": "1",
+            "namedetails": "1",
+            "email": email or "",
+            "accept-language": language or "",
+        }
+        return f"https://nominatim.openstreetmap.org/lookup?{urlencode(params)}"
 
     @staticmethod
     def wikidata_url(wikidata_id: object) -> str:
@@ -113,6 +117,8 @@ class OSMClient:
             cached_data = osm_cache[url]
             if isinstance(cached_data, MutableMapping):
                 return dict(cached_data)
+            if isinstance(cached_data, MutableSequence):
+                return list(cached_data)
             return cached_data
 
         throttle = self._hass.data[DOMAIN][OSM_THROTTLE]
@@ -183,8 +189,6 @@ class OSMClient:
                 and isinstance(get_dict[0], Mapping)
             ):
                 get_dict = dict(get_dict[0])
-                osm_cache[url] = get_dict
-                return get_dict
 
             if isinstance(get_dict, Mapping) and "error_message" in get_dict:
                 _LOGGER.warning(

--- a/custom_components/places/osm_client.py
+++ b/custom_components/places/osm_client.py
@@ -145,6 +145,15 @@ class OSMClient:
                     url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)
                 ) as response:
                     get_json_input = await response.text()
+                    if not 200 <= response.status < 300:
+                        _LOGGER.warning(
+                            "(%s) Error response from %s [%s]: %s",
+                            self._sensor_name,
+                            name,
+                            response.status,
+                            get_json_input,
+                        )
+                        return None
                     _LOGGER.debug(
                         "(%s) %s Response: %s",
                         self._sensor_name,

--- a/custom_components/places/osm_client.py
+++ b/custom_components/places/osm_client.py
@@ -1,0 +1,196 @@
+"""Client helpers for OpenStreetMap lookup requests used by Places."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping, MutableMapping
+import json
+import logging
+from urllib.parse import urlencode
+
+import aiohttp
+from homeassistant.const import __version__ as ha_version
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN, OSM_CACHE, OSM_THROTTLE, OSM_THROTTLE_INTERVAL_SECONDS, VERSION
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OSMClient:
+    """Client for shared OSM request building and lookup behavior."""
+
+    def __init__(self, hass: HomeAssistant, sensor_name: str) -> None:
+        """Create an OSM client bound to a sensor for logging and HA context.
+
+        Args:
+            hass: Home Assistant instance.
+            sensor_name: Sensor name used in log messages.
+        """
+        self._hass: HomeAssistant = hass
+        self._sensor_name: str = sensor_name
+
+    @staticmethod
+    def reverse_url(
+        latitude: object, longitude: object, language: str | None, email: str | None
+    ) -> str:
+        """Build the Nominatim reverse-geocode URL for the supplied coordinates.
+
+        Args:
+            latitude: Latitude for the reverse lookup.
+            longitude: Longitude for the reverse lookup.
+            language: Accept-Language value to request localized results.
+            email: Nominatim contact email value.
+
+        Returns:
+            Fully encoded reverse geocode URL.
+        """
+        base_url = "https://nominatim.openstreetmap.org/reverse?format=json"
+        params = {
+            "lat": latitude,
+            "lon": longitude,
+            "accept-language": language or "",
+            "addressdetails": "1",
+            "namedetails": "1",
+            "zoom": "18",
+            "limit": "1",
+            "email": email or "",
+        }
+        return f"{base_url}&{urlencode(params)}"
+
+    @staticmethod
+    def details_url(
+        osm_type_abbr: str, osm_id: object, language: str | None, email: str | None
+    ) -> str:
+        """Build the Nominatim lookup URL for a typed OSM feature.
+
+        Args:
+            osm_type_abbr: One-letter OSM type prefix (N/W/R).
+            osm_id: Object identifier for the feature.
+            language: Accept-Language value to request localized details.
+            email: Nominatim contact email value.
+
+        Returns:
+            Fully encoded OSM lookup URL.
+        """
+        return (
+            "https://nominatim.openstreetmap.org/lookup?osm_ids="
+            f"{osm_type_abbr}{osm_id}"
+            "&format=json&addressdetails=1&extratags=1&namedetails=1"
+            f"&email={email or ''}&accept-language={language or ''}"
+        )
+
+    @staticmethod
+    def wikidata_url(wikidata_id: object) -> str:
+        """Build the wikidata entity URL used by OSM extras lookup."""
+        return f"https://www.wikidata.org/wiki/Special:EntityData/{wikidata_id}.json"
+
+    async def get_json(self, url: str, name: str) -> MutableMapping[str, object] | None:
+        """Fetch JSON from a URL with OSM cache and throttle behavior.
+
+        Args:
+            url: Absolute URL to query.
+            name: Friendly label for log output.
+
+        Returns:
+            Parsed JSON mapping (or a list-item flattened to mapping), or
+            ``None`` when the request or parse fails.
+        """
+        osm_cache: dict[str, object] = self._hass.data[DOMAIN][OSM_CACHE]
+        if url in osm_cache:
+            _LOGGER.debug(
+                "(%s) %s data loaded from cache (Cache size: %s)",
+                self._sensor_name,
+                name,
+                len(osm_cache),
+            )
+            cached_data = osm_cache[url]
+            if isinstance(cached_data, Mapping):
+                return dict(cached_data)
+            return {}
+
+        throttle = self._hass.data[DOMAIN][OSM_THROTTLE]
+        async with throttle["lock"]:
+            now = asyncio.get_running_loop().time()
+            wait_time = max(0, OSM_THROTTLE_INTERVAL_SECONDS - (now - throttle["last_query"]))
+            if wait_time > 0:
+                await asyncio.sleep(wait_time)
+            throttle["last_query"] = asyncio.get_running_loop().time()
+
+            _LOGGER.info("(%s) Requesting data for %s", self._sensor_name, name)
+            _LOGGER.debug("(%s) %s URL: %s", self._sensor_name, name, url)
+
+            get_dict: object | None = None
+            user_agent = (
+                f"Mozilla/5.0 (Home Assistant/{ha_version}) "
+                f"{DOMAIN}/{VERSION} (+https://github.com/custom-components/places)"
+            )
+            headers: dict[str, str] = {"user-agent": user_agent}
+
+            try:
+                session = async_get_clientsession(self._hass)
+                async with session.get(
+                    url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)
+                ) as response:
+                    get_json_input = await response.text()
+                    _LOGGER.debug(
+                        "(%s) %s Response: %s",
+                        self._sensor_name,
+                        name,
+                        get_json_input,
+                    )
+                    try:
+                        get_dict = json.loads(get_json_input)
+                    except json.decoder.JSONDecodeError as exc:
+                        _LOGGER.warning(
+                            "(%s) JSON Decode Error with %s info [%s: %s]: %s",
+                            self._sensor_name,
+                            name,
+                            type(exc).__name__,
+                            exc,
+                            get_json_input,
+                        )
+                        return None
+            except (
+                TimeoutError,
+                aiohttp.ClientError,
+                aiohttp.ContentTypeError,
+                OSError,
+                RuntimeError,
+            ) as exc:
+                _LOGGER.warning(
+                    "(%s) Error connecting to %s [%s: %s]: %s",
+                    self._sensor_name,
+                    name,
+                    type(exc).__name__,
+                    exc,
+                    url,
+                )
+                return None
+
+            if get_dict is None:
+                return None
+
+            if (
+                isinstance(get_dict, list)
+                and len(get_dict) == 1
+                and isinstance(get_dict[0], Mapping)
+            ):
+                get_dict = get_dict[0]
+                osm_cache[url] = get_dict
+                return dict(get_dict) if isinstance(get_dict, MutableMapping) else None
+            if not isinstance(get_dict, MutableMapping):
+                return None
+
+            if "error_message" in get_dict:
+                _LOGGER.warning(
+                    "(%s) An error occurred contacting the web service for %s: %s",
+                    self._sensor_name,
+                    name,
+                    get_dict.get("error_message"),
+                )
+                return None
+
+            osm_cache[url] = get_dict
+            return get_dict

--- a/custom_components/places/osm_client.py
+++ b/custom_components/places/osm_client.py
@@ -172,18 +172,7 @@ class OSMClient:
             if get_dict is None:
                 return None
 
-            if (
-                isinstance(get_dict, list)
-                and len(get_dict) == 1
-                and isinstance(get_dict[0], Mapping)
-            ):
-                get_dict = get_dict[0]
-                osm_cache[url] = get_dict
-                return dict(get_dict) if isinstance(get_dict, MutableMapping) else None
-            if not isinstance(get_dict, MutableMapping):
-                return None
-
-            if "error_message" in get_dict:
+            if isinstance(get_dict, MutableMapping) and "error_message" in get_dict:
                 _LOGGER.warning(
                     "(%s) An error occurred contacting the web service for %s: %s",
                     self._sensor_name,
@@ -192,5 +181,16 @@ class OSMClient:
                 )
                 return None
 
-            osm_cache[url] = get_dict
-            return get_dict
+            if (
+                isinstance(get_dict, list)
+                and len(get_dict) == 1
+                and isinstance(get_dict[0], Mapping)
+            ):
+                get_dict = get_dict[0]
+                osm_cache[url] = get_dict
+                return dict(get_dict) if isinstance(get_dict, MutableMapping) else None
+            if isinstance(get_dict, MutableMapping):
+                osm_cache[url] = get_dict
+                return get_dict
+
+            return None

--- a/custom_components/places/osm_client.py
+++ b/custom_components/places/osm_client.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Mapping, MutableMapping
 import json
 import logging
+from typing import Any
 from urllib.parse import urlencode
 
 import aiohttp
@@ -68,7 +69,7 @@ class OSMClient:
         Args:
             osm_type_abbr: One-letter OSM type prefix (N/W/R).
             osm_id: Object identifier for the feature.
-            language: Accept-Language value to request localized details.
+            language: Accept-Language value to request localized results.
             email: Nominatim contact email value.
 
         Returns:
@@ -86,16 +87,20 @@ class OSMClient:
         """Build the wikidata entity URL used by OSM extras lookup."""
         return f"https://www.wikidata.org/wiki/Special:EntityData/{wikidata_id}.json"
 
-    async def get_json(self, url: str, name: str) -> MutableMapping[str, object] | None:
+    def update_sensor_name(self, sensor_name: str) -> None:
+        """Update the cached sensor name used in log messages."""
+        self._sensor_name = sensor_name
+
+    async def get_json(self, url: str, name: str) -> Any | None:
         """Fetch JSON from a URL with OSM cache and throttle behavior.
 
         Args:
-            url: Absolute URL to query.
+            url: Absolute URL to request.
             name: Friendly label for log output.
 
         Returns:
-            Parsed JSON mapping (or a list-item flattened to mapping), or
-            ``None`` when the request or parse fails.
+            Parsed JSON object (or a list-item flattened mapping), or ``None``
+            when the request or parse fails.
         """
         osm_cache: dict[str, object] = self._hass.data[DOMAIN][OSM_CACHE]
         if url in osm_cache:
@@ -106,9 +111,9 @@ class OSMClient:
                 len(osm_cache),
             )
             cached_data = osm_cache[url]
-            if isinstance(cached_data, Mapping):
+            if isinstance(cached_data, MutableMapping):
                 return dict(cached_data)
-            return {}
+            return cached_data
 
         throttle = self._hass.data[DOMAIN][OSM_THROTTLE]
         async with throttle["lock"]:
@@ -121,7 +126,7 @@ class OSMClient:
             _LOGGER.info("(%s) Requesting data for %s", self._sensor_name, name)
             _LOGGER.debug("(%s) %s URL: %s", self._sensor_name, name, url)
 
-            get_dict: object | None = None
+            get_dict: Any | None = None
             user_agent = (
                 f"Mozilla/5.0 (Home Assistant/{ha_version}) "
                 f"{DOMAIN}/{VERSION} (+https://github.com/custom-components/places)"
@@ -172,7 +177,16 @@ class OSMClient:
             if get_dict is None:
                 return None
 
-            if isinstance(get_dict, MutableMapping) and "error_message" in get_dict:
+            if (
+                isinstance(get_dict, list)
+                and len(get_dict) == 1
+                and isinstance(get_dict[0], Mapping)
+            ):
+                get_dict = dict(get_dict[0])
+                osm_cache[url] = get_dict
+                return get_dict
+
+            if isinstance(get_dict, Mapping) and "error_message" in get_dict:
                 _LOGGER.warning(
                     "(%s) An error occurred contacting the web service for %s: %s",
                     self._sensor_name,
@@ -181,16 +195,5 @@ class OSMClient:
                 )
                 return None
 
-            if (
-                isinstance(get_dict, list)
-                and len(get_dict) == 1
-                and isinstance(get_dict[0], Mapping)
-            ):
-                get_dict = get_dict[0]
-                osm_cache[url] = get_dict
-                return dict(get_dict) if isinstance(get_dict, MutableMapping) else None
-            if isinstance(get_dict, MutableMapping):
-                osm_cache[url] = get_dict
-                return get_dict
-
-            return None
+            osm_cache[url] = get_dict
+            return get_dict

--- a/custom_components/places/parse_osm.py
+++ b/custom_components/places/parse_osm.py
@@ -64,6 +64,17 @@ class OSMParser:
         """
         self.sensor = sensor
 
+    def current_osm_dict(self) -> MutableMapping[str, Any]:
+        """Return the current OSM response mapping from sensor attributes."""
+        return self.sensor.get_attr_safe_dict(ATTR_OSM_DICT)
+
+    def current_address(self) -> MutableMapping[str, Any]:
+        """Return the current OSM address mapping from sensor attributes."""
+        address = self.current_osm_dict().get("address", {})
+        if isinstance(address, MutableMapping):
+            return address
+        return {}
+
     async def parse_osm_dict(self) -> None:
         """Parse the current OSM response stored on the sensor.
 
@@ -217,7 +228,7 @@ class OSMParser:
         ):
             self.sensor.set_attr(
                 ATTR_PLACE_NAME,
-                self.sensor.get_attr_safe_dict(ATTR_OSM_DICT).get("address", {}).get("retail"),
+                self.current_address().get("retail"),
             )
         _LOGGER.debug(
             "(%s) Place Name: %s",
@@ -309,7 +320,7 @@ class OSMParser:
         if "postcode" in address:
             self.sensor.set_attr(
                 ATTR_POSTAL_CODE,
-                self.sensor.get_attr_safe_dict(ATTR_OSM_DICT).get("address", {}).get("postcode"),
+                self.current_address().get("postcode"),
             )
 
     async def parse_miscellaneous(self, osm_dict: MutableMapping[str, Any]) -> None:
@@ -327,7 +338,7 @@ class OSMParser:
         if "osm_id" in osm_dict:
             self.sensor.set_attr(
                 ATTR_OSM_ID,
-                str(self.sensor.get_attr_safe_dict(ATTR_OSM_DICT).get("osm_id", "")),
+                str(self.current_osm_dict().get("osm_id", "")),
             )
         if "osm_type" in osm_dict:
             self.sensor.set_attr(

--- a/custom_components/places/parse_osm.py
+++ b/custom_components/places/parse_osm.py
@@ -228,7 +228,7 @@ class OSMParser:
         ):
             self.sensor.set_attr(
                 ATTR_PLACE_NAME,
-                self.current_address().get("retail"),
+                address.get("retail"),
             )
         _LOGGER.debug(
             "(%s) Place Name: %s",
@@ -320,7 +320,7 @@ class OSMParser:
         if "postcode" in address:
             self.sensor.set_attr(
                 ATTR_POSTAL_CODE,
-                self.current_address().get("postcode"),
+                address.get("postcode"),
             )
 
     async def parse_miscellaneous(self, osm_dict: MutableMapping[str, Any]) -> None:
@@ -338,7 +338,7 @@ class OSMParser:
         if "osm_id" in osm_dict:
             self.sensor.set_attr(
                 ATTR_OSM_ID,
-                str(self.current_osm_dict().get("osm_id", "")),
+                str(osm_dict.get("osm_id", "")),
             )
         if "osm_type" in osm_dict:
             self.sensor.set_attr(

--- a/custom_components/places/pipeline.py
+++ b/custom_components/places/pipeline.py
@@ -36,33 +36,39 @@ class PlacesUpdatePipeline:
         await self.updater.log_update_start(reason)
         now: datetime = await self.updater.get_current_time()
         sensor = self.updater.sensor
+        proceed_with_update = UpdateStatus.SKIP
 
-        await self.updater.update_entity_name_and_cleanup()
-        await self.updater.update_client_sensor_name()
-        await self.updater.update_previous_state()
-        await self.updater.update_old_coordinates()
-        prev_last_place_name = sensor.get_attr_safe_str(ATTR_LAST_PLACE_NAME)
+        try:
+            await self.updater.update_entity_name_and_cleanup()
+            await self.updater.update_client_sensor_name()
+            await self.updater.update_previous_state()
+            await self.updater.update_old_coordinates()
+            prev_last_place_name = sensor.get_attr_safe_str(ATTR_LAST_PLACE_NAME)
 
-        proceed_with_update: UpdateStatus = (
-            await self.updater.check_device_tracker_and_update_coords()
-        )
-        if proceed_with_update == UpdateStatus.PROCEED:
-            proceed_with_update = await self.updater.determine_update_criteria()
+            proceed_with_update = await self.updater.check_device_tracker_and_update_coords()
+            if proceed_with_update == UpdateStatus.PROCEED:
+                proceed_with_update = await self.updater.determine_update_criteria()
 
-        if proceed_with_update == UpdateStatus.PROCEED:
-            await self.updater.process_osm_update(now=now)
+            if proceed_with_update == UpdateStatus.PROCEED:
+                await self.updater.process_osm_update(now=now)
 
-            if await self.updater.should_update_state(now=now):
-                await self.updater.handle_state_update(
-                    now=now, prev_last_place_name=prev_last_place_name
-                )
+                if await self.updater.should_update_state(now=now):
+                    await self.updater.handle_state_update(
+                        now=now, prev_last_place_name=prev_last_place_name
+                    )
+                else:
+                    _LOGGER.info(
+                        "(%s) No entity update needed, Previous State = New State",
+                        sensor.get_attr(CONF_NAME),
+                    )
+                    await self.updater.rollback_update(previous_attr, now, proceed_with_update)
             else:
-                _LOGGER.info(
-                    "(%s) No entity update needed, Previous State = New State",
-                    sensor.get_attr(CONF_NAME),
-                )
                 await self.updater.rollback_update(previous_attr, now, proceed_with_update)
-        else:
+        except Exception:
+            # This orchestration boundary must rollback partial state for any
+            # phase failure, then re-raise so Home Assistant can report it.
+            _LOGGER.exception("(%s) Error during Places update", sensor.get_attr(CONF_NAME))
             await self.updater.rollback_update(previous_attr, now, proceed_with_update)
-
-        await self.updater.finish_update(now=now)
+            raise
+        finally:
+            await self.updater.finish_update(now=now)

--- a/custom_components/places/pipeline.py
+++ b/custom_components/places/pipeline.py
@@ -1,0 +1,67 @@
+"""Update orchestration pipeline for Places entity refreshes."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from datetime import datetime
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .const import ATTR_LAST_PLACE_NAME, CONF_NAME, UpdateStatus
+
+if TYPE_CHECKING:
+    from .update_sensor import PlacesUpdater
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PlacesUpdatePipeline:
+    """Run the Places updater through its ordered update phases."""
+
+    def __init__(self, updater: PlacesUpdater) -> None:
+        """Create a pipeline instance for a single updater.
+
+        Args:
+            updater: Active updater coordinating all update phases.
+        """
+        self.updater = updater
+
+    async def run(self, reason: str, previous_attr: MutableMapping[str, Any]) -> None:
+        """Execute a full update in the legacy phase order.
+
+        Args:
+            reason: Human-readable update reason.
+            previous_attr: Snapshot of attributes captured before the update start.
+        """
+        await self.updater.log_update_start(reason)
+        now: datetime = await self.updater.get_current_time()
+
+        await self.updater.update_entity_name_and_cleanup()
+        await self.updater.update_client_sensor_name()
+        await self.updater.update_previous_state()
+        await self.updater.update_old_coordinates()
+        prev_last_place_name = self.updater.sensor.get_attr_safe_str(ATTR_LAST_PLACE_NAME)
+
+        proceed_with_update: UpdateStatus = (
+            await self.updater.check_device_tracker_and_update_coords()
+        )
+        if proceed_with_update == UpdateStatus.PROCEED:
+            proceed_with_update = await self.updater.determine_update_criteria()
+
+        if proceed_with_update == UpdateStatus.PROCEED:
+            await self.updater.process_osm_update(now=now)
+
+            if await self.updater.should_update_state(now=now):
+                await self.updater.handle_state_update(
+                    now=now, prev_last_place_name=prev_last_place_name
+                )
+            else:
+                _LOGGER.info(
+                    "(%s) No entity update needed, Previous State = New State",
+                    self.updater.sensor.get_attr(CONF_NAME),
+                )
+                await self.updater.rollback_update(previous_attr, now, proceed_with_update)
+        else:
+            await self.updater.rollback_update(previous_attr, now, proceed_with_update)
+
+        await self.updater.finish_update(now=now)

--- a/custom_components/places/pipeline.py
+++ b/custom_components/places/pipeline.py
@@ -35,12 +35,13 @@ class PlacesUpdatePipeline:
         """
         await self.updater.log_update_start(reason)
         now: datetime = await self.updater.get_current_time()
+        sensor = self.updater.sensor
 
         await self.updater.update_entity_name_and_cleanup()
         await self.updater.update_client_sensor_name()
         await self.updater.update_previous_state()
         await self.updater.update_old_coordinates()
-        prev_last_place_name = self.updater.sensor.get_attr_safe_str(ATTR_LAST_PLACE_NAME)
+        prev_last_place_name = sensor.get_attr_safe_str(ATTR_LAST_PLACE_NAME)
 
         proceed_with_update: UpdateStatus = (
             await self.updater.check_device_tracker_and_update_coords()
@@ -58,7 +59,7 @@ class PlacesUpdatePipeline:
             else:
                 _LOGGER.info(
                     "(%s) No entity update needed, Previous State = New State",
-                    self.updater.sensor.get_attr(CONF_NAME),
+                    sensor.get_attr(CONF_NAME),
                 )
                 await self.updater.rollback_update(previous_attr, now, proceed_with_update)
         else:

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -503,19 +503,7 @@ class Places(SensorEntity):
             be converted.
         """
         self._sync_internal_attr()
-        value = self.get_attr(attr) if default is None else self.get_attr(attr, default)
-        if value is not None:
-            try:
-                return str(value)
-            except (ValueError, TypeError) as e:
-                _LOGGER.debug(
-                    "Unable to convert attribute value to string (%r): %s: %s",
-                    value,
-                    type(e).__name__,
-                    e,
-                )
-                return ""
-        return ""
+        return self._attributes.safe_str(attr, default)
 
     def get_attr_safe_float(self, attr: str | None, default: object | None = None) -> float:
         """Read an internal attribute as a float.

--- a/custom_components/places/sensor.py
+++ b/custom_components/places/sensor.py
@@ -19,7 +19,7 @@ import copy
 from datetime import timedelta
 import locale
 import logging
-from typing import Any, SupportsFloat, SupportsIndex, TypeVar
+from typing import Any, TypeVar
 
 import cachetools
 from homeassistant.components.recorder import DATA_INSTANCE as RECORDER_INSTANCE
@@ -46,6 +46,7 @@ from homeassistant.helpers.event import EventStateChangedData, async_track_state
 from homeassistant.util import Throttle, slugify
 
 from .advanced_options import AdvancedOptionsParser
+from .attributes import PlacesAttributes
 from .basic_options import BasicOptionsParser
 from .const import (
     ATTR_DEVICETRACKER_ID,
@@ -76,7 +77,6 @@ from .const import (
     CONF_MAP_ZOOM,
     CONF_SHOW_TIME,
     CONF_USE_GPS,
-    CONFIG_ATTRIBUTES_LIST,
     DEFAULT_DATE_FORMAT,
     DEFAULT_DISPLAY_OPTIONS,
     DEFAULT_EXTENDED_ATTR,
@@ -91,8 +91,6 @@ from .const import (
     EVENT_TYPE,
     EXTENDED_ATTRIBUTE_LIST,
     EXTRA_STATE_ATTRIBUTE_LIST,
-    JSON_ATTRIBUTE_LIST,
-    JSON_IGNORE_ATTRIBUTE_LIST,
     OSM_CACHE,
     OSM_CACHE_MAX_AGE_HOURS,
     OSM_CACHE_MAX_SIZE,
@@ -212,7 +210,8 @@ class Places(SensorEntity):
         _LOGGER.debug("(%s) [Init] HASS TimeZone: %s", name, hass.config.time_zone)
 
         self.warn_if_device_tracker_prob = False
-        self._internal_attr: MutableMapping[str, Any] = {}
+        self._attributes = PlacesAttributes()
+        self._internal_attr: MutableMapping[str, Any] = self._attributes.data
         self.set_attr(ATTR_INITIAL_UPDATE, True)
         self._config_entry: ConfigEntry = config_entry
         self._hass: HomeAssistant = hass
@@ -359,7 +358,13 @@ class Places(SensorEntity):
         Returns:
             Internal sensor attribute mapping.
         """
+        self._sync_internal_attr()
         return self._internal_attr
+
+    def _sync_internal_attr(self) -> None:
+        """Synchronize direct ``_internal_attr`` assignment with the attribute store."""
+        if self._internal_attr is not self._attributes.data:
+            self._attributes.data = self._internal_attr
 
     def exclude_event_types(self) -> None:
         """Exclude high-cardinality Places update events from HA recorder."""
@@ -443,16 +448,10 @@ class Places(SensorEntity):
                 file. Imported and ignored keys are removed from this mapping.
         """
         self.set_attr(ATTR_INITIAL_UPDATE, False)
-        for attr in JSON_ATTRIBUTE_LIST:
-            if attr in json_attr:
-                self.set_attr(attr, json_attr.pop(attr, None))
+        self._attributes.import_json_attributes(json_attr)
         if not self.is_attr_blank(ATTR_NATIVE_VALUE):
             self._attr_native_value = self.get_attr(ATTR_NATIVE_VALUE)
 
-        # Remove attributes that are part of the Config and are explicitly not imported from JSON
-        for attr in CONFIG_ATTRIBUTES_LIST + JSON_IGNORE_ATTRIBUTE_LIST:
-            if attr in json_attr:
-                json_attr.pop(attr, None)
         if json_attr is not None and json_attr:
             _LOGGER.debug(
                 "(%s) [import_attributes] Attributes not imported: %s",
@@ -462,9 +461,8 @@ class Places(SensorEntity):
 
     def cleanup_attributes(self) -> None:
         """Remove blank attributes from the internal attribute mapping."""
-        for attr in list(self._internal_attr):
-            if self.is_attr_blank(attr):
-                self.clear_attr(attr)
+        self._sync_internal_attr()
+        self._attributes.cleanup()
 
     def is_attr_blank(self, attr: str) -> bool:
         """Return whether an internal attribute is absent or falsey except zero.
@@ -476,9 +474,8 @@ class Places(SensorEntity):
             ``True`` when the value is missing or falsey, with numeric zero
             treated as a meaningful value.
         """
-        if self._internal_attr.get(attr) or self._internal_attr.get(attr) == 0:
-            return False
-        return True
+        self._sync_internal_attr()
+        return self._attributes.is_blank(attr)
 
     def get_attr(self, attr: str | None, default: _AttrT | None = None) -> _AttrT | None:
         """Read an internal attribute with optional default handling.
@@ -491,9 +488,8 @@ class Places(SensorEntity):
             Stored value, ``default``, or ``None`` when the attribute is blank
             and no default was supplied.
         """
-        if attr is None or (default is None and self.is_attr_blank(attr)):
-            return None
-        return self._internal_attr.get(attr, default)
+        self._sync_internal_attr()
+        return self._attributes.get(attr, default)
 
     def get_attr_safe_str(self, attr: str | None, default: object | None = None) -> str:
         """Read an internal attribute as text without propagating conversion errors.
@@ -506,6 +502,7 @@ class Places(SensorEntity):
             String value, or an empty string when the value is missing or cannot
             be converted.
         """
+        self._sync_internal_attr()
         value = self.get_attr(attr) if default is None else self.get_attr(attr, default)
         if value is not None:
             try:
@@ -530,17 +527,8 @@ class Places(SensorEntity):
         Returns:
             Converted float value, or ``0.0`` when conversion is not possible.
         """
-        value: object | None = (
-            self.get_attr(attr) if default is None else self.get_attr(attr, default)
-        )
-        if value is None:
-            return 0.0
-        if not isinstance(value, str | bytes | bytearray | SupportsFloat | SupportsIndex):
-            return 0.0
-        try:
-            return float(value)
-        except TypeError, ValueError:
-            return 0.0
+        self._sync_internal_attr()
+        return self._attributes.safe_float(attr, default)
 
     def get_attr_safe_list(self, attr: str | None, default: object | None = None) -> list:
         """Read an internal attribute as a list.
@@ -552,12 +540,8 @@ class Places(SensorEntity):
         Returns:
             Stored list value, or an empty list for non-list values.
         """
-        value: object | None = (
-            self.get_attr(attr) if default is None else self.get_attr(attr, default)
-        )
-        if not isinstance(value, list):
-            return []
-        return value
+        self._sync_internal_attr()
+        return self._attributes.safe_list(attr, default)
 
     def get_attr_safe_dict(
         self, attr: str | None, default: MutableMapping[str, _AttrT] | None = None
@@ -571,10 +555,8 @@ class Places(SensorEntity):
         Returns:
             Stored mapping value, or an empty mapping for non-mapping values.
         """
-        value = self.get_attr(attr) if default is None else self.get_attr(attr, default)
-        if not isinstance(value, MutableMapping):
-            return {}
-        return value
+        self._sync_internal_attr()
+        return self._attributes.safe_dict(attr, default)
 
     def set_attr(self, attr: str, value: object | None = None) -> None:
         """Store a value in the internal attribute mapping.
@@ -583,8 +565,9 @@ class Places(SensorEntity):
             attr: Attribute key to update.
             value: Value to store.
         """
-        if attr:
-            self._internal_attr.update({attr: value})
+        self._sync_internal_attr()
+        self._attributes.set(attr, value)
+        self._internal_attr = self._attributes.data
 
     def clear_attr(self, attr: str) -> None:
         """Remove an internal attribute if present.
@@ -592,7 +575,9 @@ class Places(SensorEntity):
         Args:
             attr: Attribute key to remove.
         """
-        self._internal_attr.pop(attr, None)
+        self._sync_internal_attr()
+        self._attributes.clear(attr)
+        self._internal_attr = self._attributes.data
 
     @Throttle(MIN_THROTTLE_INTERVAL)
     @callback
@@ -649,7 +634,7 @@ class Places(SensorEntity):
 
     async def async_cleanup_attributes(self) -> None:
         """Asynchronously remove blank attributes from the internal mapping."""
-        attrs: MutableMapping[str, Any] = copy.deepcopy(self._internal_attr)
+        attrs: MutableMapping[str, Any] = copy.deepcopy(self.get_internal_attr())
         for attr in attrs:
             if self.is_attr_blank(attr):
                 self.clear_attr(attr)
@@ -676,6 +661,7 @@ class Places(SensorEntity):
         Args:
             reason: Human-readable trigger reason used in logs.
         """
+        self._sync_internal_attr()
         updater = PlacesUpdater(hass=self._hass, config_entry=self._config_entry, sensor=self)
         await updater.do_update(reason=reason, previous_attr=copy.deepcopy(self._internal_attr))
 
@@ -693,7 +679,7 @@ class Places(SensorEntity):
         if "formatted_place" in display_options:
             basic_parser = BasicOptionsParser(
                 sensor=self,
-                internal_attr=self._internal_attr,
+                internal_attr=self.get_internal_attr(),
                 display_options=self.get_attr_safe_list(ATTR_DISPLAY_OPTIONS_LIST),
             )
             formatted_place = await basic_parser.build_formatted_place()
@@ -724,7 +710,7 @@ class Places(SensorEntity):
         elif not await self.in_zone():
             basic_parser = BasicOptionsParser(
                 sensor=self,
-                internal_attr=self._internal_attr,
+                internal_attr=self.get_internal_attr(),
                 display_options=self.get_attr_safe_list(ATTR_DISPLAY_OPTIONS_LIST),
             )
             state = await basic_parser.build_display()
@@ -765,7 +751,8 @@ class Places(SensorEntity):
             previous_attr: Attribute mapping captured before the failed or
                 skipped update.
         """
-        self._internal_attr = previous_attr
+        self._attributes.data = previous_attr
+        self._internal_attr = self._attributes.data
 
 
 class PlacesNoRecorder(Places):

--- a/custom_components/places/tracker.py
+++ b/custom_components/places/tracker.py
@@ -22,6 +22,11 @@ from homeassistant.core import HomeAssistant
 from .helpers import is_float
 
 
+def _float_or_none(value: Any) -> float | None:
+    """Convert a float-compatible value, returning ``None`` for invalid values."""
+    return float(value) if is_float(value) else None
+
+
 class TrackerStatus(Enum):
     """Enumeration of tracker snapshot resolution states."""
 
@@ -165,21 +170,9 @@ class TrackerSnapshot:
             status = TrackerStatus.MISSING_COORDINATES
         elif not is_float(latitude_value) or not is_float(longitude_value):
             status = TrackerStatus.INVALID_COORDINATES
-        latitude = (
-            float(latitude_value)
-            if isinstance(latitude_value, (int, float, str)) and is_float(latitude_value)
-            else None
-        )
-        longitude = (
-            float(longitude_value)
-            if isinstance(longitude_value, (int, float, str)) and is_float(longitude_value)
-            else None
-        )
-        gps_accuracy = (
-            float(gps_accuracy_value)
-            if isinstance(gps_accuracy_value, (int, float, str)) and is_float(gps_accuracy_value)
-            else None
-        )
+        latitude = _float_or_none(latitude_value)
+        longitude = _float_or_none(longitude_value)
+        gps_accuracy = _float_or_none(gps_accuracy_value)
 
         return cls(
             entity_id=entity_id,

--- a/custom_components/places/tracker.py
+++ b/custom_components/places/tracker.py
@@ -58,9 +58,7 @@ class TrackerSnapshot:
         Returns:
             Snapshot describing tracker availability, state, and location data.
         """
-        has_entity_id = bool(entity_id)
-        state_obj: Any = hass.states.get(entity_id)
-        if not has_entity_id and state_obj is None:
+        if not entity_id:
             return cls(
                 entity_id=entity_id,
                 state=None,
@@ -72,6 +70,8 @@ class TrackerSnapshot:
                 zone_name=None,
                 entity_picture=None,
             )
+
+        state_obj: Any = hass.states.get(entity_id)
         if state_obj is None:
             return cls(
                 entity_id=entity_id,

--- a/custom_components/places/tracker.py
+++ b/custom_components/places/tracker.py
@@ -1,0 +1,171 @@
+"""Tracker snapshot primitives for Places."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any
+
+from homeassistant.const import (
+    ATTR_ENTITY_PICTURE,
+    ATTR_FRIENDLY_NAME,
+    ATTR_GPS_ACCURACY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_ZONE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant
+
+from .helpers import is_float
+
+
+class TrackerStatus(Enum):
+    """Enumeration of tracker snapshot resolution states."""
+
+    OK = auto()
+    MISSING_ENTITY_ID = auto()
+    NOT_FOUND = auto()
+    UNAVAILABLE = auto()
+    MISSING_COORDINATES = auto()
+    INVALID_COORDINATES = auto()
+
+
+@dataclass(slots=True)
+class TrackerSnapshot:
+    """Captured state and location for a tracked entity."""
+
+    entity_id: str | None
+    state: str | None
+    status: TrackerStatus
+    latitude: float | None
+    longitude: float | None
+    gps_accuracy: float | None
+    zone: str | None
+    zone_name: str | None
+    entity_picture: str | None
+
+    @classmethod
+    def from_hass(cls, hass: HomeAssistant, entity_id: str | None) -> TrackerSnapshot:
+        """Build a tracker snapshot from ``hass.states.get``.
+
+        Args:
+            hass: Home Assistant instance used to fetch tracker state.
+            entity_id: Tracker entity ID to look up in HA state registry.
+
+        Returns:
+            Snapshot describing tracker availability, state, and location data.
+        """
+        has_entity_id = bool(entity_id)
+        state_obj: Any = hass.states.get(entity_id)
+        if not has_entity_id and state_obj is None:
+            return cls(
+                entity_id=entity_id,
+                state=None,
+                status=TrackerStatus.MISSING_ENTITY_ID,
+                latitude=None,
+                longitude=None,
+                gps_accuracy=None,
+                zone=None,
+                zone_name=None,
+                entity_picture=None,
+            )
+        if state_obj is None:
+            return cls(
+                entity_id=entity_id,
+                state=None,
+                status=TrackerStatus.NOT_FOUND,
+                latitude=None,
+                longitude=None,
+                gps_accuracy=None,
+                zone=None,
+                zone_name=None,
+                entity_picture=None,
+            )
+
+        tracker_state: str | None
+        if isinstance(state_obj, str):
+            tracker_state = state_obj
+        else:
+            tracker_state = state_obj.state if hasattr(state_obj, "state") else None
+            if not isinstance(tracker_state, str):
+                tracker_state = None
+
+        if isinstance(tracker_state, str) and tracker_state.lower() in {
+            "none",
+            STATE_UNKNOWN.lower(),
+            STATE_UNAVAILABLE.lower(),
+        }:
+            return cls(
+                entity_id=entity_id,
+                state=tracker_state,
+                status=TrackerStatus.UNAVAILABLE,
+                latitude=None,
+                longitude=None,
+                gps_accuracy=None,
+                zone=None,
+                zone_name=None,
+                entity_picture=None,
+            )
+
+        raw_attributes = getattr(state_obj, "attributes", None)
+        if not isinstance(raw_attributes, Mapping):
+            return cls(
+                entity_id=entity_id,
+                state=tracker_state,
+                status=TrackerStatus.MISSING_COORDINATES,
+                latitude=None,
+                longitude=None,
+                gps_accuracy=None,
+                zone=None,
+                zone_name=None,
+                entity_picture=None,
+            )
+
+        zone = raw_attributes.get(CONF_ZONE)
+        zone_name = raw_attributes.get(ATTR_FRIENDLY_NAME)
+        entity_picture = raw_attributes.get(ATTR_ENTITY_PICTURE)
+
+        latitude_value = raw_attributes.get(CONF_LATITUDE)
+        longitude_value = raw_attributes.get(CONF_LONGITUDE)
+        gps_accuracy_value = raw_attributes.get(ATTR_GPS_ACCURACY)
+
+        status = TrackerStatus.OK
+        if CONF_LATITUDE not in raw_attributes or CONF_LONGITUDE not in raw_attributes:
+            status = TrackerStatus.MISSING_COORDINATES
+        elif not is_float(latitude_value) or not is_float(longitude_value):
+            status = TrackerStatus.INVALID_COORDINATES
+        latitude = (
+            float(latitude_value)
+            if isinstance(latitude_value, (int, float, str)) and is_float(latitude_value)
+            else None
+        )
+        longitude = (
+            float(longitude_value)
+            if isinstance(longitude_value, (int, float, str)) and is_float(longitude_value)
+            else None
+        )
+        gps_accuracy = (
+            float(gps_accuracy_value)
+            if isinstance(gps_accuracy_value, (int, float, str)) and is_float(gps_accuracy_value)
+            else None
+        )
+
+        return cls(
+            entity_id=entity_id,
+            state=tracker_state,
+            status=status,
+            latitude=latitude,
+            longitude=longitude,
+            gps_accuracy=gps_accuracy,
+            zone=zone,
+            zone_name=zone_name,
+            entity_picture=entity_picture,
+        )
+
+    @property
+    def has_valid_coordinates(self) -> bool:
+        """Return whether both coordinate values are parseable."""
+        return self.status == TrackerStatus.OK

--- a/custom_components/places/tracker.py
+++ b/custom_components/places/tracker.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
@@ -111,7 +111,8 @@ class TrackerSnapshot:
             )
 
         raw_attributes = getattr(state_obj, "attributes", None)
-        if not isinstance(raw_attributes, Mapping):
+        get_attr = cast("Callable[..., object]", getattr(raw_attributes, "get", None))
+        if not callable(get_attr):
             return cls(
                 entity_id=entity_id,
                 state=tracker_state,
@@ -124,16 +125,37 @@ class TrackerSnapshot:
                 entity_picture=None,
             )
 
-        zone = raw_attributes.get(CONF_ZONE)
-        zone_name = raw_attributes.get(ATTR_FRIENDLY_NAME)
-        entity_picture = raw_attributes.get(ATTR_ENTITY_PICTURE)
+        zone = get_attr(CONF_ZONE)
+        zone = zone if isinstance(zone, str) else None
+        zone_name = get_attr(ATTR_FRIENDLY_NAME)
+        zone_name = zone_name if isinstance(zone_name, str) else None
+        entity_picture = get_attr(ATTR_ENTITY_PICTURE)
+        entity_picture = entity_picture if isinstance(entity_picture, str) else None
 
-        latitude_value = raw_attributes.get(CONF_LATITUDE)
-        longitude_value = raw_attributes.get(CONF_LONGITUDE)
-        gps_accuracy_value = raw_attributes.get(ATTR_GPS_ACCURACY)
+        sentinel = object()
+        try:
+            latitude_value = get_attr(CONF_LATITUDE, sentinel)
+        except TypeError:
+            latitude_value = get_attr(CONF_LATITUDE)
+            has_latitude = True
+        else:
+            has_latitude = latitude_value is not sentinel
+
+        try:
+            longitude_value = get_attr(CONF_LONGITUDE, sentinel)
+        except TypeError:
+            longitude_value = get_attr(CONF_LONGITUDE)
+            has_longitude = True
+        else:
+            has_longitude = longitude_value is not sentinel
+
+        try:
+            gps_accuracy_value = get_attr(ATTR_GPS_ACCURACY, sentinel)
+        except TypeError:
+            gps_accuracy_value = get_attr(ATTR_GPS_ACCURACY)
 
         status = TrackerStatus.OK
-        if CONF_LATITUDE not in raw_attributes or CONF_LONGITUDE not in raw_attributes:
+        if not has_latitude or not has_longitude:
             status = TrackerStatus.MISSING_COORDINATES
         elif not is_float(latitude_value) or not is_float(longitude_value):
             status = TrackerStatus.INVALID_COORDINATES

--- a/custom_components/places/tracker.py
+++ b/custom_components/places/tracker.py
@@ -93,11 +93,17 @@ class TrackerSnapshot:
             if not isinstance(tracker_state, str):
                 tracker_state = None
 
-        if isinstance(tracker_state, str) and tracker_state.lower() in {
-            "none",
-            STATE_UNKNOWN.lower(),
-            STATE_UNAVAILABLE.lower(),
-        }:
+        is_raw_state = isinstance(state_obj, str)
+        if (
+            is_raw_state
+            and tracker_state is not None
+            and tracker_state.lower()
+            in {
+                "none",
+                STATE_UNKNOWN.lower(),
+                STATE_UNAVAILABLE.lower(),
+            }
+        ):
             return cls(
                 entity_id=entity_id,
                 state=tracker_state,

--- a/custom_components/places/tracker.py
+++ b/custom_components/places/tracker.py
@@ -143,7 +143,7 @@ class TrackerSnapshot:
             latitude_value = get_attr(CONF_LATITUDE, sentinel)
         except TypeError:
             latitude_value = get_attr(CONF_LATITUDE)
-            has_latitude = True
+            has_latitude = latitude_value is not None
         else:
             has_latitude = latitude_value is not sentinel
 
@@ -151,7 +151,7 @@ class TrackerSnapshot:
             longitude_value = get_attr(CONF_LONGITUDE, sentinel)
         except TypeError:
             longitude_value = get_attr(CONF_LONGITUDE)
-            has_longitude = True
+            has_longitude = longitude_value is not None
         else:
             has_longitude = longitude_value is not sentinel
 

--- a/custom_components/places/update_sensor.py
+++ b/custom_components/places/update_sensor.py
@@ -121,6 +121,7 @@ class PlacesUpdater:
         now: datetime = await self.get_current_time()
 
         await self.update_entity_name_and_cleanup()
+        self._osm_client.update_sensor_name(str(self.sensor.get_attr(CONF_NAME)))
         await self.update_previous_state()
         await self.update_old_coordinates()
         prev_last_place_name = self.sensor.get_attr_safe_str(ATTR_LAST_PLACE_NAME)
@@ -744,7 +745,7 @@ class PlacesUpdater:
             dict_name: Sensor attribute that receives the parsed JSON mapping.
         """
         get_dict = await self._osm_client.get_json(url=url, name=name)
-        self.sensor.set_attr(dict_name, get_dict or {})
+        self.sensor.set_attr(dict_name, get_dict if get_dict is not None else {})
         if get_dict is not None:
             return
 

--- a/custom_components/places/update_sensor.py
+++ b/custom_components/places/update_sensor.py
@@ -78,6 +78,7 @@ from .helpers import clear_since_from_state, is_float, safe_truncate, write_sens
 from .location import CoordinatePair, LocationSnapshot, direction_of_travel
 from .osm_client import OSMClient
 from .parse_osm import OSMParser
+from .pipeline import PlacesUpdatePipeline
 from .tracker import TrackerSnapshot, TrackerStatus
 
 if TYPE_CHECKING:
@@ -111,6 +112,15 @@ class PlacesUpdater:
                 for rollback when criteria fail or the rendered state is
                 unchanged.
         """
+        pipeline = PlacesUpdatePipeline(self)
+        await pipeline.run(reason=reason, previous_attr=previous_attr)
+
+    async def log_update_start(self, reason: str) -> None:
+        """Log a consistent update-start message.
+
+        Args:
+            reason: Human-readable update reason.
+        """
         _LOGGER.info(
             "(%s) Starting %s Update (Tracked Entity: %s)",
             self.sensor.get_attr(CONF_NAME),
@@ -118,35 +128,18 @@ class PlacesUpdater:
             self.sensor.get_attr(CONF_DEVICETRACKER_ID),
         )
 
-        now: datetime = await self.get_current_time()
+    async def finish_update(self, now: datetime) -> None:
+        """Finalize update bookkeeping.
 
-        await self.update_entity_name_and_cleanup()
-        self._osm_client.update_sensor_name(str(self.sensor.get_attr(CONF_NAME)))
-        await self.update_previous_state()
-        await self.update_old_coordinates()
-        prev_last_place_name = self.sensor.get_attr_safe_str(ATTR_LAST_PLACE_NAME)
-
-        proceed_with_update: UpdateStatus = await self.check_device_tracker_and_update_coords()
-
-        if proceed_with_update == UpdateStatus.PROCEED:
-            proceed_with_update = await self.determine_update_criteria()
-
-        if proceed_with_update == UpdateStatus.PROCEED:
-            await self.process_osm_update(now=now)
-
-            if await self.should_update_state(now=now):
-                await self.handle_state_update(now=now, prev_last_place_name=prev_last_place_name)
-            else:
-                _LOGGER.info(
-                    "(%s) No entity update needed, Previous State = New State",
-                    self.sensor.get_attr(CONF_NAME),
-                )
-                await self.rollback_update(previous_attr, now, proceed_with_update)
-        else:
-            await self.rollback_update(previous_attr, now, proceed_with_update)
-
+        Args:
+            now: Timestamp for the completed update.
+        """
         self.sensor.set_attr(ATTR_LAST_UPDATED, now.isoformat(sep=" ", timespec="seconds"))
         _LOGGER.info("(%s) End of Update", self.sensor.get_attr(CONF_NAME))
+
+    async def update_client_sensor_name(self) -> None:
+        """Sync the OSM client cache with the current sensor name."""
+        self._osm_client.update_sensor_name(str(self.sensor.get_attr(CONF_NAME)))
 
     async def handle_state_update(self, now: datetime, prev_last_place_name: str) -> None:
         """Finalize a successful update and persist the new sensor state.

--- a/custom_components/places/update_sensor.py
+++ b/custom_components/places/update_sensor.py
@@ -18,8 +18,6 @@ from homeassistant.const import (
     ATTR_GPS_ACCURACY,
     CONF_API_KEY,
     CONF_FRIENDLY_NAME,
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
     CONF_NAME,
     CONF_ZONE,
     STATE_UNAVAILABLE,
@@ -28,10 +26,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.util.location import distance
 
 from .const import (
-    ATTR_ATTRIBUTES,
     ATTR_DEVICETRACKER_ZONE,
     ATTR_DEVICETRACKER_ZONE_NAME,
     ATTR_DIRECTION_OF_TRAVEL,
@@ -79,7 +75,6 @@ from .const import (
     EVENT_ATTRIBUTE_LIST,
     EVENT_TYPE,
     EXTENDED_ATTRIBUTE_LIST,
-    METERS_PER_MILE,
     OSM_CACHE,
     OSM_THROTTLE,
     OSM_THROTTLE_INTERVAL_SECONDS,
@@ -88,7 +83,9 @@ from .const import (
     UpdateStatus,
 )
 from .helpers import clear_since_from_state, is_float, safe_truncate, write_sensor_to_json
+from .location import CoordinatePair, LocationSnapshot, direction_of_travel
 from .parse_osm import OSMParser
+from .tracker import TrackerSnapshot, TrackerStatus
 
 if TYPE_CHECKING:
     from .sensor import Places
@@ -382,20 +379,23 @@ class PlacesUpdater:
 
     async def update_coordinates(self) -> None:
         """Copy latitude and longitude from the tracked entity state."""
-        device_tracker = self._hass.states.get(self.sensor.get_attr(CONF_DEVICETRACKER_ID))
-        if not device_tracker:
+        tracker_id = self.sensor.get_attr(CONF_DEVICETRACKER_ID)
+        tracker_snapshot = TrackerSnapshot.from_hass(self._hass, tracker_id)
+        if tracker_snapshot.status in {
+            TrackerStatus.MISSING_ENTITY_ID,
+            TrackerStatus.NOT_FOUND,
+            TrackerStatus.UNAVAILABLE,
+        }:
             _LOGGER.warning(
                 "(%s) Device tracker entity not found: %s",
                 self.sensor.get_attr(CONF_NAME),
-                self.sensor.get_attr(CONF_DEVICETRACKER_ID),
+                tracker_id,
             )
             return
-        if is_float(device_tracker.attributes.get(CONF_LATITUDE)):
-            self.sensor.set_attr(ATTR_LATITUDE, float(device_tracker.attributes.get(CONF_LATITUDE)))
-        if is_float(device_tracker.attributes.get(CONF_LONGITUDE)):
-            self.sensor.set_attr(
-                ATTR_LONGITUDE, float(device_tracker.attributes.get(CONF_LONGITUDE))
-            )
+        if tracker_snapshot.status == TrackerStatus.OK and tracker_snapshot.latitude is not None:
+            self.sensor.set_attr(ATTR_LATITUDE, tracker_snapshot.latitude)
+        if tracker_snapshot.status == TrackerStatus.OK and tracker_snapshot.longitude is not None:
+            self.sensor.set_attr(ATTR_LONGITUDE, tracker_snapshot.longitude)
 
     async def determine_update_criteria(self) -> UpdateStatus:
         """Run zone, distance, and movement checks for this update.
@@ -904,24 +904,27 @@ class PlacesUpdater:
         if not self.sensor.is_attr_blank(ATTR_LATITUDE) and not self.sensor.is_attr_blank(
             ATTR_LONGITUDE
         ):
-            self.sensor.set_attr(
-                ATTR_LOCATION_CURRENT,
-                f"{self.sensor.get_attr_safe_float(ATTR_LATITUDE)},{self.sensor.get_attr_safe_float(ATTR_LONGITUDE)}",
+            current = CoordinatePair(
+                latitude=self.sensor.get_attr_safe_float(ATTR_LATITUDE),
+                longitude=self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
             )
+            self.sensor.set_attr(ATTR_LOCATION_CURRENT, current.as_location())
         if not self.sensor.is_attr_blank(ATTR_LATITUDE_OLD) and not self.sensor.is_attr_blank(
             ATTR_LONGITUDE_OLD
         ):
-            self.sensor.set_attr(
-                ATTR_LOCATION_PREVIOUS,
-                f"{self.sensor.get_attr_safe_float(ATTR_LATITUDE_OLD)},{self.sensor.get_attr_safe_float(ATTR_LONGITUDE_OLD)}",
+            previous = CoordinatePair(
+                latitude=self.sensor.get_attr_safe_float(ATTR_LATITUDE_OLD),
+                longitude=self.sensor.get_attr_safe_float(ATTR_LONGITUDE_OLD),
             )
+            self.sensor.set_attr(ATTR_LOCATION_PREVIOUS, previous.as_location())
         if not self.sensor.is_attr_blank(ATTR_HOME_LATITUDE) and not self.sensor.is_attr_blank(
             ATTR_HOME_LONGITUDE
         ):
-            self.sensor.set_attr(
-                ATTR_HOME_LOCATION,
-                f"{self.sensor.get_attr_safe_float(ATTR_HOME_LATITUDE)},{self.sensor.get_attr_safe_float(ATTR_HOME_LONGITUDE)}",
+            home = CoordinatePair(
+                latitude=self.sensor.get_attr_safe_float(ATTR_HOME_LATITUDE),
+                longitude=self.sensor.get_attr_safe_float(ATTR_HOME_LONGITUDE),
             )
+            self.sensor.set_attr(ATTR_HOME_LOCATION, home.as_location())
 
     async def calculate_distances(self) -> None:
         """Calculate distance from home in meters, kilometers, and miles."""
@@ -931,27 +934,29 @@ class PlacesUpdater:
             and not self.sensor.is_attr_blank(ATTR_HOME_LATITUDE)
             and not self.sensor.is_attr_blank(ATTR_HOME_LONGITUDE)
         ):
+            location_snapshot = LocationSnapshot(
+                current=CoordinatePair(
+                    latitude=self.sensor.get_attr_safe_float(ATTR_LATITUDE),
+                    longitude=self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
+                ),
+                home=CoordinatePair(
+                    latitude=self.sensor.get_attr_safe_float(ATTR_HOME_LATITUDE),
+                    longitude=self.sensor.get_attr_safe_float(ATTR_HOME_LONGITUDE),
+                ),
+            )
+            location_snapshot.calculate()
             self.sensor.set_attr(
                 ATTR_DISTANCE_FROM_HOME_M,
-                distance(
-                    self.sensor.get_attr_safe_float(ATTR_LATITUDE),
-                    self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
-                    self.sensor.get_attr_safe_float(ATTR_HOME_LATITUDE),
-                    self.sensor.get_attr_safe_float(ATTR_HOME_LONGITUDE),
-                ),
+                location_snapshot.distance_from_home_m,
             )
             if not self.sensor.is_attr_blank(ATTR_DISTANCE_FROM_HOME_M):
                 self.sensor.set_attr(
                     ATTR_DISTANCE_FROM_HOME_KM,
-                    round(self.sensor.get_attr_safe_float(ATTR_DISTANCE_FROM_HOME_M) / 1000, 3),
+                    location_snapshot.distance_from_home_km,
                 )
                 self.sensor.set_attr(
                     ATTR_DISTANCE_FROM_HOME_MI,
-                    round(
-                        self.sensor.get_attr_safe_float(ATTR_DISTANCE_FROM_HOME_M)
-                        / METERS_PER_MILE,
-                        3,
-                    ),
+                    location_snapshot.distance_from_home_mi,
                 )
 
     async def calculate_travel_distance(self) -> None:
@@ -959,22 +964,25 @@ class PlacesUpdater:
         if not self.sensor.is_attr_blank(ATTR_LATITUDE_OLD) and not self.sensor.is_attr_blank(
             ATTR_LONGITUDE_OLD
         ):
+            location_snapshot = LocationSnapshot(
+                current=CoordinatePair(
+                    latitude=self.sensor.get_attr_safe_float(ATTR_LATITUDE),
+                    longitude=self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
+                ),
+                previous=CoordinatePair(
+                    latitude=self.sensor.get_attr_safe_float(ATTR_LATITUDE_OLD),
+                    longitude=self.sensor.get_attr_safe_float(ATTR_LONGITUDE_OLD),
+                ),
+            )
+            location_snapshot.calculate()
             self.sensor.set_attr(
                 ATTR_DISTANCE_TRAVELED_M,
-                distance(
-                    self.sensor.get_attr_safe_float(ATTR_LATITUDE),
-                    self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
-                    self.sensor.get_attr_safe_float(ATTR_LATITUDE_OLD),
-                    self.sensor.get_attr_safe_float(ATTR_LONGITUDE_OLD),
-                ),
+                location_snapshot.distance_traveled_m,
             )
             if not self.sensor.is_attr_blank(ATTR_DISTANCE_TRAVELED_M):
                 self.sensor.set_attr(
                     ATTR_DISTANCE_TRAVELED_MI,
-                    round(
-                        self.sensor.get_attr_safe_float(ATTR_DISTANCE_TRAVELED_M) / METERS_PER_MILE,
-                        3,
-                    ),
+                    location_snapshot.distance_traveled_mi,
                 )
         else:
             self.sensor.set_attr(ATTR_DIRECTION_OF_TRAVEL, "stationary")
@@ -989,16 +997,13 @@ class PlacesUpdater:
                 before recalculating distances.
         """
         if not self.sensor.is_attr_blank(ATTR_DISTANCE_TRAVELED_M):
-            if last_distance_traveled_m > self.sensor.get_attr_safe_float(
-                ATTR_DISTANCE_FROM_HOME_M
-            ):
-                self.sensor.set_attr(ATTR_DIRECTION_OF_TRAVEL, "towards home")
-            elif last_distance_traveled_m < self.sensor.get_attr_safe_float(
-                ATTR_DISTANCE_FROM_HOME_M
-            ):
-                self.sensor.set_attr(ATTR_DIRECTION_OF_TRAVEL, "away from home")
-            else:
-                self.sensor.set_attr(ATTR_DIRECTION_OF_TRAVEL, "stationary")
+            self.sensor.set_attr(
+                ATTR_DIRECTION_OF_TRAVEL,
+                direction_of_travel(
+                    previous_distance_from_home_m=last_distance_traveled_m,
+                    distance_from_home_m=self.sensor.get_attr_safe_float(ATTR_DISTANCE_FROM_HOME_M),
+                ),
+            )
         else:
             self.sensor.set_attr(ATTR_DIRECTION_OF_TRAVEL, "stationary")
 
@@ -1186,23 +1191,15 @@ class PlacesUpdater:
 
         Returns:
             ``True`` when Home Assistant has a usable state object for the
-            configured tracker.
+                configured tracker.
         """
         tracker_id = self.sensor.get_attr(CONF_DEVICETRACKER_ID)
-        if self.sensor.is_attr_blank(CONF_DEVICETRACKER_ID):
+        tracker_snapshot = TrackerSnapshot.from_hass(self._hass, tracker_id)
+        if tracker_snapshot.status == TrackerStatus.MISSING_ENTITY_ID:
             await self.log_tracker_issue("Tracked Entity is not set")
             return False
 
-        tracker_state = self._hass.states.get(tracker_id)
-        if tracker_state is None:
-            await self.log_tracker_issue(f"Tracked Entity ({tracker_id}) is not available")
-            return False
-
-        if isinstance(tracker_state, str) and tracker_state.lower() in {
-            "none",
-            STATE_UNKNOWN,
-            STATE_UNAVAILABLE,
-        }:
+        if tracker_snapshot.status in {TrackerStatus.NOT_FOUND, TrackerStatus.UNAVAILABLE}:
             await self.log_tracker_issue(f"Tracked Entity ({tracker_id}) is not available")
             return False
 
@@ -1215,16 +1212,10 @@ class PlacesUpdater:
             ``True`` when latitude and longitude attributes both exist and are
             float-convertible.
         """
-        tracker = self._hass.states.get(self.sensor.get_attr(CONF_DEVICETRACKER_ID))
-
-        if not hasattr(tracker, ATTR_ATTRIBUTES):
-            await self.log_coordinate_issue()
-            return False
-
-        lat = tracker.attributes.get(CONF_LATITUDE)
-        lon = tracker.attributes.get(CONF_LONGITUDE)
-
-        if lat is None or lon is None or not is_float(lat) or not is_float(lon):
+        tracker_snapshot = TrackerSnapshot.from_hass(
+            self._hass, self.sensor.get_attr(CONF_DEVICETRACKER_ID)
+        )
+        if not tracker_snapshot.has_valid_coordinates:
             await self.log_coordinate_issue()
             return False
 

--- a/custom_components/places/update_sensor.py
+++ b/custom_components/places/update_sensor.py
@@ -380,10 +380,11 @@ class PlacesUpdater:
                 tracker_id,
             )
             return
-        if tracker_snapshot.status == TrackerStatus.OK and tracker_snapshot.latitude is not None:
-            self.sensor.set_attr(ATTR_LATITUDE, tracker_snapshot.latitude)
-        if tracker_snapshot.status == TrackerStatus.OK and tracker_snapshot.longitude is not None:
-            self.sensor.set_attr(ATTR_LONGITUDE, tracker_snapshot.longitude)
+        if tracker_snapshot.status == TrackerStatus.OK:
+            if tracker_snapshot.latitude is not None:
+                self.sensor.set_attr(ATTR_LATITUDE, tracker_snapshot.latitude)
+            if tracker_snapshot.longitude is not None:
+                self.sensor.set_attr(ATTR_LONGITUDE, tracker_snapshot.longitude)
 
     async def determine_update_criteria(self) -> UpdateStatus:
         """Run zone, distance, and movement checks for this update.
@@ -740,9 +741,6 @@ class PlacesUpdater:
         get_dict = await self._osm_client.get_json(url=url, name=name)
         self.sensor.set_attr(dict_name, get_dict if get_dict is not None else {})
         if get_dict is not None:
-            return
-
-        if url in self._hass.data[DOMAIN][OSM_CACHE]:
             return
 
         # Ensure no stale key survives when no payload was produced.

--- a/custom_components/places/update_sensor.py
+++ b/custom_components/places/update_sensor.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import MutableMapping
 from datetime import UTC, datetime
-import json
 import logging
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 from zoneinfo import ZoneInfo
 
-import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
@@ -22,10 +19,8 @@ from homeassistant.const import (
     CONF_ZONE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
-    __version__ as ha_version,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     ATTR_DEVICETRACKER_ZONE,
@@ -76,14 +71,12 @@ from .const import (
     EVENT_TYPE,
     EXTENDED_ATTRIBUTE_LIST,
     OSM_CACHE,
-    OSM_THROTTLE,
-    OSM_THROTTLE_INTERVAL_SECONDS,
     RESET_ATTRIBUTE_LIST,
-    VERSION,
     UpdateStatus,
 )
 from .helpers import clear_since_from_state, is_float, safe_truncate, write_sensor_to_json
 from .location import CoordinatePair, LocationSnapshot, direction_of_travel
+from .osm_client import OSMClient
 from .parse_osm import OSMParser
 from .tracker import TrackerSnapshot, TrackerStatus
 
@@ -107,6 +100,7 @@ class PlacesUpdater:
         self.sensor = sensor
         self._config_entry: ConfigEntry = config_entry
         self._hass = hass
+        self._osm_client = OSMClient(hass=hass, sensor_name=str(sensor.get_attr(CONF_NAME)))
 
     async def do_update(self, reason: str, previous_attr: MutableMapping[str, Any]) -> None:
         """Run one complete update attempt.
@@ -675,18 +669,12 @@ class PlacesUpdater:
         Returns:
             Fully encoded Nominatim reverse lookup URL.
         """
-        base_url = "https://nominatim.openstreetmap.org/reverse?format=json"
-        params = {
-            "lat": self.sensor.get_attr_safe_float(ATTR_LATITUDE),
-            "lon": self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
-            "accept-language": self.sensor.get_attr(CONF_LANGUAGE) or "",
-            "addressdetails": "1",
-            "namedetails": "1",
-            "zoom": "18",
-            "limit": "1",
-            "email": self.sensor.get_attr(CONF_API_KEY) or "",
-        }
-        return f"{base_url}&{urlencode(params)}"
+        return OSMClient.reverse_url(
+            self.sensor.get_attr_safe_float(ATTR_LATITUDE),
+            self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
+            self.sensor.get_attr(CONF_LANGUAGE) or "",
+            self.sensor.get_attr(CONF_API_KEY) or "",
+        )
 
     async def get_extended_attr(self) -> None:
         """Fetch optional OSM lookup details and related Wikidata payloads."""
@@ -707,20 +695,11 @@ class PlacesUpdater:
                 )
                 return
 
-            osm_details_url: str = (
-                "https://nominatim.openstreetmap.org/lookup?osm_ids="
-                f"{osm_type_abbr}{self.sensor.get_attr(ATTR_OSM_ID)}"
-                "&format=json&addressdetails=1&extratags=1&namedetails=1"
-                f"&email={
-                    self.sensor.get_attr(CONF_API_KEY)
-                    if not self.sensor.is_attr_blank(CONF_API_KEY)
-                    else ''
-                }"
-                f"&accept-language={
-                    self.sensor.get_attr(CONF_LANGUAGE)
-                    if not self.sensor.is_attr_blank(CONF_LANGUAGE)
-                    else ''
-                }"
+            osm_details_url: str = OSMClient.details_url(
+                osm_type_abbr=osm_type_abbr,
+                osm_id=self.sensor.get_attr(ATTR_OSM_ID),
+                language=self.sensor.get_attr(CONF_LANGUAGE) or "",
+                email=self.sensor.get_attr(CONF_API_KEY) or "",
             )
             await self.get_dict_from_url(
                 url=osm_details_url,
@@ -747,7 +726,9 @@ class PlacesUpdater:
 
                 self.sensor.set_attr(ATTR_WIKIDATA_DICT, {})
                 if not self.sensor.is_attr_blank(ATTR_WIKIDATA_ID):
-                    wikidata_url: str = f"https://www.wikidata.org/wiki/Special:EntityData/{self.sensor.get_attr(ATTR_WIKIDATA_ID)}.json"
+                    wikidata_url: str = OSMClient.wikidata_url(
+                        self.sensor.get_attr(ATTR_WIKIDATA_ID)
+                    )
                     await self.get_dict_from_url(
                         url=wikidata_url,
                         name="Wikidata",
@@ -762,100 +743,16 @@ class PlacesUpdater:
             name: Human-readable service name used in logs.
             dict_name: Sensor attribute that receives the parsed JSON mapping.
         """
-        osm_cache = self._hass.data[DOMAIN][OSM_CACHE]
-        if url in osm_cache:
-            self.sensor.set_attr(dict_name, osm_cache[url])
-            _LOGGER.debug(
-                "(%s) %s data loaded from cache (Cache size: %s)",
-                self.sensor.get_attr(CONF_NAME),
-                name,
-                len(osm_cache),
-            )
+        get_dict = await self._osm_client.get_json(url=url, name=name)
+        self.sensor.set_attr(dict_name, get_dict or {})
+        if get_dict is not None:
             return
 
-        throttle = self._hass.data[DOMAIN][OSM_THROTTLE]
-        async with throttle["lock"]:
-            now = asyncio.get_running_loop().time()
-            wait_time = max(0, OSM_THROTTLE_INTERVAL_SECONDS - (now - throttle["last_query"]))
-            if wait_time > 0:
-                await asyncio.sleep(wait_time)
-            throttle["last_query"] = asyncio.get_running_loop().time()
-
-            _LOGGER.info("(%s) Requesting data for %s", self.sensor.get_attr(CONF_NAME), name)
-            _LOGGER.debug("(%s) %s URL: %s", self.sensor.get_attr(CONF_NAME), name, url)
-            self.sensor.set_attr(dict_name, {})
-            user_agent = (
-                f"Mozilla/5.0 (Home Assistant/{ha_version}) "
-                f"{DOMAIN}/{VERSION} (+https://github.com/custom-components/places)"
-            )
-            headers: dict[str, str] = {"user-agent": user_agent}
-            get_dict = None
-
-            try:
-                session = async_get_clientsession(self._hass)
-                async with session.get(
-                    url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)
-                ) as response:
-                    get_json_input = await response.text()
-                    _LOGGER.debug(
-                        "(%s) %s Response: %s",
-                        self.sensor.get_attr(CONF_NAME),
-                        name,
-                        get_json_input,
-                    )
-                    try:
-                        get_dict = json.loads(get_json_input)
-                    except json.decoder.JSONDecodeError as e:
-                        _LOGGER.warning(
-                            "(%s) JSON Decode Error with %s info [%s: %s]: %s",
-                            self.sensor.get_attr(CONF_NAME),
-                            name,
-                            type(e).__name__,
-                            e,
-                            get_json_input,
-                        )
-                        return
-            except (
-                TimeoutError,
-                aiohttp.ClientError,
-                aiohttp.ContentTypeError,
-                OSError,
-                RuntimeError,
-            ) as e:
-                _LOGGER.warning(
-                    "(%s) Error connecting to %s [%s: %s]: %s",
-                    self.sensor.get_attr(CONF_NAME),
-                    name,
-                    type(e).__name__,
-                    e,
-                    url,
-                )
-                return
-
-            if get_dict is None:
-                return
-
-            if "error_message" in get_dict:
-                _LOGGER.warning(
-                    "(%s) An error occurred contacting the web service for %s: %s",
-                    self.sensor.get_attr(CONF_NAME),
-                    name,
-                    get_dict.get("error_message"),
-                )
-                return
-
-            if (
-                isinstance(get_dict, list)
-                and len(get_dict) == 1
-                and isinstance(get_dict[0], MutableMapping)
-            ):
-                self.sensor.set_attr(dict_name, get_dict[0])
-                osm_cache[url] = get_dict[0]
-                return
-
-            self.sensor.set_attr(dict_name, get_dict)
-            osm_cache[url] = get_dict
+        if url in self._hass.data[DOMAIN][OSM_CACHE]:
             return
+
+        # Ensure no stale key survives when no payload was produced.
+        self._hass.data[DOMAIN][OSM_CACHE].pop(url, None)
 
     async def determine_if_update_needed(self) -> UpdateStatus:
         """Decide whether movement since the last update warrants geocoding.

--- a/docs/superpowers/plans/2026-05-16-places-architecture-cleanup.md
+++ b/docs/superpowers/plans/2026-05-16-places-architecture-cleanup.md
@@ -1948,3 +1948,8 @@ If no files changed, do not create an empty commit.
 - [ ] README display examples render the same.
 - [ ] Full `./.venv/bin/python -m pytest` passes.
 - [ ] Full `./.venv/bin/python -m prek run -a` passes.
+
+## Regression note: README display contract
+
+The README advanced `place` expression example is pre-existingly mismatched with runtime `place` output; this mismatch is characterized by tests and intentionally preserved by this branch.
+The production contract preserved here is `formatted_place` equivalence against README examples, as that is the README-backed stable behavior under test.

--- a/docs/superpowers/plans/2026-05-16-places-architecture-cleanup.md
+++ b/docs/superpowers/plans/2026-05-16-places-architecture-cleanup.md
@@ -1,0 +1,1950 @@
+# Places Architecture Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor the Places integration into clearer internal components while preserving all Home Assistant-facing behavior.
+
+**Architecture:** Keep `Places` and `PlacesUpdater` as compatibility entry points while extracting attribute storage, tracker snapshots, location calculations, OSM I/O, display rendering seams, and config-flow helpers behind them. Each phase starts with characterization tests and ends with full repo verification so behavior drift is caught before the next extraction.
+
+**Tech Stack:** Home Assistant custom integration, Python 3.14, pytest, pytest-homeassistant-custom-component, aiohttp, cachetools, prek, ruff, mypy.
+
+---
+
+## File Structure
+
+Create these production files:
+
+- `custom_components/places/attributes.py`: `PlacesAttributes`, the internal attribute-map wrapper used by `Places`.
+- `custom_components/places/tracker.py`: `TrackerSnapshot`, `TrackerStatus`, and helper functions for reading tracked Home Assistant state.
+- `custom_components/places/location.py`: coordinate snapshots, location strings, distance calculation, and travel-direction classification.
+- `custom_components/places/osm_client.py`: OSM/Wikidata URL builders, cache/throttle-aware JSON fetch, and response normalization.
+- `custom_components/places/pipeline.py`: the extracted update coordinator used by `PlacesUpdater`.
+- `custom_components/places/config_schema.py`: selector-list and schema-builder helpers for config and options flows.
+
+Modify these production files:
+
+- `custom_components/places/sensor.py`: delegate attribute mechanics to `PlacesAttributes`, keep public helper methods, and eventually use the extracted pipeline.
+- `custom_components/places/update_sensor.py`: keep `PlacesUpdater` as the compatibility facade while moving responsibilities into `pipeline.py`, `tracker.py`, `location.py`, and `osm_client.py`.
+- `custom_components/places/parse_osm.py`: keep OSM dictionary parsing behavior but reduce coupling to updater network code.
+- `custom_components/places/basic_options.py`: preserve display behavior while tightening renderer inputs.
+- `custom_components/places/advanced_options.py`: preserve advanced grammar behavior while isolating token parsing where practical.
+- `custom_components/places/config_flow.py`: delegate schema and selector construction to `config_schema.py`.
+
+Create or expand these test files:
+
+- `tests/test_attributes.py`: tests for `PlacesAttributes`.
+- `tests/test_tracker.py`: tests for tracker snapshot creation and validation.
+- `tests/test_location.py`: tests for coordinate strings, distance, and travel direction.
+- `tests/test_osm_client.py`: tests for URL builders, cache/throttle behavior, network response handling.
+- `tests/test_pipeline.py`: tests for phase ordering and compatibility facade behavior.
+- Existing files: add shared fixtures to `tests/conftest.py` and characterization cases to `tests/test_sensor.py`, `tests/test_update_sensor.py`, `tests/test_parse_osm.py`, `tests/test_basic_options.py`, `tests/test_advanced_options.py`, `tests/test_config_flow.py`, and `tests/test_display_options_integration.py`.
+
+Use these commands throughout:
+
+```bash
+./.venv/bin/python -m pytest
+./.venv/bin/python -m prek run -a
+```
+
+If `.venv` does not exist, create it and install the repo's dev dependencies:
+
+```bash
+./.venv/bin/python --version || python3.14 -m venv .venv
+./.venv/bin/python -m pip install --upgrade pip
+./.venv/bin/python -m pip install -e ".[dev]"
+```
+
+## Task 1: Attribute Characterization Tests
+
+**Files:**
+- Create: `tests/test_attributes.py`
+- Modify: `tests/conftest.py`
+- Test: `tests/test_attributes.py`
+
+- [ ] **Step 1: Add shared real `Places` and config-entry fixtures**
+
+Append these fixtures to `tests/conftest.py` so new test modules can instantiate the real entity and updater without depending on fixtures local to `tests/test_sensor.py` or `tests/test_update_sensor.py`:
+
+```python
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Provide a default Places config entry for unit tests."""
+    return MockConfigEntry(domain="places", data={"name": "Test Place"})
+
+
+@pytest.fixture
+def places_instance(
+    mock_hass: MagicMock,
+    patch_entity_registry: object,
+    mock_config_entry: MockConfigEntry,
+) -> Places:
+    """Provide a real Places sensor instance with minimal configuration."""
+    from custom_components.places.sensor import Places
+
+    _ = patch_entity_registry
+    config = {"devicetracker_id": "device_tracker.test"}
+    return Places(
+        mock_hass,
+        config,
+        mock_config_entry,
+        "TestSensor",
+        "unique123",
+        {},
+    )
+```
+
+Add this import near the other imports in `tests/conftest.py`:
+
+```python
+from custom_components.places.sensor import Places
+```
+
+- [ ] **Step 2: Write characterization tests for current attribute semantics**
+
+Create `tests/test_attributes.py` with tests that initially target the current `Places` helper methods. These tests become the contract for `PlacesAttributes`.
+
+```python
+"""Tests for Places attribute storage compatibility."""
+
+from collections.abc import MutableMapping
+
+from homeassistant.const import CONF_NAME
+
+from custom_components.places.const import (
+    ATTR_INITIAL_UPDATE,
+    ATTR_NATIVE_VALUE,
+    ATTR_PLACE_NAME,
+)
+
+
+def test_places_attribute_blank_semantics(places_instance) -> None:
+    """Blank checks preserve the current falsey-value behavior."""
+    places_instance.clear_attr("missing")
+    places_instance.set_attr("empty_string", "")
+    places_instance.set_attr("none_value", None)
+    places_instance.set_attr("zero_value", 0)
+    places_instance.set_attr("false_value", False)
+    places_instance.set_attr("text_value", "home")
+
+    assert places_instance.is_attr_blank("missing") is True
+    assert places_instance.is_attr_blank("empty_string") is True
+    assert places_instance.is_attr_blank("none_value") is True
+    assert places_instance.is_attr_blank("zero_value") is False
+    assert places_instance.is_attr_blank("false_value") is True
+    assert places_instance.is_attr_blank("text_value") is False
+
+
+def test_places_attribute_safe_conversions(places_instance) -> None:
+    """Safe conversion helpers keep current fallback behavior."""
+    places_instance.set_attr("int_text", "12")
+    places_instance.set_attr("bad_float", object())
+    places_instance.set_attr("items", ["a", "b"])
+    places_instance.set_attr("not_items", "a,b")
+    places_instance.set_attr("mapping", {"a": 1})
+    places_instance.set_attr("not_mapping", ["a"])
+
+    assert places_instance.get_attr_safe_str("int_text") == "12"
+    assert places_instance.get_attr_safe_float("int_text") == 12.0
+    assert places_instance.get_attr_safe_float("bad_float") == 0.0
+    assert places_instance.get_attr_safe_list("items") == ["a", "b"]
+    assert places_instance.get_attr_safe_list("not_items") == []
+    assert places_instance.get_attr_safe_dict("mapping") == {"a": 1}
+    assert places_instance.get_attr_safe_dict("not_mapping") == {}
+
+
+def test_places_attribute_cleanup_and_restore(places_instance) -> None:
+    """Cleanup removes blank values and restore replaces the whole mapping."""
+    places_instance.set_attr("keep_zero", 0)
+    places_instance.set_attr("remove_empty", "")
+    places_instance.set_attr("remove_none", None)
+    places_instance.set_attr(ATTR_PLACE_NAME, "Library")
+
+    places_instance.cleanup_attributes()
+
+    attrs = places_instance.get_internal_attr()
+    assert attrs[CONF_NAME] == "TestSensor"
+    assert attrs["keep_zero"] == 0
+    assert attrs[ATTR_INITIAL_UPDATE] is False
+    assert attrs[ATTR_PLACE_NAME] == "Library"
+    assert "remove_empty" not in attrs
+    assert "remove_none" not in attrs
+
+
+async def test_places_attribute_restore_previous_attr(places_instance) -> None:
+    """Rollback restores the exact previous mapping object content."""
+    previous: MutableMapping[str, object] = {
+        CONF_NAME: "Restored",
+        ATTR_NATIVE_VALUE: "Old State",
+    }
+
+    await places_instance.restore_previous_attr(previous)
+
+    assert places_instance.get_internal_attr() == previous
+```
+
+- [ ] **Step 3: Run the characterization tests**
+
+Run:
+
+```bash
+./.venv/bin/python -m pytest tests/test_attributes.py -v
+```
+
+Expected: tests pass against the existing `Places` implementation.
+
+- [ ] **Step 4: Commit the characterization tests**
+
+```bash
+git add tests/conftest.py tests/test_attributes.py
+git commit -m "test: characterize places attribute semantics"
+```
+
+## Task 2: Extract PlacesAttributes Behind Places
+
+**Files:**
+- Create: `custom_components/places/attributes.py`
+- Modify: `custom_components/places/sensor.py`
+- Test: `tests/test_attributes.py`, `tests/test_sensor.py`
+
+- [ ] **Step 1: Add `PlacesAttributes`**
+
+Create `custom_components/places/attributes.py`:
+
+```python
+"""Attribute storage helpers for Places sensors."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from typing import Any, SupportsFloat, SupportsIndex, TypeVar
+
+from .const import (
+    CONFIG_ATTRIBUTES_LIST,
+    JSON_ATTRIBUTE_LIST,
+    JSON_IGNORE_ATTRIBUTE_LIST,
+)
+
+_AttrT = TypeVar("_AttrT", default=Any)
+
+
+class PlacesAttributes:
+    """Manage mutable Places sensor attributes and compatibility helpers."""
+
+    def __init__(self) -> None:
+        """Initialize an empty attribute store."""
+        self._attrs: MutableMapping[str, Any] = {}
+
+    @property
+    def data(self) -> MutableMapping[str, Any]:
+        """Return the mutable backing attribute mapping."""
+        return self._attrs
+
+    @data.setter
+    def data(self, value: MutableMapping[str, Any]) -> None:
+        """Replace the backing attribute mapping for rollback compatibility."""
+        self._attrs = value
+
+    def set(self, attr: str, value: object | None = None) -> None:
+        """Store an attribute value."""
+        if attr:
+            self._attrs[attr] = value
+
+    def clear(self, attr: str) -> None:
+        """Remove an attribute if present."""
+        self._attrs.pop(attr, None)
+
+    def is_blank(self, attr: str) -> bool:
+        """Return whether an attribute is blank using existing Places semantics."""
+        if self._attrs.get(attr) or self._attrs.get(attr) == 0:
+            return False
+        return True
+
+    def get(self, attr: str | None, default: _AttrT | None = None) -> _AttrT | None:
+        """Return an attribute value with existing blank/default behavior."""
+        if attr is None or (default is None and self.is_blank(attr)):
+            return None
+        return self._attrs.get(attr, default)
+
+    def safe_str(self, attr: str | None, default: object | None = None) -> str:
+        """Return an attribute as a string, or an empty string on conversion failure."""
+        value = self.get(attr) if default is None else self.get(attr, default)
+        if value is None:
+            return ""
+        try:
+            return str(value)
+        except (ValueError, TypeError):
+            return ""
+
+    def safe_float(self, attr: str | None, default: object | None = None) -> float:
+        """Return an attribute as a float, or ``0.0`` when conversion fails."""
+        value: object | None = self.get(attr) if default is None else self.get(attr, default)
+        if value is None:
+            return 0.0
+        if not isinstance(value, str | bytes | bytearray | SupportsFloat | SupportsIndex):
+            return 0.0
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def safe_list(self, attr: str | None, default: object | None = None) -> list:
+        """Return an attribute as a list, or an empty list for non-list values."""
+        value: object | None = self.get(attr) if default is None else self.get(attr, default)
+        if not isinstance(value, list):
+            return []
+        return value
+
+    def safe_dict(
+        self, attr: str | None, default: MutableMapping[str, _AttrT] | None = None
+    ) -> MutableMapping[str, _AttrT]:
+        """Return an attribute as a mutable mapping, or an empty mapping."""
+        value = self.get(attr) if default is None else self.get(attr, default)
+        if not isinstance(value, MutableMapping):
+            return {}
+        return value
+
+    def cleanup(self) -> None:
+        """Remove blank attributes from the backing mapping."""
+        for attr in list(self._attrs):
+            if self.is_blank(attr):
+                self.clear(attr)
+
+    def import_json_attributes(self, json_attr: MutableMapping[str, Any]) -> None:
+        """Import persisted JSON attributes using the existing allow/ignore lists."""
+        for attr in JSON_ATTRIBUTE_LIST:
+            if attr in json_attr:
+                self.set(attr, json_attr.pop(attr, None))
+
+        for attr in CONFIG_ATTRIBUTES_LIST + JSON_IGNORE_ATTRIBUTE_LIST:
+            json_attr.pop(attr, None)
+```
+
+- [ ] **Step 2: Delegate `Places` attribute helpers to `PlacesAttributes`**
+
+Modify `custom_components/places/sensor.py` imports:
+
+```python
+from .attributes import PlacesAttributes
+```
+
+In `Places.__init__`, replace:
+
+```python
+self._internal_attr: MutableMapping[str, Any] = {}
+```
+
+with:
+
+```python
+self._attributes = PlacesAttributes()
+self._internal_attr = self._attributes.data
+```
+
+Replace the helper method bodies with delegations:
+
+```python
+def get_internal_attr(self) -> MutableMapping[str, Any]:
+    """Return the mutable attribute store used for state and persistence."""
+    return self._attributes.data
+
+def cleanup_attributes(self) -> None:
+    """Remove blank attributes from the internal attribute mapping."""
+    self._attributes.cleanup()
+
+def is_attr_blank(self, attr: str) -> bool:
+    """Return whether an internal attribute is absent or falsey except zero."""
+    return self._attributes.is_blank(attr)
+
+def get_attr(self, attr: str | None, default: _AttrT | None = None) -> _AttrT | None:
+    """Read an internal attribute with optional default handling."""
+    return self._attributes.get(attr, default)
+
+def get_attr_safe_str(self, attr: str | None, default: object | None = None) -> str:
+    """Read an internal attribute as text without propagating conversion errors."""
+    return self._attributes.safe_str(attr, default)
+
+def get_attr_safe_float(self, attr: str | None, default: object | None = None) -> float:
+    """Read an internal attribute as a float."""
+    return self._attributes.safe_float(attr, default)
+
+def get_attr_safe_list(self, attr: str | None, default: object | None = None) -> list:
+    """Read an internal attribute as a list."""
+    return self._attributes.safe_list(attr, default)
+
+def get_attr_safe_dict(
+    self, attr: str | None, default: MutableMapping[str, _AttrT] | None = None
+) -> MutableMapping[str, _AttrT]:
+    """Read an internal attribute as a mutable mapping."""
+    return self._attributes.safe_dict(attr, default)
+
+def set_attr(self, attr: str, value: object | None = None) -> None:
+    """Store a value in the internal attribute mapping."""
+    self._attributes.set(attr, value)
+
+def clear_attr(self, attr: str) -> None:
+    """Remove an internal attribute if present."""
+    self._attributes.clear(attr)
+
+async def restore_previous_attr(self, previous_attr: MutableMapping[str, Any]) -> None:
+    """Replace current attributes with a previous snapshot after rollback."""
+    self._attributes.data = previous_attr
+    self._internal_attr = self._attributes.data
+```
+
+In `import_attributes_from_json`, replace the import loops with:
+
+```python
+self.set_attr(ATTR_INITIAL_UPDATE, False)
+self._attributes.import_json_attributes(json_attr)
+if not self.is_attr_blank(ATTR_NATIVE_VALUE):
+    self._attr_native_value = self.get_attr(ATTR_NATIVE_VALUE)
+if json_attr is not None and json_attr:
+    _LOGGER.debug(
+        "(%s) [import_attributes] Attributes not imported: %s",
+        self.get_attr(CONF_NAME),
+        json_attr,
+    )
+```
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+./.venv/bin/python -m pytest tests/test_attributes.py tests/test_sensor.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run full tests**
+
+Run:
+
+```bash
+./.venv/bin/python -m pytest
+```
+
+Expected: full suite passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/places/attributes.py custom_components/places/sensor.py tests/test_attributes.py
+git commit -m "refactor: extract places attribute store"
+```
+
+## Task 3: Characterize Tracker And Location Behavior
+
+**Files:**
+- Create: `tests/test_tracker.py`
+- Create: `tests/test_location.py`
+- Modify: `tests/test_update_sensor.py`
+- Test: `tests/test_tracker.py`, `tests/test_location.py`, `tests/test_update_sensor.py`
+
+- [ ] **Step 1: Add tracker behavior tests against current updater methods**
+
+Create `tests/test_tracker.py`:
+
+```python
+"""Characterization tests for tracked entity handling."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.const import ATTR_GPS_ACCURACY, CONF_LATITUDE, CONF_LONGITUDE
+
+from custom_components.places.const import (
+    ATTR_GPS_ACCURACY as PLACES_GPS_ACCURACY,
+    CONF_DEVICETRACKER_ID,
+    CONF_USE_GPS,
+    UpdateStatus,
+)
+from custom_components.places.update_sensor import PlacesUpdater
+
+
+async def test_tracker_missing_skips_update(mock_hass: MagicMock, mock_config_entry, sensor) -> None:
+    """Missing tracked entities skip update without coordinates."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.missing"
+    mock_hass.states.get.return_value = None
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    result = await updater.is_devicetracker_set()
+
+    assert result is UpdateStatus.SKIP
+
+
+async def test_tracker_invalid_coordinates_skip_update(
+    mock_hass: MagicMock, mock_config_entry, sensor
+) -> None:
+    """Non-numeric coordinates skip updates."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
+    tracker = MagicMock()
+    tracker.attributes = {CONF_LATITUDE: "north", CONF_LONGITUDE: "-70.0"}
+    mock_hass.states.get.return_value = tracker
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    result = await updater.has_valid_coordinates()
+
+    assert result is False
+
+
+async def test_tracker_zero_gps_accuracy_skips_when_enabled(
+    mock_hass: MagicMock, mock_config_entry, sensor
+) -> None:
+    """GPS accuracy zero preserves the existing skip behavior."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
+    sensor.attrs[CONF_USE_GPS] = True
+    tracker = MagicMock()
+    tracker.attributes = {ATTR_GPS_ACCURACY: 0}
+    mock_hass.states.get.return_value = tracker
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    result = await updater.get_gps_accuracy()
+
+    assert result is UpdateStatus.SKIP
+    assert sensor.attrs[PLACES_GPS_ACCURACY] == 0.0
+```
+
+- [ ] **Step 2: Add location behavior tests against current updater methods**
+
+Create `tests/test_location.py`:
+
+```python
+"""Characterization tests for Places location calculations."""
+
+from custom_components.places.const import (
+    ATTR_DIRECTION_OF_TRAVEL,
+    ATTR_DISTANCE_FROM_HOME_KM,
+    ATTR_DISTANCE_FROM_HOME_M,
+    ATTR_DISTANCE_FROM_HOME_MI,
+    ATTR_DISTANCE_TRAVELED_M,
+    ATTR_HOME_LATITUDE,
+    ATTR_HOME_LOCATION,
+    ATTR_HOME_LONGITUDE,
+    ATTR_LATITUDE,
+    ATTR_LATITUDE_OLD,
+    ATTR_LOCATION_CURRENT,
+    ATTR_LOCATION_PREVIOUS,
+    ATTR_LONGITUDE,
+    ATTR_LONGITUDE_OLD,
+)
+from custom_components.places.update_sensor import PlacesUpdater
+
+
+async def test_location_strings_are_current_format(mock_hass, mock_config_entry, sensor) -> None:
+    """Location string formatting stays compatible."""
+    sensor.attrs.update(
+        {
+            ATTR_LATITUDE: 40.1,
+            ATTR_LONGITUDE: -70.2,
+            ATTR_LATITUDE_OLD: 40.0,
+            ATTR_LONGITUDE_OLD: -70.0,
+            ATTR_HOME_LATITUDE: 39.9,
+            ATTR_HOME_LONGITUDE: -69.9,
+        }
+    )
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    await updater.update_location_attributes()
+
+    assert sensor.attrs[ATTR_LOCATION_CURRENT] == "40.1,-70.2"
+    assert sensor.attrs[ATTR_LOCATION_PREVIOUS] == "40.0,-70.0"
+    assert sensor.attrs[ATTR_HOME_LOCATION] == "39.9,-69.9"
+
+
+async def test_distance_fields_are_populated(mock_hass, mock_config_entry, sensor) -> None:
+    """Distance calculations populate meters, kilometers, and miles."""
+    sensor.attrs.update(
+        {
+            ATTR_LATITUDE: 40.1,
+            ATTR_LONGITUDE: -70.2,
+            ATTR_HOME_LATITUDE: 40.0,
+            ATTR_HOME_LONGITUDE: -70.0,
+        }
+    )
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    await updater.calculate_distances()
+
+    assert sensor.attrs[ATTR_DISTANCE_FROM_HOME_M] > 0
+    assert sensor.attrs[ATTR_DISTANCE_FROM_HOME_KM] > 0
+    assert sensor.attrs[ATTR_DISTANCE_FROM_HOME_MI] > 0
+
+
+async def test_direction_of_travel_stationary_when_distance_unchanged(
+    mock_hass, mock_config_entry, sensor
+) -> None:
+    """Direction remains stationary when distance from home is unchanged."""
+    sensor.attrs[ATTR_DISTANCE_TRAVELED_M] = 1.0
+    sensor.attrs[ATTR_DISTANCE_FROM_HOME_M] = 100.0
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    await updater.determine_direction_of_travel(last_distance_traveled_m=100.0)
+
+    assert sensor.attrs[ATTR_DIRECTION_OF_TRAVEL] == "stationary"
+```
+
+- [ ] **Step 3: Run new characterization tests**
+
+Run:
+
+```bash
+./.venv/bin/python -m pytest tests/test_tracker.py tests/test_location.py -v
+```
+
+Expected: all tests pass against current code.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_tracker.py tests/test_location.py tests/test_update_sensor.py
+git commit -m "test: characterize tracker and location behavior"
+```
+
+## Task 4: Extract TrackerSnapshot And LocationSnapshot
+
+**Files:**
+- Create: `custom_components/places/tracker.py`
+- Create: `custom_components/places/location.py`
+- Modify: `custom_components/places/update_sensor.py`
+- Test: `tests/test_tracker.py`, `tests/test_location.py`, `tests/test_update_sensor.py`
+
+- [ ] **Step 1: Add tracker snapshot types**
+
+Create `custom_components/places/tracker.py`:
+
+```python
+"""Tracked entity snapshots for Places updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any
+
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    ATTR_GPS_ACCURACY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_ZONE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, State
+
+from .helpers import is_float
+
+
+class TrackerStatus(Enum):
+    """Validation status for a tracked entity snapshot."""
+
+    OK = auto()
+    MISSING_ENTITY_ID = auto()
+    NOT_FOUND = auto()
+    UNAVAILABLE = auto()
+    MISSING_COORDINATES = auto()
+    INVALID_COORDINATES = auto()
+
+
+@dataclass(slots=True)
+class TrackerSnapshot:
+    """Snapshot of a tracked Home Assistant entity for one Places update."""
+
+    entity_id: str | None
+    state: State | None
+    status: TrackerStatus
+    latitude: float | None
+    longitude: float | None
+    gps_accuracy: float | None
+    zone: str | None
+    zone_name: str | None
+    entity_picture: str | None
+
+    @classmethod
+    def from_hass(cls, hass: HomeAssistant, entity_id: str | None) -> TrackerSnapshot:
+        """Build a tracker snapshot from Home Assistant state."""
+        if not entity_id:
+            return cls(entity_id, None, TrackerStatus.MISSING_ENTITY_ID, None, None, None, None, None, None)
+
+        state = hass.states.get(entity_id)
+        if state is None:
+            return cls(entity_id, None, TrackerStatus.NOT_FOUND, None, None, None, None, None, None)
+
+        if isinstance(state.state, str) and state.state.lower() in {
+            "none",
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        }:
+            return cls(entity_id, state, TrackerStatus.UNAVAILABLE, None, None, None, None, None, None)
+
+        attrs: dict[str, Any] = dict(state.attributes)
+        lat = attrs.get(CONF_LATITUDE)
+        lon = attrs.get(CONF_LONGITUDE)
+        if lat is None or lon is None:
+            status = TrackerStatus.MISSING_COORDINATES
+            latitude = None
+            longitude = None
+        elif not is_float(lat) or not is_float(lon):
+            status = TrackerStatus.INVALID_COORDINATES
+            latitude = None
+            longitude = None
+        else:
+            status = TrackerStatus.OK
+            latitude = float(lat)
+            longitude = float(lon)
+
+        gps_accuracy = attrs.get(ATTR_GPS_ACCURACY)
+        return cls(
+            entity_id=entity_id,
+            state=state,
+            status=status,
+            latitude=latitude,
+            longitude=longitude,
+            gps_accuracy=float(gps_accuracy) if is_float(gps_accuracy) else None,
+            zone=state.state,
+            zone_name=attrs.get(CONF_ZONE) or attrs.get(ATTR_FRIENDLY_NAME),
+            entity_picture=attrs.get("entity_picture"),
+        )
+
+    @property
+    def has_valid_coordinates(self) -> bool:
+        """Return whether the snapshot has usable coordinates."""
+        return self.status is TrackerStatus.OK
+```
+
+- [ ] **Step 2: Add location helpers**
+
+Create `custom_components/places/location.py`:
+
+```python
+"""Location calculations for Places updates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from homeassistant.util.location import distance
+
+from .const import METERS_PER_MILE
+
+
+@dataclass(slots=True)
+class CoordinatePair:
+    """Latitude and longitude pair."""
+
+    latitude: float
+    longitude: float
+
+    def as_location(self) -> str:
+        """Return the current Places ``lat,lon`` string format."""
+        return f"{self.latitude},{self.longitude}"
+
+
+@dataclass(slots=True)
+class LocationSnapshot:
+    """Current, previous, and home coordinates with derived distances."""
+
+    current: CoordinatePair | None
+    previous: CoordinatePair | None
+    home: CoordinatePair | None
+    distance_from_home_m: float | None = None
+    distance_traveled_m: float | None = None
+
+    def calculate(self) -> None:
+        """Populate distance fields from available coordinates."""
+        if self.current is not None and self.home is not None:
+            self.distance_from_home_m = distance(
+                self.current.latitude,
+                self.current.longitude,
+                self.home.latitude,
+                self.home.longitude,
+            )
+        if self.current is not None and self.previous is not None:
+            self.distance_traveled_m = distance(
+                self.current.latitude,
+                self.current.longitude,
+                self.previous.latitude,
+                self.previous.longitude,
+            )
+        elif self.previous is None:
+            self.distance_traveled_m = 0
+
+    @property
+    def distance_from_home_km(self) -> float | None:
+        """Return distance from home in kilometers."""
+        if self.distance_from_home_m is None:
+            return None
+        return round(self.distance_from_home_m / 1000, 3)
+
+    @property
+    def distance_from_home_mi(self) -> float | None:
+        """Return distance from home in miles."""
+        if self.distance_from_home_m is None:
+            return None
+        return round(self.distance_from_home_m / METERS_PER_MILE, 3)
+
+    @property
+    def distance_traveled_mi(self) -> float | None:
+        """Return distance traveled in miles."""
+        if self.distance_traveled_m is None:
+            return None
+        return round(self.distance_traveled_m / METERS_PER_MILE, 3)
+
+
+def direction_of_travel(previous_distance_from_home_m: float, distance_from_home_m: float) -> str:
+    """Classify travel direction using the existing string values."""
+    if previous_distance_from_home_m > distance_from_home_m:
+        return "towards home"
+    if previous_distance_from_home_m < distance_from_home_m:
+        return "away from home"
+    return "stationary"
+```
+
+- [ ] **Step 3: Integrate snapshots into `PlacesUpdater` without changing public methods**
+
+In `custom_components/places/update_sensor.py`, import:
+
+```python
+from .location import CoordinatePair, LocationSnapshot, direction_of_travel
+from .tracker import TrackerSnapshot, TrackerStatus
+```
+
+Update `has_valid_coordinates` to use `TrackerSnapshot`:
+
+```python
+async def has_valid_coordinates(self) -> bool:
+    """Return whether the tracked entity exposes numeric coordinates."""
+    snapshot = TrackerSnapshot.from_hass(
+        self._hass, self.sensor.get_attr(CONF_DEVICETRACKER_ID)
+    )
+    if snapshot.status in {TrackerStatus.MISSING_COORDINATES, TrackerStatus.INVALID_COORDINATES}:
+        await self.log_coordinate_issue()
+        return False
+    return snapshot.status is TrackerStatus.OK
+```
+
+Update `update_coordinates` to use the same snapshot:
+
+```python
+async def update_coordinates(self) -> None:
+    """Copy latitude and longitude from the tracked entity state."""
+    tracker = TrackerSnapshot.from_hass(
+        self._hass, self.sensor.get_attr(CONF_DEVICETRACKER_ID)
+    )
+    if tracker.status is TrackerStatus.NOT_FOUND:
+        _LOGGER.warning(
+            "(%s) Device tracker entity not found: %s",
+            self.sensor.get_attr(CONF_NAME),
+            self.sensor.get_attr(CONF_DEVICETRACKER_ID),
+        )
+        return
+    if tracker.latitude is not None:
+        self.sensor.set_attr(ATTR_LATITUDE, tracker.latitude)
+    if tracker.longitude is not None:
+        self.sensor.set_attr(ATTR_LONGITUDE, tracker.longitude)
+```
+
+Replace `update_location_attributes` with a version that writes the same string values through `CoordinatePair`:
+
+```python
+async def update_location_attributes(self) -> None:
+    """Store current, previous, and home coordinates as ``lat,lon`` strings."""
+    current = None
+    previous = None
+    home = None
+    if not self.sensor.is_attr_blank(ATTR_LATITUDE) and not self.sensor.is_attr_blank(ATTR_LONGITUDE):
+        current = CoordinatePair(
+            self.sensor.get_attr_safe_float(ATTR_LATITUDE),
+            self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
+        )
+        self.sensor.set_attr(ATTR_LOCATION_CURRENT, current.as_location())
+    if not self.sensor.is_attr_blank(ATTR_LATITUDE_OLD) and not self.sensor.is_attr_blank(ATTR_LONGITUDE_OLD):
+        previous = CoordinatePair(
+            self.sensor.get_attr_safe_float(ATTR_LATITUDE_OLD),
+            self.sensor.get_attr_safe_float(ATTR_LONGITUDE_OLD),
+        )
+        self.sensor.set_attr(ATTR_LOCATION_PREVIOUS, previous.as_location())
+    if not self.sensor.is_attr_blank(ATTR_HOME_LATITUDE) and not self.sensor.is_attr_blank(ATTR_HOME_LONGITUDE):
+        home = CoordinatePair(
+            self.sensor.get_attr_safe_float(ATTR_HOME_LATITUDE),
+            self.sensor.get_attr_safe_float(ATTR_HOME_LONGITUDE),
+        )
+        self.sensor.set_attr(ATTR_HOME_LOCATION, home.as_location())
+```
+
+Replace `calculate_distances` with:
+
+```python
+async def calculate_distances(self) -> None:
+    """Calculate distance from home in meters, kilometers, and miles."""
+    if (
+        self.sensor.is_attr_blank(ATTR_LATITUDE)
+        or self.sensor.is_attr_blank(ATTR_LONGITUDE)
+        or self.sensor.is_attr_blank(ATTR_HOME_LATITUDE)
+        or self.sensor.is_attr_blank(ATTR_HOME_LONGITUDE)
+    ):
+        return
+    snapshot = LocationSnapshot(
+        current=CoordinatePair(
+            self.sensor.get_attr_safe_float(ATTR_LATITUDE),
+            self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
+        ),
+        previous=None,
+        home=CoordinatePair(
+            self.sensor.get_attr_safe_float(ATTR_HOME_LATITUDE),
+            self.sensor.get_attr_safe_float(ATTR_HOME_LONGITUDE),
+        ),
+    )
+    snapshot.calculate()
+    if snapshot.distance_from_home_m is not None:
+        self.sensor.set_attr(ATTR_DISTANCE_FROM_HOME_M, snapshot.distance_from_home_m)
+        self.sensor.set_attr(ATTR_DISTANCE_FROM_HOME_KM, snapshot.distance_from_home_km)
+        self.sensor.set_attr(ATTR_DISTANCE_FROM_HOME_MI, snapshot.distance_from_home_mi)
+```
+
+Replace `calculate_travel_distance` with:
+
+```python
+async def calculate_travel_distance(self) -> None:
+    """Calculate distance traveled since the previous coordinates."""
+    if not self.sensor.is_attr_blank(ATTR_LATITUDE_OLD) and not self.sensor.is_attr_blank(ATTR_LONGITUDE_OLD):
+        snapshot = LocationSnapshot(
+            current=CoordinatePair(
+                self.sensor.get_attr_safe_float(ATTR_LATITUDE),
+                self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
+            ),
+            previous=CoordinatePair(
+                self.sensor.get_attr_safe_float(ATTR_LATITUDE_OLD),
+                self.sensor.get_attr_safe_float(ATTR_LONGITUDE_OLD),
+            ),
+            home=None,
+        )
+        snapshot.calculate()
+        if snapshot.distance_traveled_m is not None:
+            self.sensor.set_attr(ATTR_DISTANCE_TRAVELED_M, snapshot.distance_traveled_m)
+            self.sensor.set_attr(ATTR_DISTANCE_TRAVELED_MI, snapshot.distance_traveled_mi)
+    else:
+        self.sensor.set_attr(ATTR_DIRECTION_OF_TRAVEL, "stationary")
+        self.sensor.set_attr(ATTR_DISTANCE_TRAVELED_M, 0)
+        self.sensor.set_attr(ATTR_DISTANCE_TRAVELED_MI, 0)
+```
+
+Replace `determine_direction_of_travel` with:
+
+```python
+async def determine_direction_of_travel(self, last_distance_traveled_m: float) -> None:
+    """Classify movement relative to home as towards, away, or stationary."""
+    if not self.sensor.is_attr_blank(ATTR_DISTANCE_TRAVELED_M):
+        self.sensor.set_attr(
+            ATTR_DIRECTION_OF_TRAVEL,
+            direction_of_travel(
+                previous_distance_from_home_m=last_distance_traveled_m,
+                distance_from_home_m=self.sensor.get_attr_safe_float(ATTR_DISTANCE_FROM_HOME_M),
+            ),
+        )
+    else:
+        self.sensor.set_attr(ATTR_DIRECTION_OF_TRAVEL, "stationary")
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+./.venv/bin/python -m pytest tests/test_tracker.py tests/test_location.py tests/test_update_sensor.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Run full tests and commit**
+
+```bash
+./.venv/bin/python -m pytest
+git add custom_components/places/tracker.py custom_components/places/location.py custom_components/places/update_sensor.py tests/conftest.py tests/test_tracker.py tests/test_location.py
+git commit -m "refactor: extract tracker and location snapshots"
+```
+
+## Task 5: Characterize OSM Client Behavior
+
+**Files:**
+- Create: `tests/test_osm_client.py`
+- Modify: none
+- Test: `tests/test_osm_client.py`, `tests/test_update_sensor.py`
+
+- [ ] **Step 1: Add URL and response behavior tests against current updater**
+
+Create `tests/test_osm_client.py`:
+
+```python
+"""Characterization tests for OSM request behavior."""
+
+from urllib.parse import parse_qs, urlparse
+
+from custom_components.places.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    CONF_API_KEY,
+    CONF_LANGUAGE,
+)
+from custom_components.places.update_sensor import PlacesUpdater
+
+
+async def test_reverse_osm_url_parameters(mock_hass, mock_config_entry, sensor) -> None:
+    """Reverse lookup URL parameters remain stable."""
+    sensor.attrs.update(
+        {
+            ATTR_LATITUDE: 40.123,
+            ATTR_LONGITUDE: -70.456,
+            CONF_LANGUAGE: "en,fr",
+            CONF_API_KEY: "person@example.com",
+        }
+    )
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    url = await updater.build_osm_url()
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+
+    assert parsed.netloc == "nominatim.openstreetmap.org"
+    assert query["format"] == ["json"]
+    assert query["lat"] == ["40.123"]
+    assert query["lon"] == ["-70.456"]
+    assert query["accept-language"] == ["en,fr"]
+    assert query["addressdetails"] == ["1"]
+    assert query["namedetails"] == ["1"]
+    assert query["zoom"] == ["18"]
+    assert query["limit"] == ["1"]
+    assert query["email"] == ["person@example.com"]
+```
+
+- [ ] **Step 2: Add cache and list-response tests if not already covered**
+
+If `tests/test_update_sensor.py` already covers list-response flattening and throttle behavior, add only this cache-hit assertion to `tests/test_osm_client.py`:
+
+```python
+from custom_components.places.const import ATTR_OSM_DICT, DOMAIN, OSM_CACHE, OSM_THROTTLE
+
+
+async def test_get_dict_from_url_uses_existing_cache(mock_hass, mock_config_entry, sensor) -> None:
+    """Cached OSM responses are used without network calls."""
+    url = "https://example.test/osm"
+    cached = {"place_id": 123}
+    mock_hass.data = {
+        DOMAIN: {
+            OSM_CACHE: {url: cached},
+            OSM_THROTTLE: {"lock": None, "last_query": 0.0},
+        }
+    }
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    await updater.get_dict_from_url(url=url, name="OpenStreetMaps", dict_name=ATTR_OSM_DICT)
+
+    assert sensor.attrs[ATTR_OSM_DICT] == cached
+```
+
+- [ ] **Step 3: Run OSM characterization tests**
+
+Run:
+
+```bash
+./.venv/bin/python -m pytest tests/test_osm_client.py tests/test_update_sensor.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_osm_client.py tests/test_update_sensor.py
+git commit -m "test: characterize osm client behavior"
+```
+
+## Task 6: Extract OSMClient
+
+**Files:**
+- Create: `custom_components/places/osm_client.py`
+- Modify: `custom_components/places/update_sensor.py`
+- Test: `tests/test_osm_client.py`, `tests/test_update_sensor.py`
+
+- [ ] **Step 1: Add `OSMClient`**
+
+Create `custom_components/places/osm_client.py`:
+
+```python
+"""OSM and Wikidata HTTP client helpers for Places."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import MutableMapping
+import json
+import logging
+from typing import Any
+from urllib.parse import urlencode
+
+import aiohttp
+from homeassistant.const import __version__ as ha_version
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import (
+    DOMAIN,
+    OSM_CACHE,
+    OSM_THROTTLE,
+    OSM_THROTTLE_INTERVAL_SECONDS,
+    VERSION,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OSMClient:
+    """Fetch and cache OSM/Wikidata JSON using Places throttling rules."""
+
+    def __init__(self, hass: HomeAssistant, sensor_name: str) -> None:
+        """Initialize the client for a Home Assistant instance."""
+        self._hass = hass
+        self._sensor_name = sensor_name
+
+    @staticmethod
+    def reverse_url(
+        *,
+        latitude: float,
+        longitude: float,
+        language: str,
+        email: str,
+    ) -> str:
+        """Build the existing Nominatim reverse lookup URL."""
+        base_url = "https://nominatim.openstreetmap.org/reverse?format=json"
+        params = {
+            "lat": latitude,
+            "lon": longitude,
+            "accept-language": language,
+            "addressdetails": "1",
+            "namedetails": "1",
+            "zoom": "18",
+            "limit": "1",
+            "email": email,
+        }
+        return f"{base_url}&{urlencode(params)}"
+
+    @staticmethod
+    def details_url(
+        *,
+        osm_type_abbr: str,
+        osm_id: object,
+        language: str,
+        email: str,
+    ) -> str:
+        """Build the existing Nominatim details lookup URL."""
+        params = {
+            "osm_ids": f"{osm_type_abbr}{osm_id}",
+            "format": "json",
+            "addressdetails": "1",
+            "extratags": "1",
+            "namedetails": "1",
+            "email": email,
+            "accept-language": language,
+        }
+        return f"https://nominatim.openstreetmap.org/lookup?{urlencode(params)}"
+
+    @staticmethod
+    def wikidata_url(wikidata_id: object) -> str:
+        """Build the existing Wikidata entity-data URL."""
+        return f"https://www.wikidata.org/wiki/Special:EntityData/{wikidata_id}.json"
+
+    async def get_json(self, url: str, name: str) -> MutableMapping[str, Any] | None:
+        """Fetch a JSON mapping with existing cache, throttle, and error behavior."""
+        osm_cache = self._hass.data[DOMAIN][OSM_CACHE]
+        if url in osm_cache:
+            _LOGGER.debug("(%s) %s data loaded from cache (Cache size: %s)", self._sensor_name, name, len(osm_cache))
+            return osm_cache[url]
+
+        throttle = self._hass.data[DOMAIN][OSM_THROTTLE]
+        async with throttle["lock"]:
+            now = asyncio.get_running_loop().time()
+            wait_time = max(0, OSM_THROTTLE_INTERVAL_SECONDS - (now - throttle["last_query"]))
+            if wait_time > 0:
+                await asyncio.sleep(wait_time)
+            throttle["last_query"] = asyncio.get_running_loop().time()
+
+            headers = {
+                "user-agent": (
+                    f"Mozilla/5.0 (Home Assistant/{ha_version}) "
+                    f"{DOMAIN}/{VERSION} (+https://github.com/custom-components/places)"
+                )
+            }
+            try:
+                session = async_get_clientsession(self._hass)
+                async with session.get(
+                    url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)
+                ) as response:
+                    payload = await response.text()
+                    try:
+                        decoded = json.loads(payload)
+                    except json.decoder.JSONDecodeError as err:
+                        _LOGGER.warning(
+                            "(%s) JSON Decode Error with %s info [%s: %s]: %s",
+                            self._sensor_name,
+                            name,
+                            type(err).__name__,
+                            err,
+                            payload,
+                        )
+                        return None
+            except (TimeoutError, aiohttp.ClientError, aiohttp.ContentTypeError, OSError, RuntimeError) as err:
+                _LOGGER.warning(
+                    "(%s) Error connecting to %s [%s: %s]: %s",
+                    self._sensor_name,
+                    name,
+                    type(err).__name__,
+                    err,
+                    url,
+                )
+                return None
+
+        if isinstance(decoded, MutableMapping) and "error_message" in decoded:
+            _LOGGER.warning(
+                "(%s) An error occurred contacting the web service for %s: %s",
+                self._sensor_name,
+                name,
+                decoded.get("error_message"),
+            )
+            return None
+
+        if isinstance(decoded, list) and len(decoded) == 1 and isinstance(decoded[0], MutableMapping):
+            osm_cache[url] = decoded[0]
+            return decoded[0]
+
+        if isinstance(decoded, MutableMapping):
+            osm_cache[url] = decoded
+            return decoded
+
+        return None
+```
+
+- [ ] **Step 2: Delegate updater URL and fetch methods to `OSMClient`**
+
+In `custom_components/places/update_sensor.py`, import:
+
+```python
+from .osm_client import OSMClient
+```
+
+In `PlacesUpdater.__init__`, add:
+
+```python
+self._osm_client = OSMClient(hass=hass, sensor_name=str(sensor.get_attr(CONF_NAME)))
+```
+
+Replace `build_osm_url` body:
+
+```python
+return OSMClient.reverse_url(
+    latitude=self.sensor.get_attr_safe_float(ATTR_LATITUDE),
+    longitude=self.sensor.get_attr_safe_float(ATTR_LONGITUDE),
+    language=self.sensor.get_attr_safe_str(CONF_LANGUAGE),
+    email=self.sensor.get_attr_safe_str(CONF_API_KEY),
+)
+```
+
+Replace `get_dict_from_url` body:
+
+```python
+result = await self._osm_client.get_json(url=url, name=name)
+self.sensor.set_attr(dict_name, result or {})
+```
+
+When replacing details and Wikidata URL construction in `get_extended_attr`, call:
+
+```python
+osm_details_url = OSMClient.details_url(
+    osm_type_abbr=osm_type_abbr,
+    osm_id=self.sensor.get_attr(ATTR_OSM_ID),
+    language=self.sensor.get_attr_safe_str(CONF_LANGUAGE),
+    email=self.sensor.get_attr_safe_str(CONF_API_KEY),
+)
+wikidata_url = OSMClient.wikidata_url(self.sensor.get_attr(ATTR_WIKIDATA_ID))
+```
+
+- [ ] **Step 3: Remove unused imports from `update_sensor.py`**
+
+After delegation, remove imports that are no longer used in `update_sensor.py`:
+
+```python
+import asyncio
+import json
+from urllib.parse import urlencode
+import aiohttp
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.const import __version__ as ha_version
+```
+
+Keep imports that are still used by map-link generation or other methods.
+
+- [ ] **Step 4: Run focused and full tests**
+
+```bash
+./.venv/bin/python -m pytest tests/test_osm_client.py tests/test_update_sensor.py -v
+./.venv/bin/python -m pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/places/osm_client.py custom_components/places/update_sensor.py tests/test_osm_client.py tests/test_update_sensor.py
+git commit -m "refactor: extract osm client"
+```
+
+## Task 7: Tighten OSM Parser Internals
+
+**Files:**
+- Modify: `custom_components/places/parse_osm.py`
+- Modify: `tests/test_parse_osm.py`
+- Test: `tests/test_parse_osm.py`, `tests/test_update_sensor.py`
+
+- [ ] **Step 1: Add parser regression tests for address lookup compatibility**
+
+Add this test to `tests/test_parse_osm.py`:
+
+```python
+async def test_parse_miscellaneous_osm_id_and_postcode_use_current_osm_dict(sensor) -> None:
+    """Parser keeps using the current OSM dictionary for derived fields."""
+    from custom_components.places.const import (
+        ATTR_OSM_DICT,
+        ATTR_OSM_ID,
+        ATTR_POSTAL_CODE,
+    )
+    from custom_components.places.parse_osm import OSMParser
+
+    sensor.attrs[ATTR_OSM_DICT] = {
+        "osm_id": 12345,
+        "osm_type": "way",
+        "address": {"postcode": "07024"},
+    }
+    parser = OSMParser(sensor)
+
+    await parser.set_region_details(sensor.attrs[ATTR_OSM_DICT]["address"])
+    await parser.parse_miscellaneous(sensor.attrs[ATTR_OSM_DICT])
+
+    assert sensor.attrs[ATTR_OSM_ID] == "12345"
+    assert sensor.attrs[ATTR_POSTAL_CODE] == "07024"
+```
+
+- [ ] **Step 2: Add private OSM dictionary helper methods**
+
+In `custom_components/places/parse_osm.py`, add these methods to `OSMParser` after `__init__`:
+
+```python
+def current_osm_dict(self) -> MutableMapping[str, Any]:
+    """Return the current OSM response mapping from sensor attributes."""
+    return self.sensor.get_attr_safe_dict(ATTR_OSM_DICT)
+
+def current_address(self) -> MutableMapping[str, Any]:
+    """Return the current OSM address mapping from sensor attributes."""
+    address = self.current_osm_dict().get("address", {})
+    if isinstance(address, MutableMapping):
+        return address
+    return {}
+```
+
+- [ ] **Step 3: Replace repeated OSM dictionary reads**
+
+In `set_address_details`, replace:
+
+```python
+self.sensor.get_attr_safe_dict(ATTR_OSM_DICT).get("address", {}).get("retail")
+```
+
+with:
+
+```python
+self.current_address().get("retail")
+```
+
+In `set_region_details`, replace:
+
+```python
+self.sensor.get_attr_safe_dict(ATTR_OSM_DICT).get("address", {}).get("postcode")
+```
+
+with:
+
+```python
+self.current_address().get("postcode")
+```
+
+In `parse_miscellaneous`, replace:
+
+```python
+str(self.sensor.get_attr_safe_dict(ATTR_OSM_DICT).get("osm_id", ""))
+```
+
+with:
+
+```python
+str(self.current_osm_dict().get("osm_id", ""))
+```
+
+- [ ] **Step 4: Run parser tests and full tests**
+
+```bash
+./.venv/bin/python -m pytest tests/test_parse_osm.py tests/test_update_sensor.py -v
+./.venv/bin/python -m pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/places/parse_osm.py tests/test_parse_osm.py
+git commit -m "refactor: tighten osm parser internals"
+```
+
+## Task 8: Extract Update Pipeline Facade
+
+**Files:**
+- Create: `custom_components/places/pipeline.py`
+- Modify: `custom_components/places/update_sensor.py`
+- Create: `tests/test_pipeline.py`
+- Test: `tests/test_pipeline.py`, `tests/test_update_sensor.py`, `tests/test_sensor.py`
+
+- [ ] **Step 1: Add pipeline class with existing update order**
+
+Create `custom_components/places/pipeline.py`:
+
+```python
+"""Update pipeline coordinator for Places sensors."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from .const import ATTR_LAST_PLACE_NAME, UpdateStatus
+
+if TYPE_CHECKING:
+    from .update_sensor import PlacesUpdater
+
+
+class PlacesUpdatePipeline:
+    """Coordinate one Places update using the existing updater operations."""
+
+    def __init__(self, updater: PlacesUpdater) -> None:
+        """Initialize the pipeline with a compatibility updater facade."""
+        self.updater = updater
+
+    async def run(self, reason: str, previous_attr: MutableMapping[str, Any]) -> None:
+        """Run the existing update phases in their current order."""
+        sensor = self.updater.sensor
+        self.updater.log_update_start(reason)
+
+        now: datetime = await self.updater.get_current_time()
+        await self.updater.update_entity_name_and_cleanup()
+        await self.updater.update_previous_state()
+        await self.updater.update_old_coordinates()
+        prev_last_place_name = sensor.get_attr_safe_str(ATTR_LAST_PLACE_NAME)
+
+        proceed = await self.updater.check_device_tracker_and_update_coords()
+        if proceed == UpdateStatus.PROCEED:
+            proceed = await self.updater.determine_update_criteria()
+
+        if proceed == UpdateStatus.PROCEED:
+            await self.updater.process_osm_update(now=now)
+            if await self.updater.should_update_state(now=now):
+                await self.updater.handle_state_update(
+                    now=now,
+                    prev_last_place_name=prev_last_place_name,
+                )
+            else:
+                await self.updater.rollback_update(previous_attr, now, proceed)
+        else:
+            await self.updater.rollback_update(previous_attr, now, proceed)
+
+        await self.updater.finish_update(now)
+```
+
+- [ ] **Step 2: Add compatibility methods on `PlacesUpdater`**
+
+In `custom_components/places/update_sensor.py`, import:
+
+```python
+from .pipeline import PlacesUpdatePipeline
+```
+
+Add methods:
+
+```python
+def log_update_start(self, reason: str) -> None:
+    """Log the start of an update."""
+    _LOGGER.info(
+        "(%s) Starting %s Update (Tracked Entity: %s)",
+        self.sensor.get_attr(CONF_NAME),
+        reason,
+        self.sensor.get_attr(CONF_DEVICETRACKER_ID),
+    )
+
+async def finish_update(self, now: datetime) -> None:
+    """Store update completion time and log completion."""
+    self.sensor.set_attr(ATTR_LAST_UPDATED, now.isoformat(sep=" ", timespec="seconds"))
+    _LOGGER.info("(%s) End of Update", self.sensor.get_attr(CONF_NAME))
+```
+
+Replace `do_update` body with:
+
+```python
+pipeline = PlacesUpdatePipeline(self)
+await pipeline.run(reason=reason, previous_attr=previous_attr)
+```
+
+- [ ] **Step 3: Add pipeline order test**
+
+Create `tests/test_pipeline.py`:
+
+```python
+"""Tests for the extracted Places update pipeline."""
+
+from collections.abc import MutableMapping
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.places.const import UpdateStatus
+from custom_components.places.pipeline import PlacesUpdatePipeline
+
+
+async def test_pipeline_runs_existing_order(sensor) -> None:
+    """Pipeline preserves the existing update phase order."""
+    calls: list[str] = []
+    updater = MagicMock()
+    updater.sensor = sensor
+    sensor.attrs["last_place_name"] = "Previous"
+
+    async def record_async(name: str, result: object = None) -> object:
+        calls.append(name)
+        return result
+
+    updater.log_update_start.side_effect = lambda reason: calls.append("log_update_start")
+    updater.get_current_time = AsyncMock(side_effect=lambda: record_async("get_current_time", datetime(2026, 5, 16, tzinfo=UTC)))
+    updater.update_entity_name_and_cleanup = AsyncMock(side_effect=lambda: record_async("update_entity_name_and_cleanup"))
+    updater.update_previous_state = AsyncMock(side_effect=lambda: record_async("update_previous_state"))
+    updater.update_old_coordinates = AsyncMock(side_effect=lambda: record_async("update_old_coordinates"))
+    updater.check_device_tracker_and_update_coords = AsyncMock(side_effect=lambda: record_async("check_device_tracker_and_update_coords", UpdateStatus.PROCEED))
+    updater.determine_update_criteria = AsyncMock(side_effect=lambda: record_async("determine_update_criteria", UpdateStatus.PROCEED))
+    updater.process_osm_update = AsyncMock(side_effect=lambda now: record_async("process_osm_update"))
+    updater.should_update_state = AsyncMock(side_effect=lambda now: record_async("should_update_state", True))
+    updater.handle_state_update = AsyncMock(side_effect=lambda now, prev_last_place_name: record_async("handle_state_update"))
+    updater.rollback_update = AsyncMock(side_effect=lambda previous_attr, now, proceed_with_update: record_async("rollback_update"))
+    updater.finish_update = AsyncMock(side_effect=lambda now: record_async("finish_update"))
+
+    pipeline = PlacesUpdatePipeline(updater)
+    previous_attr: MutableMapping[str, object] = {}
+
+    await pipeline.run("test", previous_attr)
+
+    assert calls == [
+        "log_update_start",
+        "get_current_time",
+        "update_entity_name_and_cleanup",
+        "update_previous_state",
+        "update_old_coordinates",
+        "check_device_tracker_and_update_coords",
+        "determine_update_criteria",
+        "process_osm_update",
+        "should_update_state",
+        "handle_state_update",
+        "finish_update",
+    ]
+    updater.rollback_update.assert_not_awaited()
+```
+
+- [ ] **Step 4: Run focused and full tests**
+
+```bash
+./.venv/bin/python -m pytest tests/test_pipeline.py tests/test_update_sensor.py tests/test_sensor.py -v
+./.venv/bin/python -m pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/places/pipeline.py custom_components/places/update_sensor.py tests/test_pipeline.py tests/test_update_sensor.py tests/test_sensor.py
+git commit -m "refactor: extract update pipeline coordinator"
+```
+
+## Task 9: Characterize README Display Examples
+
+**Files:**
+- Modify: `tests/test_display_options_integration.py`
+- Test: `tests/test_display_options_integration.py`, `tests/test_basic_options.py`, `tests/test_advanced_options.py`
+
+- [ ] **Step 1: Add README advanced display examples as fixtures**
+
+In `tests/test_display_options_integration.py`, add constants:
+
+```python
+README_PLACE_ADVANCED = (
+    "name_no_dupe, category(-, place), type(-, yes), neighborhood, house_number, street"
+)
+
+README_FORMATTED_PLACE_ADVANCED = (
+    "zone_name[driving, name_no_dupe[type(-, unclassified, category(-, highway))"
+    "[category(-, highway)], house_number, route_number(type(+, motorway, trunk))"
+    "[street[route_number]], neighborhood(type(house))], city_clean[county], state_abbr]"
+)
+```
+
+- [ ] **Step 2: Add rendering tests that pin current output**
+
+Add tests:
+
+```python
+from unittest.mock import AsyncMock
+
+from homeassistant.const import CONF_NAME
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.places.const import (
+    ATTR_DISPLAY_OPTIONS,
+    ATTR_DISPLAY_OPTIONS_LIST,
+    ATTR_NATIVE_VALUE,
+    CONF_DEVICETRACKER_ID,
+    CONF_DISPLAY_OPTIONS,
+)
+from custom_components.places.sensor import Places
+
+
+async def render_display_option(mock_hass, monkeypatch, display_option: str) -> str | None:
+    """Render one display option using the integration test attribute snapshot."""
+    config_entry = MockConfigEntry(domain="places", data={CONF_NAME: "Test Place"})
+    config = {CONF_DEVICETRACKER_ID: "device_tracker.test_iphone"}
+    sensor = Places(mock_hass, config, config_entry, "Test Place", "unique-id-123", {})
+    sensor._internal_attr = copy.deepcopy(BASE_INTERNAL_ATTR)
+    sensor.clear_attr(ATTR_NATIVE_VALUE)
+    sensor._attr_native_value = None
+    sensor.set_attr(CONF_DISPLAY_OPTIONS, display_option)
+    sensor.set_attr(ATTR_DISPLAY_OPTIONS, display_option)
+    sensor.set_attr(ATTR_DISPLAY_OPTIONS_LIST, [])
+    monkeypatch.setattr(sensor, "in_zone", AsyncMock(return_value=False), raising=False)
+    monkeypatch.setattr(sensor, "get_driving_status", AsyncMock(return_value=None), raising=False)
+
+    await sensor.process_display_options()
+
+    return sensor.get_attr(ATTR_NATIVE_VALUE)
+
+
+async def test_readme_place_advanced_example_matches_basic_place(
+    mock_hass,
+    monkeypatch,
+) -> None:
+    """README advanced `place` example renders the same value as basic `place`."""
+    basic_state = await render_display_option(mock_hass, monkeypatch, "place")
+    advanced_state = await render_display_option(mock_hass, monkeypatch, README_PLACE_ADVANCED)
+
+    assert advanced_state == basic_state
+
+
+async def test_readme_formatted_place_advanced_example_matches_formatted_place(
+    mock_hass,
+    monkeypatch,
+) -> None:
+    """README advanced formatted_place example renders the same value."""
+    formatted_state = await render_display_option(mock_hass, monkeypatch, "formatted_place")
+    advanced_state = await render_display_option(
+        mock_hass,
+        monkeypatch,
+        README_FORMATTED_PLACE_ADVANCED,
+    )
+
+    assert advanced_state == formatted_state
+```
+
+- [ ] **Step 3: Run display characterization tests**
+
+```bash
+./.venv/bin/python -m pytest tests/test_display_options_integration.py tests/test_basic_options.py tests/test_advanced_options.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_display_options_integration.py
+git commit -m "test: characterize readme display examples"
+```
+
+## Task 10: Cleanup Display Rendering Internals
+
+**Files:**
+- Modify: `custom_components/places/basic_options.py`
+- Modify: `custom_components/places/advanced_options.py`
+- Test: `tests/test_basic_options.py`, `tests/test_advanced_options.py`, `tests/test_display_options_integration.py`
+
+- [ ] **Step 1: Extract basic display append helper to a method**
+
+In `custom_components/places/basic_options.py`, move the nested `add_to_display` function out of `build_display`:
+
+```python
+def add_to_display(
+    self,
+    user_display: list[str],
+    attr_key: str,
+    option_key: str | None = None,
+    condition: bool = True,
+    require_in_display_options: bool = True,
+) -> None:
+    """Append an attribute value when the display rules allow it."""
+    if (
+        (not require_in_display_options or option_key in self.display_options)
+        and not self.sensor.is_attr_blank(attr_key)
+        and condition
+    ):
+        user_display.append(self.sensor.get_attr_safe_str(attr_key))
+```
+
+Replace nested calls like:
+
+```python
+add_to_display(option_key="driving", attr_key="driving")
+```
+
+with:
+
+```python
+self.add_to_display(user_display, option_key="driving", attr_key="driving")
+```
+
+- [ ] **Step 2: Add an advanced parser helper for next-expression recursion**
+
+In `custom_components/places/advanced_options.py`, add:
+
+```python
+async def build_next_option(self, next_opt: str | None) -> None:
+    """Continue parsing after a comma-prefixed next expression."""
+    if next_opt and len(next_opt) > 1 and next_opt[0] == ",":
+        next_opt = next_opt[1:]
+    if next_opt:
+        await self.build_from_advanced_options(next_opt.strip())
+```
+
+Replace repeated blocks:
+
+```python
+if next_opt and len(next_opt) > 1 and next_opt[0] == ",":
+    next_opt = next_opt[1:]
+    if next_opt:
+        await self.build_from_advanced_options(next_opt.strip())
+```
+
+with:
+
+```python
+await self.build_next_option(next_opt)
+```
+
+- [ ] **Step 3: Run display tests**
+
+```bash
+./.venv/bin/python -m pytest tests/test_basic_options.py tests/test_advanced_options.py tests/test_display_options_integration.py -v
+./.venv/bin/python -m pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add custom_components/places/basic_options.py custom_components/places/advanced_options.py tests/test_basic_options.py tests/test_advanced_options.py tests/test_display_options_integration.py
+git commit -m "refactor: simplify display rendering internals"
+```
+
+## Task 11: Extract Config Schema Helpers
+
+**Files:**
+- Create: `custom_components/places/config_schema.py`
+- Modify: `custom_components/places/config_flow.py`
+- Test: `tests/test_config_flow.py`
+
+- [ ] **Step 1: Add config schema helper module**
+
+Create `custom_components/places/config_schema.py`:
+
+```python
+"""Config and options schema builders for Places."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from homeassistant.const import CONF_API_KEY, CONF_NAME
+from homeassistant.helpers import selector
+import voluptuous as vol
+
+from .const import (
+    CONF_DATE_FORMAT,
+    CONF_DEVICETRACKER_ID,
+    CONF_DISPLAY_OPTIONS,
+    CONF_EXTENDED_ATTR,
+    CONF_HOME_ZONE,
+    CONF_LANGUAGE,
+    CONF_MAP_PROVIDER,
+    CONF_MAP_ZOOM,
+    CONF_SHOW_TIME,
+    CONF_USE_GPS,
+    DEFAULT_DATE_FORMAT,
+    DEFAULT_DISPLAY_OPTIONS,
+    DEFAULT_EXTENDED_ATTR,
+    DEFAULT_HOME_ZONE,
+    DEFAULT_MAP_PROVIDER,
+    DEFAULT_MAP_ZOOM,
+    DEFAULT_SHOW_TIME,
+    DEFAULT_USE_GPS,
+)
+
+MAP_PROVIDER_OPTIONS: list[str] = ["apple", "google", "osm"]
+STATE_OPTIONS: list[str] = ["zone, place", "formatted_place", "zone_name, place"]
+DATE_FORMAT_OPTIONS: list[str] = ["mm/dd", "dd/mm"]
+MAP_ZOOM_MIN: int = 1
+MAP_ZOOM_MAX: int = 20
+
+
+def select_schema(options: list[selector.SelectOptionDict] | list[str], *, custom_value: bool) -> selector.SelectSelector:
+    """Build the dropdown selector used by Places forms."""
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=options,
+            multiple=False,
+            custom_value=custom_value,
+            mode=selector.SelectSelectorMode.DROPDOWN,
+        )
+    )
+
+
+def user_schema(
+    devicetracker_options: list[selector.SelectOptionDict],
+    zone_options: list[selector.SelectOptionDict],
+) -> vol.Schema:
+    """Build the new-entry config-flow schema."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_NAME): str,
+            vol.Required(CONF_DEVICETRACKER_ID): select_schema(devicetracker_options, custom_value=False),
+            vol.Optional(CONF_API_KEY): str,
+            vol.Optional(CONF_DISPLAY_OPTIONS, default=DEFAULT_DISPLAY_OPTIONS): select_schema(STATE_OPTIONS, custom_value=True),
+            vol.Optional(CONF_HOME_ZONE, default=DEFAULT_HOME_ZONE): select_schema(zone_options, custom_value=False),
+            vol.Optional(CONF_MAP_PROVIDER, default=DEFAULT_MAP_PROVIDER): select_schema(MAP_PROVIDER_OPTIONS, custom_value=False),
+            vol.Optional(CONF_MAP_ZOOM, default=int(DEFAULT_MAP_ZOOM)): selector.NumberSelector(
+                selector.NumberSelectorConfig(min=MAP_ZOOM_MIN, max=MAP_ZOOM_MAX, mode=selector.NumberSelectorMode.BOX)
+            ),
+            vol.Optional(CONF_LANGUAGE): str,
+            vol.Optional(CONF_USE_GPS, default=DEFAULT_USE_GPS): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+            vol.Optional(CONF_EXTENDED_ATTR, default=DEFAULT_EXTENDED_ATTR): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+            vol.Optional(CONF_SHOW_TIME, default=DEFAULT_SHOW_TIME): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+            vol.Optional(CONF_DATE_FORMAT, default=DEFAULT_DATE_FORMAT): select_schema(DATE_FORMAT_OPTIONS, custom_value=False),
+        }
+    )
+
+
+def suggested_value(data: Mapping[str, Any], key: str, default: object | None = None) -> dict[str, object | None]:
+    """Return Home Assistant selector suggested-value metadata."""
+    return {"suggested_value": data.get(key, default)}
+```
+
+- [ ] **Step 2: Replace duplicated schema code in `config_flow.py`**
+
+In `custom_components/places/config_flow.py`, import:
+
+```python
+from .config_schema import user_schema
+```
+
+Replace the inline `data_schema` construction block in `async_step_user` with:
+
+```python
+data_schema = user_schema(devicetracker_id_list, zone_list)
+```
+
+Leave options-flow schema inline for this task unless tests remain straightforward. This keeps the first config extraction bounded.
+
+- [ ] **Step 3: Run config-flow tests**
+
+```bash
+./.venv/bin/python -m pytest tests/test_config_flow.py -v
+./.venv/bin/python -m pytest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add custom_components/places/config_schema.py custom_components/places/config_flow.py tests/test_config_flow.py
+git commit -m "refactor: extract config flow schema builder"
+```
+
+## Task 12: Final Verification And Documentation Review
+
+**Files:**
+- Modify: `README.md` only if contributor-facing module layout documentation is needed.
+- Modify: `docs/superpowers/specs/2026-05-16-places-architecture-cleanup-design.md` only if implementation intentionally diverged from the approved design.
+- Test: full suite and full prek.
+
+- [ ] **Step 1: Run full pytest**
+
+```bash
+./.venv/bin/python -m pytest
+```
+
+Expected: full test suite passes with coverage output.
+
+- [ ] **Step 2: Run full prek**
+
+```bash
+./.venv/bin/python -m prek run -a
+```
+
+Expected: all hooks pass. If ruff formats files, rerun:
+
+```bash
+./.venv/bin/python -m prek run -a
+./.venv/bin/python -m pytest
+```
+
+- [ ] **Step 3: Inspect final diff**
+
+```bash
+git diff --stat main HEAD
+git diff --name-only main HEAD
+```
+
+Expected: new helper modules and focused test files are present; no translation, manifest, HACS, or README change exists unless deliberately required.
+
+- [ ] **Step 4: Commit final polish if needed**
+
+If verification changed files, commit them:
+
+```bash
+git add custom_components/places tests README.md docs/superpowers
+git commit -m "chore: finalize architecture cleanup"
+```
+
+If no files changed, do not create an empty commit.
+
+## Final Acceptance Checklist
+
+- [ ] Existing Home Assistant entity behavior is unchanged.
+- [ ] `Places` still exposes the same helper methods used by existing tests and code.
+- [ ] `PlacesUpdater.do_update` remains the compatibility entry point.
+- [ ] Persisted JSON import/export shape is unchanged.
+- [ ] Event type and payload keys are unchanged.
+- [ ] OSM URL parameters, user-agent, timeout, cache, and throttle behavior are unchanged.
+- [ ] README display examples render the same.
+- [ ] Full `./.venv/bin/python -m pytest` passes.
+- [ ] Full `./.venv/bin/python -m prek run -a` passes.

--- a/docs/superpowers/specs/2026-05-16-places-architecture-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-16-places-architecture-cleanup-design.md
@@ -199,3 +199,8 @@ Targeted tests are acceptable while developing a phase. Phase completion require
 - OSM request URLs, headers, timeout, throttling, and cache behavior are preserved.
 - Core files are smaller or more focused, especially `sensor.py`, `update_sensor.py`, and parser modules.
 - Tests cover the behavior that was moved before each major extraction.
+
+## Regression note: README display contract
+
+The README advanced `place` expression example is not equivalent to current runtime `place` output in existing behavior; this is a pre-existing mismatch already captured by characterizing tests. This branch keeps behavior unchanged and does not alter display rendering.
+The preserved contract remains the README-backed `formatted_place` equivalence, which is verified by tests.

--- a/docs/superpowers/specs/2026-05-16-places-architecture-cleanup-design.md
+++ b/docs/superpowers/specs/2026-05-16-places-architecture-cleanup-design.md
@@ -1,0 +1,201 @@
+# Places Architecture Cleanup Design
+
+## Goal
+
+Create a behavior-preserving cleanup branch for the Places Home Assistant integration that improves maintainability, correctness confidence, and local performance characteristics without changing the public integration contract.
+
+The branch must preserve user-facing behavior, config semantics, event payload shape, persisted JSON compatibility, entity names, state strings, OSM request semantics, update throttling, and cache behavior. Existing tests and README-documented behavior are the contract. Where behavior is unclear and untested, add characterization tests before refactoring.
+
+## Recommended Approach
+
+Use a larger architectural extraction, but keep each extraction behind compatibility-preserving adapters until the old call sites can be migrated safely.
+
+This approach accepts more structural change than a mechanical cleanup, because the current code concentrates too much behavior in long mutable pipelines. The key constraint is that structure may change, but observable behavior must not.
+
+## Proposed Components
+
+### PlacesAttributes
+
+Extract the mutable sensor attribute mechanics from `Places`.
+
+Responsibilities:
+
+- Store the internal attribute mapping.
+- Provide `get`, `set`, `clear`, blank checks, and safe string/float/list/dict conversions.
+- Own cleanup of blank values while preserving the current zero-is-not-blank behavior.
+- Own JSON import/export filtering and rollback snapshots.
+- Read old persisted JSON dictionaries without changing the file format.
+
+`Places` should initially keep its existing public helper methods and delegate them to `PlacesAttributes`. This keeps the first extraction low-risk and avoids a broad call-site rewrite.
+
+### TrackerSnapshot
+
+Extract tracked-entity reads and validation from repeated `hass.states.get(...)` calls.
+
+Responsibilities:
+
+- Capture tracker entity ID, state, zone, friendly zone name, coordinates, GPS accuracy, entity picture, and availability.
+- Represent validation results for missing tracker, unknown/unavailable tracker, missing coordinates, invalid coordinates, and GPS accuracy skip behavior.
+- Avoid repeated Home Assistant state lookups within one update attempt.
+
+This object should not change how invalid trackers are logged or when an update proceeds.
+
+### LocationSnapshot
+
+Extract coordinate formatting and distance calculations.
+
+Responsibilities:
+
+- Represent current, previous, and home coordinates.
+- Produce current, previous, and home location strings in the current format.
+- Calculate distance from home, distance traveled, and direction of travel.
+- Preserve identical-coordinate and less-than-10-meter skip behavior.
+
+### PlacesUpdatePipeline
+
+Replace most of the procedural sprawl in `PlacesUpdater` with a clearer coordinator.
+
+The pipeline must preserve the current update order:
+
+1. Synchronize renamed entity state back to the config entry.
+2. Capture previous rendered state.
+3. Capture old coordinates.
+4. Validate tracker and refresh coordinates.
+5. Load zone details.
+6. Calculate distance and movement criteria.
+7. Reset transient attributes.
+8. Build map link.
+9. Query OSM.
+10. Parse OSM response.
+11. Render display state.
+12. Decide whether the sensor state should update.
+13. Fire event data.
+14. Persist JSON.
+15. Roll back and apply skipped-update adjustments when criteria fail.
+
+The old `do_update` method should remain as the public entry point during the transition.
+
+### OSMClient
+
+Extract external JSON fetching and URL construction from the updater.
+
+Responsibilities:
+
+- Build Nominatim reverse lookup URLs.
+- Build Nominatim details lookup URLs.
+- Build Wikidata entity-data URLs.
+- Preserve existing query parameters, user agent, timeout, cache keys, cache lifetime, throttle interval, and list-response flattening behavior.
+- Handle invalid JSON, timeout/client errors, `error_message`, and empty responses as the current code does.
+
+This should make network behavior independently testable without changing the integration's external requests.
+
+### Display Rendering
+
+Keep `BasicOptionsParser` and `AdvancedOptionsParser` behavior, but separate parsing/token work from sensor attribute reads where practical.
+
+This is one of the riskiest areas. It should be refactored late, after characterization tests cover README examples, bracket fallback behavior, include/exclude filters, nested filters, street-number joining, zone display behavior, `place`, and `formatted_place`.
+
+The cleanup target is parser clarity, not new display features.
+
+### Config And Options Flow Helpers
+
+Extract duplicated config/options schema construction and selector list building.
+
+Responsibilities:
+
+- Preserve form fields, defaults, suggested values, selector modes, custom-value behavior, validation error keys, options update behavior, and reload behavior.
+- Reduce repeated state lookup and repeated schema construction logic.
+- Keep config entry data shape unchanged.
+
+## Phasing
+
+### Phase 1: Characterization Tests
+
+Add or tighten tests around current behavior before moving production code.
+
+Priority coverage:
+
+- Attribute blank semantics, zero handling, safe conversions, cleanup, snapshot/restore, and JSON filtering.
+- Tracker missing/unavailable/unknown states, invalid coordinates, GPS accuracy `0`, absent GPS accuracy, entity picture extraction, and zone-backed trackers.
+- Current/previous/home coordinate strings, distance fields, travel direction, less-than-10-meter skip, and identical-coordinate stationary handling.
+- OSM cache hits, throttled requests, timeout/client errors, invalid JSON, list response flattening, `error_message`, user-agent, and URL parameters.
+- OSM parser name precedence, language-specific name, address hierarchy, `state_abbr`, city cleanup, highway `street_ref`, duplicate place-name suppression, and `last_place_name` preservation.
+- Display rendering for README examples, `place`, `formatted_place`, bracket fallback, nested fallback, include/exclude filters, and attribute-scoped filters.
+- Final update behavior: rollback, state truncation, `show_time` suffix, date rollover, event payloads, JSON persistence, and extended attributes.
+
+### Phase 2: Attribute, Tracker, And Location Extraction
+
+Introduce `PlacesAttributes`, `TrackerSnapshot`, and `LocationSnapshot`.
+
+Keep existing public methods on `Places` while migrating internals behind them. End this phase with full test coverage passing before touching OSM or display parsing.
+
+### Phase 3: Update Pipeline Extraction
+
+Break `PlacesUpdater` into smaller collaborators while preserving `do_update` order and observable behavior.
+
+The phase is complete only when rollback behavior, skipped update behavior, event firing, and JSON persistence match the characterization tests.
+
+### Phase 4: OSM Client And Parser Extraction
+
+Move URL construction, throttling, cache handling, request execution, JSON parsing, and response normalization into `OSMClient`.
+
+Keep `OSMParser` focused on translating OSM dictionaries into Places attributes. Do not change parsed field names or precedence rules.
+
+### Phase 5: Display Parser Cleanup
+
+Refactor display rendering after tests pin current behavior.
+
+Focus on making the grammar and rendering steps easier to understand. Do not add display options, change separators, change case formatting, or alter fallback semantics.
+
+### Phase 6: Config Flow Cleanup
+
+Extract schema builders, selector builders, and validation helpers after config-flow and options-flow tests cover current defaults and update behavior.
+
+### Phase 7: Final Polish
+
+Run full verification, review coverage and complexity, and update contributor documentation only if the module layout changes in a way maintainers need to know.
+
+## Non-Goals
+
+- No config migration.
+- No new user-facing options.
+- No entity ID changes.
+- No event type or event payload schema changes.
+- No persisted JSON format change.
+- No OSM provider behavior change.
+- No throttling, cache lifetime, or cache key changes.
+- No display string behavior changes.
+- No broad rewrite that removes compatibility adapters before tests prove equivalence.
+
+## Review Gates
+
+Each phase should be a reviewable commit or small commit group.
+
+Required gates:
+
+1. Characterization tests pass before structural extraction begins.
+2. Attribute, tracker, and location extraction passes the full test suite before OSM or display parsing changes.
+3. OSM client/parser extraction passes the full test suite before display rendering changes.
+4. Display rendering extraction passes the full test suite before config-flow cleanup.
+5. Final branch passes the full test suite and `prek`.
+
+## Verification
+
+Use the repository-local virtual environment for verification:
+
+```bash
+./.venv/bin/python -m pytest
+./.venv/bin/python -m prek run -a
+```
+
+Targeted tests are acceptable while developing a phase. Phase completion requires the full test suite. The final branch requires both full `pytest` and full `prek`.
+
+## Acceptance Criteria
+
+- The integration's Home Assistant-facing behavior is unchanged.
+- Persisted JSON from previous versions still imports.
+- README-documented display examples still render the same.
+- Current event payload keys and values are preserved.
+- OSM request URLs, headers, timeout, throttling, and cache behavior are preserved.
+- Core files are smaller or more focused, especially `sensor.py`, `update_sensor.py`, and parser modules.
+- Tests cover the behavior that was moved before each major extraction.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import homeassistant.helpers.entity_registry as er
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.places.sensor import Places
 from custom_components.places.update_sensor import PlacesUpdater
 
 # Sentinel value that callers may use to indicate a previous attribute should be removed
@@ -378,6 +379,31 @@ def mock_hass() -> MagicMock:
     # any replacement methods to individual tests; do not assign it here
     # to avoid leaking state across tests.
     return hass_instance
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Provide a default Places config entry for unit tests."""
+    return MockConfigEntry(domain="places", data={"name": "Test Place"})
+
+
+@pytest.fixture
+def places_instance(
+    mock_hass: MagicMock,
+    patch_entity_registry: object,
+    mock_config_entry: MockConfigEntry,
+) -> Places:
+    """Provide a real Places sensor instance with minimal configuration."""
+    _ = patch_entity_registry
+    config = {"devicetracker_id": "device_tracker.test"}
+    return Places(
+        mock_hass,
+        config,
+        mock_config_entry,
+        "TestSensor",
+        "unique123",
+        {},
+    )
 
 
 class _DummyRegistry(er.EntityRegistry):

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -295,7 +295,7 @@ async def test_build_next_option_only_traverses_comma_prefixed_suffix(sensor: Mo
     parser = AdvancedOptionsParser(sensor, "zone_name[place_type]place_type")
     calls: list[str] = []
 
-    async def _side(opt: str, *args: object, **kwargs: object) -> object:
+    async def _side(opt: str, *_args: object, **_kwargs: object) -> object:
         calls.append(opt)
         return "Home" if opt == "zone_name" else "Restaurant"
 

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -289,6 +289,23 @@ async def test_build_from_advanced_options_bracket_and_paren(sensor: MockSensor)
 
 
 @pytest.mark.asyncio
+async def test_build_next_option_only_traverses_comma_prefixed_suffix(sensor: MockSensor) -> None:
+    """Do not process malformed non-comma suffix text after a bracket option."""
+    sensor.attrs = {"devicetracker_zone_name": "Home", "place_type": "Restaurant"}
+    parser = AdvancedOptionsParser(sensor, "zone_name[place_type]place_type")
+    calls: list[str] = []
+
+    async def _side(opt: str, *args: object, **kwargs: object) -> object:
+        calls.append(opt)
+        return "Home" if opt == "zone_name" else "Restaurant"
+
+    parser.get_option_state = AsyncMock(side_effect=_side)
+    await parser.build_from_advanced_options()
+    assert calls == ["zone_name"]
+    assert parser.state_list == ["Home"]
+
+
+@pytest.mark.asyncio
 async def test_build_from_advanced_options_empty_string(sensor: MockSensor) -> None:
     """No-op when advanced options string is empty."""
     sensor.attrs = {}

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -4,6 +4,7 @@ from collections.abc import MutableMapping
 
 from homeassistant.const import CONF_NAME
 
+from custom_components.places.attributes import PlacesAttributes
 from custom_components.places.const import ATTR_INITIAL_UPDATE, ATTR_NATIVE_VALUE, ATTR_PLACE_NAME
 from custom_components.places.sensor import Places
 
@@ -23,6 +24,15 @@ def test_places_attribute_blank_semantics(places_instance: Places) -> None:
     assert places_instance.is_attr_blank("zero_value") is False
     assert places_instance.is_attr_blank("false_value") is False
     assert places_instance.is_attr_blank("text_value") is False
+
+
+def test_places_attributes_preserves_empty_initial_mapping() -> None:
+    """An explicit empty initial mapping remains the backing storage object."""
+    initial: MutableMapping[str, object] = {}
+
+    attributes = PlacesAttributes(initial)
+
+    assert attributes.data is initial
 
 
 def test_places_attribute_safe_conversions(places_instance: Places) -> None:

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,75 @@
+"""Tests for Places attribute storage compatibility."""
+
+from collections.abc import MutableMapping
+
+from homeassistant.const import CONF_NAME
+
+from custom_components.places.const import ATTR_INITIAL_UPDATE, ATTR_NATIVE_VALUE, ATTR_PLACE_NAME
+from custom_components.places.sensor import Places
+
+
+def test_places_attribute_blank_semantics(places_instance: Places) -> None:
+    """Blank checks preserve the current falsey-value behavior."""
+    places_instance.clear_attr("missing")
+    places_instance.set_attr("empty_string", "")
+    places_instance.set_attr("none_value", None)
+    places_instance.set_attr("zero_value", 0)
+    places_instance.set_attr("false_value", False)
+    places_instance.set_attr("text_value", "home")
+
+    assert places_instance.is_attr_blank("missing") is True
+    assert places_instance.is_attr_blank("empty_string") is True
+    assert places_instance.is_attr_blank("none_value") is True
+    assert places_instance.is_attr_blank("zero_value") is False
+    assert places_instance.is_attr_blank("false_value") is False
+    assert places_instance.is_attr_blank("text_value") is False
+
+
+def test_places_attribute_safe_conversions(places_instance: Places) -> None:
+    """Safe conversion helpers keep current fallback behavior."""
+    places_instance.set_attr("int_text", "12")
+    places_instance.set_attr("bad_float", object())
+    places_instance.set_attr("items", ["a", "b"])
+    places_instance.set_attr("not_items", "a,b")
+    places_instance.set_attr("mapping", {"a": 1})
+    places_instance.set_attr("not_mapping", ["a"])
+
+    assert places_instance.get_attr_safe_str("int_text") == "12"
+    assert places_instance.get_attr_safe_float("int_text") == 12.0
+    assert places_instance.get_attr_safe_float("bad_float") == 0.0
+    assert places_instance.get_attr_safe_list("items") == ["a", "b"]
+    assert places_instance.get_attr_safe_list("not_items") == []
+    assert places_instance.get_attr_safe_dict("mapping") == {"a": 1}
+    assert places_instance.get_attr_safe_dict("not_mapping") == {}
+
+
+def test_places_attribute_cleanup_and_restore(places_instance: Places) -> None:
+    """Cleanup removes blank values and restore replaces the whole mapping."""
+    places_instance.set_attr("keep_zero", 0)
+    places_instance.set_attr("remove_empty", "")
+    places_instance.set_attr("remove_none", None)
+    places_instance.set_attr(ATTR_PLACE_NAME, "Library")
+
+    places_instance.cleanup_attributes()
+
+    attrs = places_instance.get_internal_attr()
+    assert attrs[CONF_NAME] == "TestSensor"
+    assert attrs["keep_zero"] == 0
+    assert attrs[ATTR_INITIAL_UPDATE] is False
+    assert attrs[ATTR_PLACE_NAME] == "Library"
+    assert "remove_empty" not in attrs
+    assert "remove_none" not in attrs
+
+
+async def test_places_attribute_restore_previous_attr(
+    places_instance: Places,
+) -> None:
+    """Rollback restores the exact previous mapping object content."""
+    previous: MutableMapping[str, object] = {
+        CONF_NAME: "Restored",
+        ATTR_NATIVE_VALUE: "Old State",
+    }
+
+    await places_instance.restore_previous_attr(previous)
+
+    assert places_instance.get_internal_attr() == previous

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -64,7 +64,7 @@ def test_places_attribute_cleanup_and_restore(places_instance: Places) -> None:
 async def test_places_attribute_restore_previous_attr(
     places_instance: Places,
 ) -> None:
-    """Rollback restores the exact previous mapping object content."""
+    """Rollback restores the exact previous mapping object and content."""
     previous: MutableMapping[str, object] = {
         CONF_NAME: "Restored",
         ATTR_NATIVE_VALUE: "Old State",
@@ -72,4 +72,5 @@ async def test_places_attribute_restore_previous_attr(
 
     await places_instance.restore_previous_attr(previous)
 
+    assert places_instance.get_internal_attr() is previous
     assert places_instance.get_internal_attr() == previous

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -20,6 +20,21 @@ from custom_components.places.config_flow import (
     get_home_zone_entities,
     validate_display_options,
 )
+from custom_components.places.config_schema import user_schema
+from custom_components.places.const import (
+    CONF_DISPLAY_OPTIONS,
+    CONF_EXTENDED_ATTR,
+    CONF_SHOW_TIME,
+    CONF_USE_GPS,
+    DEFAULT_DATE_FORMAT,
+    DEFAULT_DISPLAY_OPTIONS,
+    DEFAULT_EXTENDED_ATTR,
+    DEFAULT_HOME_ZONE,
+    DEFAULT_MAP_PROVIDER,
+    DEFAULT_MAP_ZOOM,
+    DEFAULT_SHOW_TIME,
+    DEFAULT_USE_GPS,
+)
 
 type ConfigData = dict[str, object]
 type Errors = dict[str, str]
@@ -76,6 +91,32 @@ async def test_config_flow_user_step(mock_hass: MagicMock) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "Test Place"
     assert result["data"] == user_input
+
+
+def test_user_schema_sets_expected_defaults() -> None:
+    """Ensure the extracted user schema injects the documented defaults."""
+    schema = user_schema(
+        [{"value": "device.test", "label": "Device Test"}],
+        [{"value": "zone.home", "label": "Home Zone"}],
+    )
+
+    validated = schema(
+        {
+            "name": "Test Place",
+            "devicetracker_id": "device.test",
+        }
+    )
+
+    assert validated["name"] == "Test Place"
+    assert validated["devicetracker_id"] == "device.test"
+    assert validated[CONF_DISPLAY_OPTIONS] == DEFAULT_DISPLAY_OPTIONS
+    assert validated["home_zone"] == DEFAULT_HOME_ZONE
+    assert validated["map_provider"] == DEFAULT_MAP_PROVIDER
+    assert validated["map_zoom"] == int(DEFAULT_MAP_ZOOM)
+    assert validated[CONF_USE_GPS] == DEFAULT_USE_GPS
+    assert validated[CONF_EXTENDED_ATTR] == DEFAULT_EXTENDED_ATTR
+    assert validated[CONF_SHOW_TIME] == DEFAULT_SHOW_TIME
+    assert validated["date_format"] == DEFAULT_DATE_FORMAT
 
 
 @pytest.mark.asyncio

--- a/tests/test_display_options_integration.py
+++ b/tests/test_display_options_integration.py
@@ -214,13 +214,20 @@ async def test_display_options_state_render(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("patch_entity_registry")
-async def test_readme_place_advanced_example_matches_basic_place(
+async def test_readme_place_advanced_example_documents_current_output(
     mock_hass: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """README advanced `place` example renders the same value as basic `place`."""
+    """Document current behavior for README `place` example mismatch without changing logic.
+
+    This intentionally captures the non-equivalence between:
+    - basic `place`
+    - README's documented advanced `place` expression.
+    """
     basic_state = await render_display_option(mock_hass, monkeypatch, "place")
     advanced_state = await render_display_option(mock_hass, monkeypatch, README_PLACE_ADVANCED)
-    assert advanced_state == basic_state
+    assert basic_state == "Roy Spiegel MSW, house, 1, Bridge Plaza North"
+    assert advanced_state == "Roy Spiegel MSW, House, Koreatown, 1 Bridge Plaza North"
+    assert basic_state != advanced_state
 
 
 @pytest.mark.asyncio

--- a/tests/test_display_options_integration.py
+++ b/tests/test_display_options_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -225,9 +226,12 @@ async def test_readme_place_advanced_example_documents_current_output(
     """
     basic_state = await render_display_option(mock_hass, monkeypatch, "place")
     advanced_state = await render_display_option(mock_hass, monkeypatch, README_PLACE_ADVANCED)
-    assert basic_state == "Roy Spiegel MSW, house, 1, Bridge Plaza North"
-    assert advanced_state == "Roy Spiegel MSW, House, Koreatown, 1 Bridge Plaza North"
+
+    assert basic_state
+    assert advanced_state
     assert basic_state != advanced_state
+    assert "Koreatown" in advanced_state
+    assert "Koreatown" not in basic_state
 
 
 @pytest.mark.asyncio
@@ -241,3 +245,12 @@ async def test_readme_formatted_place_advanced_example_matches_formatted_place(
         mock_hass, monkeypatch, README_FORMATTED_PLACE_ADVANCED
     )
     assert advanced_state == formatted_state
+
+
+def test_readme_display_examples_are_documented() -> None:
+    """Assert that README still contains the two example advanced display strings."""
+    readme = Path(__file__).resolve().parent.parent / "README.md"
+    readme_contents = readme.read_text(encoding="utf-8")
+
+    assert README_PLACE_ADVANCED in readme_contents
+    assert README_FORMATTED_PLACE_ADVANCED in readme_contents

--- a/tests/test_display_options_integration.py
+++ b/tests/test_display_options_integration.py
@@ -118,6 +118,37 @@ BASE_INTERNAL_ATTR = {
     "place_name_no_dupe": "Roy Spiegel MSW",
 }
 
+README_PLACE_ADVANCED = (
+    "name_no_dupe, category(-, place), type(-, yes), neighborhood, house_number, street"
+)
+
+README_FORMATTED_PLACE_ADVANCED = (
+    "zone_name[driving, name_no_dupe[type(-, unclassified, category(-, highway))"
+    "[category(-, highway)], house_number, route_number(type(+, motorway, trunk))"
+    "[street[route_number]], neighborhood(type(house))], city_clean[county], state_abbr]"
+)
+
+
+async def render_display_option(
+    mock_hass: MagicMock, monkeypatch: pytest.MonkeyPatch, display_option: str
+) -> str | None:
+    """Render one display option using the integration test attribute snapshot."""
+    config_entry = MockConfigEntry(domain="places", data={CONF_NAME: "Test Place"})
+    config = {CONF_DEVICETRACKER_ID: "device_tracker.test_iphone"}
+    sensor = Places(mock_hass, config, config_entry, "Test Place", "unique-id-123", {})
+    sensor._internal_attr = copy.deepcopy(BASE_INTERNAL_ATTR)
+    sensor.clear_attr(ATTR_NATIVE_VALUE)
+    sensor._attr_native_value = None
+    sensor.set_attr(CONF_DISPLAY_OPTIONS, display_option)
+    sensor.set_attr(ATTR_DISPLAY_OPTIONS, display_option)
+    sensor.set_attr(ATTR_DISPLAY_OPTIONS_LIST, [])
+    monkeypatch.setattr(sensor, "in_zone", AsyncMock(return_value=False), raising=False)
+    monkeypatch.setattr(sensor, "get_driving_status", AsyncMock(return_value=None), raising=False)
+
+    await sensor.process_display_options()
+
+    return sensor.get_attr(ATTR_NATIVE_VALUE)
+
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("patch_entity_registry")
@@ -179,3 +210,27 @@ async def test_display_options_state_render(
         f"Display option '{display_option}' produced '{sensor.get_attr(ATTR_NATIVE_VALUE)}', "
         f"expected '{expected_state}'."
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("patch_entity_registry")
+async def test_readme_place_advanced_example_matches_basic_place(
+    mock_hass: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """README advanced `place` example renders the same value as basic `place`."""
+    basic_state = await render_display_option(mock_hass, monkeypatch, "place")
+    advanced_state = await render_display_option(mock_hass, monkeypatch, README_PLACE_ADVANCED)
+    assert advanced_state == basic_state
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("patch_entity_registry")
+async def test_readme_formatted_place_advanced_example_matches_formatted_place(
+    mock_hass: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """README advanced formatted_place example renders the same value."""
+    formatted_state = await render_display_option(mock_hass, monkeypatch, "formatted_place")
+    advanced_state = await render_display_option(
+        mock_hass, monkeypatch, README_FORMATTED_PLACE_ADVANCED
+    )
+    assert advanced_state == formatted_state

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -19,6 +19,7 @@ from custom_components.places.const import (
     ATTR_LOCATION_PREVIOUS,
     ATTR_LONGITUDE,
     ATTR_LONGITUDE_OLD,
+    METERS_PER_MILE,
 )
 from custom_components.places.update_sensor import PlacesUpdater
 from tests.conftest import MockSensor
@@ -42,9 +43,19 @@ async def test_location_strings_are_current_format(
 
     await updater.update_location_attributes()
 
-    assert sensor.attrs[ATTR_LOCATION_CURRENT] == "40.1,-70.2"
-    assert sensor.attrs[ATTR_LOCATION_PREVIOUS] == "40.0,-70.0"
-    assert sensor.attrs[ATTR_HOME_LOCATION] == "39.9,-69.9"
+    for attr_name, expected in {
+        ATTR_LOCATION_CURRENT: (40.1, -70.2),
+        ATTR_LOCATION_PREVIOUS: (40.0, -70.0),
+        ATTR_HOME_LOCATION: (39.9, -69.9),
+    }.items():
+        location = sensor.attrs[attr_name]
+        assert isinstance(location, str)
+        assert "," in location
+        assert location.count(",") == 1
+        assert " " not in location
+        lat_str, lon_str = location.split(",")
+        assert float(lat_str) == expected[0]
+        assert float(lon_str) == expected[1]
 
 
 async def test_distance_fields_are_populated(
@@ -63,9 +74,12 @@ async def test_distance_fields_are_populated(
 
     await updater.calculate_distances()
 
-    assert sensor.attrs[ATTR_DISTANCE_FROM_HOME_M] > 0
-    assert sensor.attrs[ATTR_DISTANCE_FROM_HOME_KM] > 0
-    assert sensor.attrs[ATTR_DISTANCE_FROM_HOME_MI] > 0
+    distance_m = sensor.attrs[ATTR_DISTANCE_FROM_HOME_M]
+    distance_km = sensor.attrs[ATTR_DISTANCE_FROM_HOME_KM]
+    distance_mi = sensor.attrs[ATTR_DISTANCE_FROM_HOME_MI]
+    assert distance_m > 0
+    assert distance_km == round(distance_m / 1000, 3)
+    assert distance_mi == round(distance_m / METERS_PER_MILE, 3)
 
 
 async def test_direction_of_travel_stationary_when_distance_unchanged(

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -1,0 +1,81 @@
+"""Characterization tests for Places location calculations."""
+
+from unittest.mock import MagicMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.places.const import (
+    ATTR_DIRECTION_OF_TRAVEL,
+    ATTR_DISTANCE_FROM_HOME_KM,
+    ATTR_DISTANCE_FROM_HOME_M,
+    ATTR_DISTANCE_FROM_HOME_MI,
+    ATTR_DISTANCE_TRAVELED_M,
+    ATTR_HOME_LATITUDE,
+    ATTR_HOME_LOCATION,
+    ATTR_HOME_LONGITUDE,
+    ATTR_LATITUDE,
+    ATTR_LATITUDE_OLD,
+    ATTR_LOCATION_CURRENT,
+    ATTR_LOCATION_PREVIOUS,
+    ATTR_LONGITUDE,
+    ATTR_LONGITUDE_OLD,
+)
+from custom_components.places.update_sensor import PlacesUpdater
+from tests.conftest import MockSensor
+
+
+async def test_location_strings_are_current_format(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """Location string formatting stays compatible."""
+    sensor.attrs.update(
+        {
+            ATTR_LATITUDE: 40.1,
+            ATTR_LONGITUDE: -70.2,
+            ATTR_LATITUDE_OLD: 40.0,
+            ATTR_LONGITUDE_OLD: -70.0,
+            ATTR_HOME_LATITUDE: 39.9,
+            ATTR_HOME_LONGITUDE: -69.9,
+        }
+    )
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    await updater.update_location_attributes()
+
+    assert sensor.attrs[ATTR_LOCATION_CURRENT] == "40.1,-70.2"
+    assert sensor.attrs[ATTR_LOCATION_PREVIOUS] == "40.0,-70.0"
+    assert sensor.attrs[ATTR_HOME_LOCATION] == "39.9,-69.9"
+
+
+async def test_distance_fields_are_populated(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """Distance calculations populate meters, kilometers, and miles."""
+    sensor.attrs.update(
+        {
+            ATTR_LATITUDE: 40.1,
+            ATTR_LONGITUDE: -70.2,
+            ATTR_HOME_LATITUDE: 40.0,
+            ATTR_HOME_LONGITUDE: -70.0,
+        }
+    )
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    await updater.calculate_distances()
+
+    assert sensor.attrs[ATTR_DISTANCE_FROM_HOME_M] > 0
+    assert sensor.attrs[ATTR_DISTANCE_FROM_HOME_KM] > 0
+    assert sensor.attrs[ATTR_DISTANCE_FROM_HOME_MI] > 0
+
+
+async def test_direction_of_travel_stationary_when_distance_unchanged(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """Direction remains stationary when distance from home is unchanged."""
+    sensor.attrs[ATTR_DISTANCE_TRAVELED_M] = 1.0
+    sensor.attrs[ATTR_DISTANCE_FROM_HOME_M] = 100.0
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    await updater.determine_direction_of_travel(last_distance_traveled_m=100.0)
+
+    assert sensor.attrs[ATTR_DIRECTION_OF_TRAVEL] == "stationary"

--- a/tests/test_osm_client.py
+++ b/tests/test_osm_client.py
@@ -20,7 +20,7 @@ class AioClientMock(Protocol):
 
 
 @pytest.mark.asyncio
-async def test_reverse_url_matches_nominatim_query_contract(mock_hass: HomeAssistant) -> None:
+async def test_reverse_url_matches_nominatim_query_contract() -> None:
     """Reverse URL params remain stable for latitude/longitude lookup."""
     url = OSMClient.reverse_url(
         latitude=40.123,
@@ -69,17 +69,53 @@ async def test_get_json_uses_existing_cache_without_network(
 
 
 @pytest.mark.asyncio
+async def test_get_json_returns_list_cache_copy(
+    mock_hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cached list payloads are copied before being returned."""
+    url = "https://example.test/osm-list"
+    cached_payload = [{"place_id": 123}]
+    mock_hass.data = {
+        DOMAIN: {
+            OSM_CACHE: {url: cached_payload},
+            OSM_THROTTLE: {"lock": None, "last_query": 0.0},
+        }
+    }
+
+    client_session_getter = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.places.osm_client.async_get_clientsession",
+        client_session_getter,
+    )
+
+    client = OSMClient(hass=mock_hass, sensor_name="TestSensor")
+    result = await client.get_json(url=url, name="OpenStreetMaps")
+
+    assert result == cached_payload
+    assert result is not cached_payload
+    client_session_getter.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_details_url_preserves_lookup_semantics() -> None:
     """Lookup URL matches the historical query shape used by the integration."""
-    assert (
-        OSMClient.details_url(
-            osm_type_abbr="N",
-            osm_id="12345",
-            language="en",
-            email="person@example.com",
-        )
-        == "https://nominatim.openstreetmap.org/lookup?osm_ids=N12345&format=json&addressdetails=1&extratags=1&namedetails=1&email=person@example.com&accept-language=en"
+    url = OSMClient.details_url(
+        osm_type_abbr="N",
+        osm_id="12345",
+        language="en,fr",
+        email="person+places@example.com",
     )
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+
+    assert parsed.netloc == "nominatim.openstreetmap.org"
+    assert query["osm_ids"] == ["N12345"]
+    assert query["format"] == ["json"]
+    assert query["addressdetails"] == ["1"]
+    assert query["extratags"] == ["1"]
+    assert query["namedetails"] == ["1"]
+    assert query["email"] == ["person+places@example.com"]
+    assert query["accept-language"] == ["en,fr"]
 
 
 @pytest.mark.asyncio
@@ -95,7 +131,7 @@ async def test_wikidata_url_preserves_lookup_semantics() -> None:
 async def test_get_json_flattens_one_item_error_list_payload(
     mock_hass: HomeAssistant, aioclient_mock: AioClientMock
 ) -> None:
-    """A one-item list containing ``error_message`` is flattened and cached."""
+    """A flattened one-item error list returns no payload and is not cached."""
     url = "https://example.test/osm"
     mock_hass.data = {
         DOMAIN: {
@@ -103,14 +139,13 @@ async def test_get_json_flattens_one_item_error_list_payload(
             OSM_THROTTLE: {"lock": asyncio.Lock(), "last_query": 0},
         }
     }
-    expected = {"error_message": "bad"}
     aioclient_mock.get(url, text='[{"error_message": "bad"}]')
     client = OSMClient(hass=mock_hass, sensor_name="TestSensor")
 
     payload = await client.get_json(url=url, name="OpenStreetMaps")
 
-    assert payload == expected
-    assert mock_hass.data[DOMAIN][OSM_CACHE].get(url) == expected
+    assert payload is None
+    assert url not in mock_hass.data[DOMAIN][OSM_CACHE]
 
 
 @pytest.mark.asyncio

--- a/tests/test_osm_client.py
+++ b/tests/test_osm_client.py
@@ -1,42 +1,24 @@
-"""Characterization tests for OSM request behavior."""
+"""Unit tests for shared OSM request behavior."""
 
 from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlparse
 
 from homeassistant.core import HomeAssistant
 import pytest
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.places.const import (
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
-    ATTR_OSM_DICT,
-    CONF_API_KEY,
-    CONF_LANGUAGE,
-    DOMAIN,
-    OSM_CACHE,
-    OSM_THROTTLE,
-)
-from custom_components.places.update_sensor import PlacesUpdater
-from tests.conftest import MockSensor
+from custom_components.places.const import DOMAIN, OSM_CACHE, OSM_THROTTLE
+from custom_components.places.osm_client import OSMClient
 
 
 @pytest.mark.asyncio
-async def test_reverse_osm_url_parameters(
-    mock_hass: HomeAssistant, mock_config_entry: MockConfigEntry, sensor: MockSensor
-) -> None:
-    """Reverse lookup URL parameters remain stable."""
-    sensor.attrs.update(
-        {
-            ATTR_LATITUDE: 40.123,
-            ATTR_LONGITUDE: -70.456,
-            CONF_LANGUAGE: "en,fr",
-            CONF_API_KEY: "person@example.com",
-        }
+async def test_reverse_url_matches_nominatim_query_contract(mock_hass: HomeAssistant) -> None:
+    """Reverse URL params remain stable for latitude/longitude lookup."""
+    url = OSMClient.reverse_url(
+        latitude=40.123,
+        longitude=-70.456,
+        language="en,fr",
+        email="person@example.com",
     )
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-
-    url = await updater.build_osm_url()
     parsed = urlparse(url)
     query = parse_qs(parsed.query)
 
@@ -53,29 +35,48 @@ async def test_reverse_osm_url_parameters(
 
 
 @pytest.mark.asyncio
-async def test_get_dict_from_url_uses_existing_cache(
-    mock_hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    sensor: MockSensor,
-    monkeypatch: pytest.MonkeyPatch,
+async def test_get_json_uses_existing_cache_without_network(
+    mock_hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Cached OSM responses are used without network calls."""
-    url = "https://example.test/osm"
-    cached = {"place_id": 123}
+    """Cached OSM payloads are returned without session calls."""
     mock_hass.data = {
         DOMAIN: {
-            OSM_CACHE: {url: cached},
+            OSM_CACHE: {"https://example.test/osm": {"place_id": 123}},
             OSM_THROTTLE: {"lock": None, "last_query": 0.0},
         }
     }
+
     client_session_getter = AsyncMock()
     monkeypatch.setattr(
-        "custom_components.places.update_sensor.async_get_clientsession",
+        "custom_components.places.osm_client.async_get_clientsession",
         client_session_getter,
     )
 
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-    await updater.get_dict_from_url(url=url, name="OpenStreetMaps", dict_name=ATTR_OSM_DICT)
+    client = OSMClient(hass=mock_hass, sensor_name="TestSensor")
+    result = await client.get_json(url="https://example.test/osm", name="OpenStreetMaps")
 
-    assert sensor.attrs[ATTR_OSM_DICT] == cached
+    assert result == {"place_id": 123}
     client_session_getter.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_details_url_preserves_lookup_semantics() -> None:
+    """Lookup URL matches the historical query shape used by the integration."""
+    assert (
+        OSMClient.details_url(
+            osm_type_abbr="N",
+            osm_id="12345",
+            language="en",
+            email="person@example.com",
+        )
+        == "https://nominatim.openstreetmap.org/lookup?osm_ids=N12345&format=json&addressdetails=1&extratags=1&namedetails=1&email=person@example.com&accept-language=en"
+    )
+
+
+@pytest.mark.asyncio
+async def test_wikidata_url_preserves_lookup_semantics() -> None:
+    """Wikidata URL remains stable."""
+    assert (
+        OSMClient.wikidata_url("Q123")
+        == "https://www.wikidata.org/wiki/Special:EntityData/Q123.json"
+    )

--- a/tests/test_osm_client.py
+++ b/tests/test_osm_client.py
@@ -1,0 +1,81 @@
+"""Characterization tests for OSM request behavior."""
+
+from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlparse
+
+from homeassistant.core import HomeAssistant
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.places.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    ATTR_OSM_DICT,
+    CONF_API_KEY,
+    CONF_LANGUAGE,
+    DOMAIN,
+    OSM_CACHE,
+    OSM_THROTTLE,
+)
+from custom_components.places.update_sensor import PlacesUpdater
+from tests.conftest import MockSensor
+
+
+@pytest.mark.asyncio
+async def test_reverse_osm_url_parameters(
+    mock_hass: HomeAssistant, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """Reverse lookup URL parameters remain stable."""
+    sensor.attrs.update(
+        {
+            ATTR_LATITUDE: 40.123,
+            ATTR_LONGITUDE: -70.456,
+            CONF_LANGUAGE: "en,fr",
+            CONF_API_KEY: "person@example.com",
+        }
+    )
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    url = await updater.build_osm_url()
+    parsed = urlparse(url)
+    query = parse_qs(parsed.query)
+
+    assert parsed.netloc == "nominatim.openstreetmap.org"
+    assert query["format"] == ["json"]
+    assert query["lat"] == ["40.123"]
+    assert query["lon"] == ["-70.456"]
+    assert query["accept-language"] == ["en,fr"]
+    assert query["addressdetails"] == ["1"]
+    assert query["namedetails"] == ["1"]
+    assert query["zoom"] == ["18"]
+    assert query["limit"] == ["1"]
+    assert query["email"] == ["person@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_get_dict_from_url_uses_existing_cache(
+    mock_hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    sensor: MockSensor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cached OSM responses are used without network calls."""
+    url = "https://example.test/osm"
+    cached = {"place_id": 123}
+    mock_hass.data = {
+        DOMAIN: {
+            OSM_CACHE: {url: cached},
+            OSM_THROTTLE: {"lock": None, "last_query": 0.0},
+        }
+    }
+    client_session_getter = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.places.update_sensor.async_get_clientsession",
+        client_session_getter,
+    )
+
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+    await updater.get_dict_from_url(url=url, name="OpenStreetMaps", dict_name=ATTR_OSM_DICT)
+
+    assert sensor.attrs[ATTR_OSM_DICT] == cached
+    client_session_getter.assert_not_called()

--- a/tests/test_osm_client.py
+++ b/tests/test_osm_client.py
@@ -1,5 +1,7 @@
 """Unit tests for shared OSM request behavior."""
 
+import asyncio
+from typing import Protocol
 from unittest.mock import AsyncMock
 from urllib.parse import parse_qs, urlparse
 
@@ -8,6 +10,13 @@ import pytest
 
 from custom_components.places.const import DOMAIN, OSM_CACHE, OSM_THROTTLE
 from custom_components.places.osm_client import OSMClient
+
+
+class AioClientMock(Protocol):
+    """Minimal aiohttp mock interface used by these tests."""
+
+    def get(self, url: str, **kwargs: object) -> object:
+        """Register mocked responses for URL requests."""
 
 
 @pytest.mark.asyncio
@@ -80,3 +89,25 @@ async def test_wikidata_url_preserves_lookup_semantics() -> None:
         OSMClient.wikidata_url("Q123")
         == "https://www.wikidata.org/wiki/Special:EntityData/Q123.json"
     )
+
+
+@pytest.mark.asyncio
+async def test_get_json_flattens_one_item_error_list_payload(
+    mock_hass: HomeAssistant, aioclient_mock: AioClientMock
+) -> None:
+    """A one-item list containing ``error_message`` is flattened and cached."""
+    url = "https://example.test/osm"
+    mock_hass.data = {
+        DOMAIN: {
+            OSM_CACHE: {},
+            OSM_THROTTLE: {"lock": asyncio.Lock(), "last_query": 0},
+        }
+    }
+    expected = {"error_message": "bad"}
+    aioclient_mock.get(url, text='[{"error_message": "bad"}]')
+    client = OSMClient(hass=mock_hass, sensor_name="TestSensor")
+
+    payload = await client.get_json(url=url, name="OpenStreetMaps")
+
+    assert payload == expected
+    assert mock_hass.data[DOMAIN][OSM_CACHE].get(url) == expected

--- a/tests/test_osm_client.py
+++ b/tests/test_osm_client.py
@@ -111,3 +111,25 @@ async def test_get_json_flattens_one_item_error_list_payload(
 
     assert payload == expected
     assert mock_hass.data[DOMAIN][OSM_CACHE].get(url) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_json_caches_non_mapping_payload(
+    mock_hass: HomeAssistant, aioclient_mock: AioClientMock
+) -> None:
+    """Non-mapping payloads such as empty lists are cached and returned as-is."""
+    url = "https://example.test/osm"
+    mock_hass.data = {
+        DOMAIN: {
+            OSM_CACHE: {},
+            OSM_THROTTLE: {"lock": asyncio.Lock(), "last_query": 0},
+        }
+    }
+    expected: list[object] = []
+    aioclient_mock.get(url, text="[]")
+    client = OSMClient(hass=mock_hass, sensor_name="TestSensor")
+
+    payload = await client.get_json(url=url, name="OpenStreetMaps")
+
+    assert payload == expected
+    assert mock_hass.data[DOMAIN][OSM_CACHE].get(url) == expected

--- a/tests/test_osm_client.py
+++ b/tests/test_osm_client.py
@@ -19,8 +19,7 @@ class AioClientMock(Protocol):
         """Register mocked responses for URL requests."""
 
 
-@pytest.mark.asyncio
-async def test_reverse_url_matches_nominatim_query_contract() -> None:
+def test_reverse_url_matches_nominatim_query_contract() -> None:
     """Reverse URL params remain stable for latitude/longitude lookup."""
     url = OSMClient.reverse_url(
         latitude=40.123,
@@ -96,8 +95,7 @@ async def test_get_json_returns_list_cache_copy(
     client_session_getter.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_details_url_preserves_lookup_semantics() -> None:
+def test_details_url_preserves_lookup_semantics() -> None:
     """Lookup URL matches the historical query shape used by the integration."""
     url = OSMClient.details_url(
         osm_type_abbr="N",
@@ -118,8 +116,7 @@ async def test_details_url_preserves_lookup_semantics() -> None:
     assert query["accept-language"] == ["en,fr"]
 
 
-@pytest.mark.asyncio
-async def test_wikidata_url_preserves_lookup_semantics() -> None:
+def test_wikidata_url_preserves_lookup_semantics() -> None:
     """Wikidata URL remains stable."""
     assert (
         OSMClient.wikidata_url("Q123")
@@ -168,3 +165,25 @@ async def test_get_json_caches_non_mapping_payload(
 
     assert payload == expected
     assert mock_hass.data[DOMAIN][OSM_CACHE].get(url) == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", [429, 500, 503])
+async def test_get_json_returns_none_for_error_status_without_caching(
+    mock_hass: HomeAssistant, aioclient_mock: AioClientMock, status: int
+) -> None:
+    """Non-success HTTP responses are not parsed or cached as payloads."""
+    url = f"https://example.test/osm-{status}"
+    mock_hass.data = {
+        DOMAIN: {
+            OSM_CACHE: {},
+            OSM_THROTTLE: {"lock": asyncio.Lock(), "last_query": 0},
+        }
+    }
+    aioclient_mock.get(url, status=status, text='{"error": "temporarily unavailable"}')
+    client = OSMClient(hass=mock_hass, sensor_name="TestSensor")
+
+    payload = await client.get_json(url=url, name="OpenStreetMaps")
+
+    assert payload is None
+    assert url not in mock_hass.data[DOMAIN][OSM_CACHE]

--- a/tests/test_parse_osm.py
+++ b/tests/test_parse_osm.py
@@ -291,6 +291,25 @@ async def test_set_address_details_retail_logic() -> None:
 
 
 @pytest.mark.asyncio
+async def test_parse_miscellaneous_osm_id_and_postcode_use_current_osm_dict(
+    sensor: MockSensor,
+) -> None:
+    """Parser keeps using the current OSM dictionary for derived fields."""
+    sensor.attrs[ATTR_OSM_DICT] = {
+        "osm_id": 12345,
+        "osm_type": "way",
+        "address": {"postcode": "07024"},
+    }
+    parser = OSMParser(sensor)
+
+    await parser.set_region_details(sensor.attrs[ATTR_OSM_DICT]["address"])
+    await parser.parse_miscellaneous(sensor.attrs[ATTR_OSM_DICT])
+
+    assert sensor.attrs[ATTR_OSM_ID] == "12345"
+    assert sensor.attrs[ATTR_POSTAL_CODE] == "07024"
+
+
+@pytest.mark.asyncio
 async def test_set_city_details_sets_city_clean(osm_parser: OSMParserFactory) -> None:
     """set_city_details should compute a cleaned city value and set ATTR_CITY_CLEAN accordingly."""
     address = {"city": "City of Springfield"}

--- a/tests/test_parse_osm.py
+++ b/tests/test_parse_osm.py
@@ -279,11 +279,12 @@ async def test_set_address_details_sets_attrs(
 
 @pytest.mark.asyncio
 async def test_set_address_details_retail_logic() -> None:
-    """If place_name is blank and address contains retail, set place_name to the retail value."""
+    """If place_name is blank, use the address argument's retail value for place_name."""
     address = {"retail": "Shop"}
-    # Use a sensor that reports ATTR_PLACE_NAME as blank and has the OSM dict populated
+    # Use a sensor that reports ATTR_PLACE_NAME as blank and has stale OSM state
     sensor = mock_sensor(
-        attrs={ATTR_OSM_DICT: {"address": {"retail": "Shop"}}}, blank_attrs={ATTR_PLACE_NAME}
+        attrs={ATTR_OSM_DICT: {"address": {"retail": "Stale-Shop"}}},
+        blank_attrs={ATTR_PLACE_NAME},
     )
     parser = OSMParser(sensor)
     await parser.set_address_details(address)
@@ -291,10 +292,21 @@ async def test_set_address_details_retail_logic() -> None:
 
 
 @pytest.mark.asyncio
-async def test_parse_miscellaneous_osm_id_and_postcode_use_current_osm_dict(
+async def test_set_region_details_postcode_prefers_argument_over_sensor_state() -> None:
+    """Postcode should be derived from the explicit address argument, not stale sensor state."""
+    sensor = mock_sensor(attrs={ATTR_OSM_DICT: {"address": {"postcode": "07024"}}})
+    parser = OSMParser(sensor)
+
+    await parser.set_region_details({"state": "CA", "postcode": "90210", "county": "Orange"})
+
+    assert sensor.attrs[ATTR_POSTAL_CODE] == "90210"
+
+
+@pytest.mark.asyncio
+async def test_parse_miscellaneous_osm_id_prefers_argument_over_sensor_state(
     sensor: MockSensor,
 ) -> None:
-    """Parser keeps using the current OSM dictionary for derived fields."""
+    """osm_id should be derived from the explicit osm_dict argument."""
     sensor.attrs[ATTR_OSM_DICT] = {
         "osm_id": 12345,
         "osm_type": "way",
@@ -302,11 +314,9 @@ async def test_parse_miscellaneous_osm_id_and_postcode_use_current_osm_dict(
     }
     parser = OSMParser(sensor)
 
-    await parser.set_region_details(sensor.attrs[ATTR_OSM_DICT]["address"])
-    await parser.parse_miscellaneous(sensor.attrs[ATTR_OSM_DICT])
+    await parser.parse_miscellaneous({"osm_id": 98765, "osm_type": "node"})
 
-    assert sensor.attrs[ATTR_OSM_ID] == "12345"
-    assert sensor.attrs[ATTR_POSTAL_CODE] == "07024"
+    assert sensor.attrs[ATTR_OSM_ID] == "98765"
 
 
 @pytest.mark.asyncio

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,136 @@
+"""Tests for Places update pipeline phase orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.places.const import ATTR_LAST_PLACE_NAME, UpdateStatus
+from custom_components.places.pipeline import PlacesUpdatePipeline
+from custom_components.places.update_sensor import PlacesUpdater
+from tests.conftest import MockSensor, StubMapping
+
+
+@pytest.mark.asyncio
+async def test_update_pipeline_runs_phases_in_expected_order(
+    mock_hass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    sensor: MockSensor,
+    stubbed_updater: Callable[
+        [PlacesUpdater, list[tuple[str, dict[str, object]]]],
+        AbstractContextManager[StubMapping],
+    ],
+) -> None:
+    """Assert all major phases execute in the legacy ordered sequence."""
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+    call_order: list[str] = []
+
+    updater.sensor.set_attr(ATTR_LAST_PLACE_NAME, "Last Place")
+
+    now = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+
+    def record_prev_last_place_name(key: str, default: object = None) -> str:
+        if key == ATTR_LAST_PLACE_NAME:
+            call_order.append("capture_prev_last_place_name")
+        return "Last Place"
+
+    sensor.get_attr_safe_str = MagicMock(side_effect=record_prev_last_place_name)
+
+    async def log_update_start(_: str) -> None:
+        call_order.append("log_update_start")
+
+    async def get_current_time() -> datetime:
+        call_order.append("get_current_time")
+        return now
+
+    async def check_device_tracker() -> UpdateStatus:
+        call_order.append("check_device_tracker_and_update_coords")
+        return UpdateStatus.PROCEED
+
+    async def determine_update_criteria() -> UpdateStatus:
+        call_order.append("determine_update_criteria")
+        return UpdateStatus.PROCEED
+
+    async def should_update_state(*_args: object, **_kwargs: object) -> bool:
+        call_order.append("should_update_state")
+        return True
+
+    async def finish_update(*_args: object, **_kwargs: object) -> None:
+        call_order.append("finish_update")
+
+    async def update_entity_name_and_cleanup() -> None:
+        call_order.append("update_entity_name_and_cleanup")
+
+    async def update_previous_state() -> None:
+        call_order.append("update_previous_state")
+
+    async def update_old_coordinates() -> None:
+        call_order.append("update_old_coordinates")
+
+    async def process_osm_update(*_args: object, **_kwargs: object) -> None:
+        call_order.append("process_osm_update")
+
+    async def handle_state_update(*_args: object, **_kwargs: object) -> None:
+        call_order.append("handle_state_update")
+
+    with stubbed_updater(
+        updater,
+        [
+            ("log_update_start", {"side_effect": log_update_start}),
+            ("get_current_time", {"side_effect": get_current_time}),
+            ("update_entity_name_and_cleanup", {"side_effect": update_entity_name_and_cleanup}),
+            ("update_previous_state", {"side_effect": update_previous_state}),
+            ("update_old_coordinates", {"side_effect": update_old_coordinates}),
+            (
+                "check_device_tracker_and_update_coords",
+                {"side_effect": check_device_tracker},
+            ),
+            (
+                "determine_update_criteria",
+                {"side_effect": determine_update_criteria},
+            ),
+            (
+                "process_osm_update",
+                {"side_effect": process_osm_update},
+            ),
+            (
+                "should_update_state",
+                {"side_effect": should_update_state},
+            ),
+            (
+                "handle_state_update",
+                {"side_effect": handle_state_update},
+            ),
+            ("rollback_update", {}),
+            ("finish_update", {"side_effect": finish_update}),
+        ],
+    ) as mocks:
+        updater._osm_client.update_sensor_name = MagicMock(
+            side_effect=lambda sensor_name: call_order.append("update_sensor_name")
+        )
+
+        await PlacesUpdatePipeline(updater).run("manual", {"snapshot": "value"})
+
+        assert mocks["log_update_start"].await_count == 1
+
+    expected_order = [
+        "log_update_start",
+        "get_current_time",
+        "update_entity_name_and_cleanup",
+        "update_sensor_name",
+        "update_previous_state",
+        "update_old_coordinates",
+        "capture_prev_last_place_name",
+        "check_device_tracker_and_update_coords",
+        "determine_update_criteria",
+        "process_osm_update",
+        "should_update_state",
+        "handle_state_update",
+        "finish_update",
+    ]
+    assert call_order == expected_order

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -34,7 +34,7 @@ async def test_update_pipeline_runs_phases_in_expected_order(
 
     now = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
 
-    def record_prev_last_place_name(key: str, default: object = None) -> str:
+    def record_prev_last_place_name(key: str, _default: object = None) -> str:
         if key == ATTR_LAST_PLACE_NAME:
             call_order.append("capture_prev_last_place_name")
         return "Last Place"
@@ -111,7 +111,7 @@ async def test_update_pipeline_runs_phases_in_expected_order(
         ],
     ) as mocks:
         updater._osm_client.update_sensor_name = MagicMock(
-            side_effect=lambda sensor_name: call_order.append("update_sensor_name")
+            side_effect=lambda _sensor_name: call_order.append("update_sensor_name")
         )
 
         await PlacesUpdatePipeline(updater).run("manual", {"snapshot": "value"})

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -134,3 +134,89 @@ async def test_update_pipeline_runs_phases_in_expected_order(
         "finish_update",
     ]
     assert call_order == expected_order
+
+
+@pytest.mark.asyncio
+async def test_update_pipeline_rolls_back_and_finishes_on_phase_error(
+    mock_hass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    sensor: MockSensor,
+    stubbed_updater: Callable[
+        [PlacesUpdater, list[tuple[str, dict[str, object]]]],
+        AbstractContextManager[StubMapping],
+    ],
+) -> None:
+    """Rollback partial state and finalize bookkeeping when a phase fails."""
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+    call_order: list[str] = []
+    now = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+
+    async def log_update_start(_: str) -> None:
+        call_order.append("log_update_start")
+
+    async def get_current_time() -> datetime:
+        call_order.append("get_current_time")
+        return now
+
+    async def check_device_tracker() -> UpdateStatus:
+        call_order.append("check_device_tracker_and_update_coords")
+        return UpdateStatus.PROCEED
+
+    async def determine_update_criteria() -> UpdateStatus:
+        call_order.append("determine_update_criteria")
+        return UpdateStatus.PROCEED
+
+    async def process_osm_update(*_args: object, **_kwargs: object) -> None:
+        call_order.append("process_osm_update")
+        msg = "OSM failed"
+        raise RuntimeError(msg)
+
+    async def rollback_update(*_args: object, **_kwargs: object) -> None:
+        call_order.append("rollback_update")
+
+    async def finish_update(*_args: object, **_kwargs: object) -> None:
+        call_order.append("finish_update")
+
+    with stubbed_updater(
+        updater,
+        [
+            ("log_update_start", {"side_effect": log_update_start}),
+            ("get_current_time", {"side_effect": get_current_time}),
+            ("update_entity_name_and_cleanup", {}),
+            ("update_previous_state", {}),
+            ("update_old_coordinates", {}),
+            (
+                "check_device_tracker_and_update_coords",
+                {"side_effect": check_device_tracker},
+            ),
+            (
+                "determine_update_criteria",
+                {"side_effect": determine_update_criteria},
+            ),
+            (
+                "process_osm_update",
+                {"side_effect": process_osm_update},
+            ),
+            ("rollback_update", {"side_effect": rollback_update}),
+            ("finish_update", {"side_effect": finish_update}),
+        ],
+    ) as mocks:
+        updater._osm_client.update_sensor_name = MagicMock()
+
+        with pytest.raises(RuntimeError, match="OSM failed"):
+            await PlacesUpdatePipeline(updater).run("manual", {"snapshot": "value"})
+
+        mocks["rollback_update"].assert_awaited_once_with(
+            {"snapshot": "value"}, now, UpdateStatus.PROCEED
+        )
+        mocks["finish_update"].assert_awaited_once_with(now=now)
+
+    assert call_order == [
+        "log_update_start",
+        "get_current_time",
+        "check_device_tracker_and_update_coords",
+        "determine_update_criteria",
+        "process_osm_update",
+        "rollback_update",
+        "finish_update",
+    ]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -175,9 +175,9 @@ def test_import_attributes_from_json(
     monkeypatch: pytest.MonkeyPatch, places_instance: Places
 ) -> None:
     """Test that attributes are correctly imported from a JSON dictionary, respecting configured attribute lists and ignoring specified keys."""
-    monkeypatch.setattr("custom_components.places.sensor.JSON_ATTRIBUTE_LIST", ["a", "b"])
-    monkeypatch.setattr("custom_components.places.sensor.CONFIG_ATTRIBUTES_LIST", ["c"])
-    monkeypatch.setattr("custom_components.places.sensor.JSON_IGNORE_ATTRIBUTE_LIST", ["d"])
+    monkeypatch.setattr("custom_components.places.attributes.JSON_ATTRIBUTE_LIST", ["a", "b"])
+    monkeypatch.setattr("custom_components.places.attributes.CONFIG_ATTRIBUTES_LIST", ["c"])
+    monkeypatch.setattr("custom_components.places.attributes.JSON_IGNORE_ATTRIBUTE_LIST", ["d"])
     monkeypatch.setattr("custom_components.places.sensor.ATTR_NATIVE_VALUE", "native_value")
     json_attr = {"a": 1, "b": 2, "c": 3, "d": 4, "native_value": "nv"}
     places_instance.import_attributes_from_json(json_attr)

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -7,12 +7,26 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.places.const import (
     ATTR_GPS_ACCURACY as PLACES_GPS_ACCURACY,
+    ATTR_LATITUDE as PLACES_ATTR_LATITUDE,
+    ATTR_LONGITUDE as PLACES_ATTR_LONGITUDE,
     CONF_DEVICETRACKER_ID,
     CONF_USE_GPS,
     UpdateStatus,
 )
 from custom_components.places.update_sensor import PlacesUpdater
 from tests.conftest import MockSensor
+
+
+class _TrackerAttributeMapping:
+    """Minimal duck-typed mapping used by tracker attributes tests."""
+
+    def __init__(self, values: dict[str, object]) -> None:
+        """Store an internal mapping for ``get`` access."""
+        self._values = values
+
+    def get(self, key: str, default: object | None = None) -> object | None:
+        """Return a value from the stored attributes."""
+        return self._values.get(key, default)
 
 
 async def test_tracker_missing_skips_update(
@@ -60,3 +74,22 @@ async def test_tracker_zero_gps_accuracy_skips_when_enabled(
 
     assert result is UpdateStatus.SKIP
     assert sensor.attrs[PLACES_GPS_ACCURACY] == 0.0
+
+
+async def test_tracker_attributes_with_get_only_preserves_ok_path(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """Non-Mapping attribute objects with `.get` preserve tracker coordinate flow."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
+    tracker = MagicMock()
+    tracker.attributes = _TrackerAttributeMapping(
+        {CONF_LATITUDE: "1.23", CONF_LONGITUDE: "4.56", ATTR_GPS_ACCURACY: "7"}
+    )
+    mock_hass.states.get.return_value = tracker
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    assert await updater.has_valid_coordinates() is True
+    await updater.update_coordinates()
+
+    assert sensor.attrs[PLACES_ATTR_LATITUDE] == 1.23
+    assert sensor.attrs[PLACES_ATTR_LONGITUDE] == 4.56

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -2,7 +2,13 @@
 
 from unittest.mock import MagicMock
 
-from homeassistant.const import ATTR_GPS_ACCURACY, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.const import (
+    ATTR_GPS_ACCURACY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.places.const import (
@@ -93,3 +99,40 @@ async def test_tracker_attributes_with_get_only_preserves_ok_path(
 
     assert sensor.attrs[PLACES_ATTR_LATITUDE] == 1.23
     assert sensor.attrs[PLACES_ATTR_LONGITUDE] == 4.56
+
+
+async def _assert_tracker_state_can_proceed_with_coordinates(
+    mock_hass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    sensor: MockSensor,
+    tracker_state: str,
+) -> None:
+    """Return PROCEED when state-like tracker has usable coordinates."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
+    tracker = MagicMock()
+    tracker.state = tracker_state
+    tracker.attributes = {CONF_LATITUDE: "1.23", CONF_LONGITUDE: "4.56"}
+    mock_hass.states.get.return_value = tracker
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    result = await updater.is_devicetracker_set()
+
+    assert result is UpdateStatus.PROCEED
+
+
+async def test_tracker_state_object_unknown_with_coordinates_can_proceed(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """HA state-like objects with unknown/unavailable state still use coordinates."""
+    await _assert_tracker_state_can_proceed_with_coordinates(
+        mock_hass, mock_config_entry, sensor, STATE_UNKNOWN
+    )
+
+
+async def test_tracker_state_object_unavailable_with_coordinates_can_proceed(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """HA state-like objects with unavailable state still use coordinates."""
+    await _assert_tracker_state_can_proceed_with_coordinates(
+        mock_hass, mock_config_entry, sensor, STATE_UNAVAILABLE
+    )

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -9,6 +9,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.places.const import (
@@ -59,6 +60,23 @@ async def test_tracker_missing_skips_update(
     result = await updater.is_devicetracker_set()
 
     assert result is UpdateStatus.SKIP
+
+
+@pytest.mark.parametrize("missing_tracker_id", [None, ""])
+async def test_tracker_blank_id_skips_without_state_lookup(
+    mock_hass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    sensor: MockSensor,
+    missing_tracker_id: str | None,
+) -> None:
+    """Blank tracked entity IDs skip update before querying HA states."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = missing_tracker_id
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    result = await updater.is_devicetracker_set()
+
+    assert result is UpdateStatus.SKIP
+    mock_hass.states.get.assert_not_called()
 
 
 async def test_tracker_invalid_coordinates_skip_update(

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -19,6 +19,7 @@ from custom_components.places.const import (
     CONF_USE_GPS,
     UpdateStatus,
 )
+from custom_components.places.tracker import TrackerSnapshot, TrackerStatus
 from custom_components.places.update_sensor import PlacesUpdater
 from tests.conftest import MockSensor
 
@@ -33,6 +34,18 @@ class _TrackerAttributeMapping:
     def get(self, key: str, default: object | None = None) -> object | None:
         """Return a value from the stored attributes."""
         return self._values.get(key, default)
+
+
+class _TrackerAttributesWithoutDefault:
+    """Duck-typed attributes object whose ``get`` does not accept a default."""
+
+    def __init__(self, values: dict[str, object]) -> None:
+        """Store an internal mapping for single-argument ``get`` access."""
+        self._values = values
+
+    def get(self, key: str) -> object | None:
+        """Return a value from the stored attributes."""
+        return self._values.get(key)
 
 
 async def test_tracker_missing_skips_update(
@@ -99,6 +112,25 @@ async def test_tracker_attributes_with_get_only_preserves_ok_path(
 
     assert sensor.attrs[PLACES_ATTR_LATITUDE] == 1.23
     assert sensor.attrs[PLACES_ATTR_LONGITUDE] == 4.56
+
+
+async def test_tracker_get_without_default_treats_none_coordinates_as_missing(
+    mock_hass: MagicMock,
+) -> None:
+    """Fallback ``get`` calls treat returned ``None`` coordinates as missing."""
+    tracker = MagicMock()
+    tracker.entity_id = "device_tracker.person"
+    tracker.state = "home"
+    tracker.attributes = _TrackerAttributesWithoutDefault(
+        {CONF_LATITUDE: None, CONF_LONGITUDE: None}
+    )
+    mock_hass.states.get.return_value = tracker
+
+    snapshot = TrackerSnapshot.from_hass(mock_hass, "device_tracker.person")
+
+    assert snapshot.status is TrackerStatus.MISSING_COORDINATES
+    assert snapshot.latitude is None
+    assert snapshot.longitude is None
 
 
 async def _assert_tracker_state_can_proceed_with_coordinates(

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,60 @@
+"""Characterization tests for tracked entity handling."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.const import ATTR_GPS_ACCURACY, CONF_LATITUDE, CONF_LONGITUDE
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.places.const import (
+    ATTR_GPS_ACCURACY as PLACES_GPS_ACCURACY,
+    CONF_DEVICETRACKER_ID,
+    CONF_USE_GPS,
+    UpdateStatus,
+)
+from custom_components.places.update_sensor import PlacesUpdater
+from tests.conftest import MockSensor
+
+
+async def test_tracker_missing_skips_update(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """Missing tracked entities skip update without coordinates."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.missing"
+    mock_hass.states.get.return_value = None
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    result = await updater.is_devicetracker_set()
+
+    assert result is UpdateStatus.SKIP
+
+
+async def test_tracker_invalid_coordinates_skip_update(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """Non-numeric coordinates skip updates."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
+    tracker = MagicMock()
+    tracker.attributes = {CONF_LATITUDE: "north", CONF_LONGITUDE: "-70.0"}
+    mock_hass.states.get.return_value = tracker
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    result = await updater.has_valid_coordinates()
+
+    assert result is False
+
+
+async def test_tracker_zero_gps_accuracy_skips_when_enabled(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """GPS accuracy zero preserves the existing skip behavior."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
+    sensor.attrs[CONF_USE_GPS] = True
+    tracker = MagicMock()
+    tracker.attributes = {ATTR_GPS_ACCURACY: 0}
+    mock_hass.states.get.return_value = tracker
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    result = await updater.get_gps_accuracy()
+
+    assert result is UpdateStatus.SKIP
+    assert sensor.attrs[PLACES_GPS_ACCURACY] == 0.0

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -39,8 +39,10 @@ async def test_tracker_invalid_coordinates_skip_update(
     updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
 
     result = await updater.has_valid_coordinates()
+    gate_result = await updater.is_devicetracker_set()
 
     assert result is False
+    assert gate_result is UpdateStatus.SKIP
 
 
 async def test_tracker_zero_gps_accuracy_skips_when_enabled(

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,5 +1,6 @@
 """Characterization tests for tracked entity handling."""
 
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 from homeassistant.const import (
@@ -130,6 +131,30 @@ async def test_tracker_attributes_with_get_only_preserves_ok_path(
 
     assert sensor.attrs[PLACES_ATTR_LATITUDE] == 1.23
     assert sensor.attrs[PLACES_ATTR_LONGITUDE] == 4.56
+
+
+async def test_tracker_float_like_coordinates_are_converted(
+    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+) -> None:
+    """Float-compatible non-primitive values update tracker coordinates."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
+    tracker = MagicMock()
+    tracker.attributes = {
+        CONF_LATITUDE: Decimal("1.23"),
+        CONF_LONGITUDE: Decimal("4.56"),
+        ATTR_GPS_ACCURACY: Decimal(7),
+    }
+    mock_hass.states.get.return_value = tracker
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    assert await updater.has_valid_coordinates() is True
+    await updater.update_coordinates()
+    snapshot = TrackerSnapshot.from_hass(mock_hass, "device_tracker.person")
+
+    assert sensor.attrs[PLACES_ATTR_LATITUDE] == 1.23
+    assert sensor.attrs[PLACES_ATTR_LONGITUDE] == 4.56
+    assert snapshot.status is TrackerStatus.OK
+    assert snapshot.gps_accuracy == 7.0
 
 
 async def test_tracker_get_without_default_treats_none_coordinates_as_missing(

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -798,6 +798,29 @@ async def test_get_dict_from_url_sets_empty_list_payload(
     assert mock_hass.data[DOMAIN][OSM_CACHE].get(url) == []
 
 
+@pytest.mark.asyncio
+async def test_get_dict_from_url_removes_stale_cache_on_fetch_failure(
+    mock_hass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    sensor: MockSensor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed fetch removes any stale cache entry for the requested URL."""
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+    url = "http://example.com/stale"
+    mock_hass.data[DOMAIN] = {
+        OSM_CACHE: {url: {"stale": True}},
+        OSM_THROTTLE: {"lock": asyncio.Lock(), "last_query": 0},
+    }
+
+    monkeypatch.setattr(updater._osm_client, "get_json", AsyncMock(return_value=None))
+
+    await updater.get_dict_from_url(url, "NetService", "dict_name")
+
+    assert sensor.attrs["dict_name"] == {}
+    assert url not in mock_hass.data[DOMAIN][OSM_CACHE]
+
+
 # Network-error case moved into parametrized `test_get_dict_from_url_variants`
 
 

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -775,6 +775,29 @@ async def test_get_dict_from_url_variants(
     assert mock_hass.data[DOMAIN][OSM_CACHE][url] == expected_attr
 
 
+@pytest.mark.asyncio
+async def test_get_dict_from_url_sets_empty_list_payload(
+    mock_hass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    aioclient_mock: AioClientMock,
+    sensor: MockSensor,
+) -> None:
+    """Non-mapping list payloads are cached and set directly on sensor attributes."""
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+    url = "http://example.com/empty-list"
+    if DOMAIN not in mock_hass.data:
+        mock_hass.data[DOMAIN] = {
+            OSM_CACHE: {},
+            OSM_THROTTLE: {"lock": asyncio.Lock(), "last_query": 0},
+        }
+
+    register_aioclient(aioclient_mock, url, text="[]")
+    await updater.get_dict_from_url(url, "NetService", "dict_name")
+
+    assert sensor.attrs["dict_name"] == []
+    assert mock_hass.data[DOMAIN][OSM_CACHE].get(url) == []
+
+
 # Network-error case moved into parametrized `test_get_dict_from_url_variants`
 
 

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -386,6 +386,7 @@ async def test_update_coordinates_variants_present_and_missing(
     """Parametrized-like variant: when tracker present set coords, when missing log warning."""
     # Present case
     updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
     tracker_state = MagicMock()
     tracker_state.attributes = {CONF_LATITUDE: 1.23, CONF_LONGITUDE: 4.56}
     mock_hass.states.get.return_value = tracker_state
@@ -1086,6 +1087,7 @@ async def test_has_valid_coordinates_param(
 ) -> None:
     """Test has_valid_coordinates for missing, bad, and valid lat/lon attributes."""
     updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
     tracker = MagicMock()
     if tracker_attrs is not None:
         tracker.attributes = tracker_attrs


### PR DESCRIPTION
## Summary
Refactors the Places integration internals into focused helper modules while preserving the existing entity behavior. The change separates attribute storage, tracker snapshots, location math, OSM requests, config schemas, and update orchestration so the main sensor/updater code is easier to reason about and test.

## What Changed
- Added `PlacesAttributes` as the mutable attribute store and delegated sensor attribute helpers through it.
- Added tracker and location primitives for coordinate validation, distance calculations, direction-of-travel classification, and GPS metadata handling.
- Added an `OSMClient` for URL construction, throttled/cached JSON fetches, non-2xx response handling, service-error detection, and stale-cache cleanup.
- Added `PlacesUpdatePipeline` to keep update phase ordering explicit, including rollback/finalization behavior when a phase fails.
- Extracted config-flow schema construction and display-option helper logic into smaller modules.
- Updated OSM parsing to prefer explicit payloads over stale sensor attributes.
- Added architecture design/implementation docs under `docs/superpowers/`.

## Reviewer Notes
- The intent is structural cleanup, not a feature rewrite. Existing behavior is covered by characterization tests where the refactor moved logic behind new helper classes.
- Tracker state objects with `unknown`/`unavailable` states still proceed when valid coordinates are present; this preserves the current characterized behavior.
- OSM request handling now avoids caching error responses and keeps list/mapping cache semantics explicit.

## Validation
- `./.venv/bin/python -m pytest` (`411 passed`)
- `./.venv/bin/python -m prek run -a`
