### PR TITLE
Fix home zone friendly name lookup

### DIFF
--- a/custom_components/places/update_sensor.py
+++ b/custom_components/places/update_sensor.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
 
 from .const import (
     ATTR_DEVICETRACKER_ZONE,
@@ -473,6 +474,10 @@ class PlacesUpdater:
             devicetracker_zone_id: str | None = None
             if state is not None:
                 devicetracker_zone_id = state.attributes.get(CONF_ZONE)
+            if not devicetracker_zone_id and not self.sensor.is_attr_blank(ATTR_DEVICETRACKER_ZONE):
+                devicetracker_zone_id = slugify(
+                    self.sensor.get_attr_safe_str(ATTR_DEVICETRACKER_ZONE)
+                )
             if devicetracker_zone_id:
                 devicetracker_zone_id = f"{CONF_ZONE}.{devicetracker_zone_id}"
                 devicetracker_zone_name_state = self._hass.states.get(devicetracker_zone_id)

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -583,6 +583,33 @@ async def test_get_zone_details_param(
 
 
 @pytest.mark.asyncio
+async def test_get_zone_details_uses_home_zone_friendly_name_from_state(
+    mock_hass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    sensor: MockSensor,
+) -> None:
+    """Default home zone state should resolve the configured zone friendly name."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
+    tracker_state = MagicMock(state="home", attributes={})
+    home_zone_state = MagicMock(attributes={ATTR_FRIENDLY_NAME: "Casa Concordia"})
+
+    mock_hass.states.get.side_effect = lambda entity_id: (
+        tracker_state
+        if entity_id == "device_tracker.person"
+        else home_zone_state
+        if entity_id == "zone.home"
+        else None
+    )
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+
+    with stub_in_zone(sensor, True):
+        await updater.get_zone_details()
+
+    assert sensor.attrs[ATTR_DEVICETRACKER_ZONE] == "home"
+    assert sensor.attrs[ATTR_DEVICETRACKER_ZONE_NAME] == "Casa Concordia"
+
+
+@pytest.mark.asyncio
 async def test_process_osm_update_calls(
     mock_hass: MagicMock,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
## Summary

Fixes home-zone friendly name resolution when a tracked entity reports `state="home"` without a `zone` attribute. The updater now falls back to the stored tracker zone value, slugifies it, and resolves the corresponding `zone.*` entity so configured friendly names are preserved.

## What Changed

- Added a fallback in `PlacesUpdater.get_zone_details()` that derives the zone entity ID from `ATTR_DEVICETRACKER_ZONE` when the tracker state has no `CONF_ZONE` attribute.
- Uses Home Assistant's `slugify` helper so zone names map to entity IDs consistently with HA naming.
- Added regression coverage for a default `home` tracker state resolving `zone.home` to its friendly name.

## Why

Some tracker states expose `home` as their state but do not include a `zone` attribute. In that case, the integration could leave the displayed zone name as the raw state instead of resolving the configured Home Assistant zone friendly name. Reusing the already-stored tracker zone preserves the existing zone resolution path without changing behavior for trackers that do provide `CONF_ZONE`.

## Validation

- `./.venv/bin/python -m prek run -a`
- `./.venv/bin/python -m pytest`

I know this is an old issue but this fixes #325 