### PR TITLE
Consolidate duplicate test cases

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -330,36 +330,6 @@ async def test_options_flow_handler_shows_form_when_no_user_input(
     assert result["description_placeholders"]["component_config_url"]
 
 
-@pytest.mark.asyncio
-async def test_options_flow_handler_merges_config_entry_data(
-    mock_hass: MagicMock, config_entry: MockConfigEntry, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Test that the options flow handler merges user input with existing config entry data and updates the entry.
-
-    Asserts that the updated config entry data contains both the original and new values, and that the flow returns a create entry result.
-    """
-    config_entry.add_to_hass(mock_hass)
-    handler = PlacesOptionsFlowHandler()
-    handler.hass = mock_hass
-    # attach config_entry property so the handler can access it
-    monkeypatch.setattr(
-        type(handler), "config_entry", property(lambda self: config_entry), raising=False
-    )
-    user_input = {
-        "devicetracker_id": "device.test",
-        "display_options": "zone, place",
-    }
-    expected_data = dict(config_entry.data)
-    expected_data.update(user_input)
-    mock_hass.config_entries.async_update_entry = MagicMock()
-    mock_hass.config_entries.async_reload = AsyncMock()
-    result = await handler.async_step_init(user_input)
-    updated_data = mock_hass.config_entries.async_update_entry.call_args[1]["data"]
-    for k, v in expected_data.items():
-        assert updated_data[k] == v
-    assert result["type"] == FlowResultType.CREATE_ENTRY
-
-
 @pytest.mark.parametrize(
     ("display_options", "expected"),
     [

--- a/tests/test_display_options_integration.py
+++ b/tests/test_display_options_integration.py
@@ -168,11 +168,11 @@ async def render_display_option(
         ("zone_name, place", "not_home, Roy Spiegel MSW, house, 1, Bridge Plaza North"),
         ("formatted_place", "Roy Spiegel MSW, Fort Lee, NJ"),
         (
-            "name_no_dupe, category(-, place), type(-, yes), neighborhood, house_number, street",
+            README_PLACE_ADVANCED,
             "Roy Spiegel MSW, House, Koreatown, 1 Bridge Plaza North",
         ),
         (
-            "zone_name[driving, name_no_dupe[type(-, unclassified, category(-, highway))[category(-, highway)], house_number, route_number(type(+, motorway, trunk))[street[route_number]], neighborhood(type(house))], city_clean[county], state_abbr]",
+            README_FORMATTED_PLACE_ADVANCED,
             "Roy Spiegel MSW, Fort Lee, NJ",
         ),
     ],
@@ -242,19 +242,6 @@ async def test_readme_place_advanced_example_documents_current_output(
     assert basic_state != advanced_state
     assert "Koreatown" in advanced_state
     assert "Koreatown" not in basic_state
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("patch_entity_registry")
-async def test_readme_formatted_place_advanced_example_matches_formatted_place(
-    mock_hass: MagicMock, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """README advanced formatted_place example renders the same value."""
-    formatted_state = await render_display_option(mock_hass, monkeypatch, "formatted_place")
-    advanced_state = await render_display_option(
-        mock_hass, monkeypatch, README_FORMATTED_PLACE_ADVANCED
-    )
-    assert advanced_state == formatted_state
 
 
 def test_readme_display_examples_are_documented() -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -122,22 +122,13 @@ async def test_async_unload_entry_logs_safe_identifier(
 
 
 @pytest.mark.asyncio
-async def test_runtime_data_set_on_entry(mock_hass: MagicMock, mock_entry: MockConfigEntry) -> None:
-    """async_setup_entry should set entry.runtime_data and forward entry setups once."""
-    result = await async_setup_entry(mock_hass, mock_entry)
-    assert result is True
-    assert mock_entry.runtime_data == mock_entry.data
-    # Ensure the coroutine was actually awaited once
-    mock_hass.config_entries.async_forward_entry_setups.assert_awaited_once()
-
-
-@pytest.mark.asyncio
 async def test_async_setup_entry_calls_forward_setups(
     mock_hass: MagicMock, mock_entry: MockConfigEntry
 ) -> None:
-    """Ensure async_setup_entry forwards platform setups to Home Assistant for the given entry."""
+    """Ensure async_setup_entry sets runtime data and forwards platform setups."""
     result = await async_setup_entry(mock_hass, mock_entry)
     assert result is True
+    assert mock_entry.runtime_data == mock_entry.data
     # Verify the async_forward_entry_setups coroutine was awaited with the expected args
     mock_hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(
         mock_entry, PLATFORMS

--- a/tests/test_osm_client.py
+++ b/tests/test_osm_client.py
@@ -43,37 +43,21 @@ def test_reverse_url_matches_nominatim_query_contract() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("url", "cached_payload", "expect_copy"),
+    [
+        ("https://example.test/osm", {"place_id": 123}, False),
+        ("https://example.test/osm-list", [{"place_id": 123}], True),
+    ],
+)
 async def test_get_json_uses_existing_cache_without_network(
-    mock_hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+    mock_hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    url: str,
+    cached_payload: object,
+    expect_copy: bool,
 ) -> None:
     """Cached OSM payloads are returned without session calls."""
-    mock_hass.data = {
-        DOMAIN: {
-            OSM_CACHE: {"https://example.test/osm": {"place_id": 123}},
-            OSM_THROTTLE: {"lock": None, "last_query": 0.0},
-        }
-    }
-
-    client_session_getter = AsyncMock()
-    monkeypatch.setattr(
-        "custom_components.places.osm_client.async_get_clientsession",
-        client_session_getter,
-    )
-
-    client = OSMClient(hass=mock_hass, sensor_name="TestSensor")
-    result = await client.get_json(url="https://example.test/osm", name="OpenStreetMaps")
-
-    assert result == {"place_id": 123}
-    client_session_getter.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_get_json_returns_list_cache_copy(
-    mock_hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Cached list payloads are copied before being returned."""
-    url = "https://example.test/osm-list"
-    cached_payload = [{"place_id": 123}]
     mock_hass.data = {
         DOMAIN: {
             OSM_CACHE: {url: cached_payload},
@@ -91,7 +75,8 @@ async def test_get_json_returns_list_cache_copy(
     result = await client.get_json(url=url, name="OpenStreetMaps")
 
     assert result == cached_payload
-    assert result is not cached_payload
+    if expect_copy:
+        assert result is not cached_payload
     client_session_getter.assert_not_called()
 
 

--- a/tests/test_parse_osm.py
+++ b/tests/test_parse_osm.py
@@ -320,19 +320,10 @@ async def test_parse_miscellaneous_osm_id_prefers_argument_over_sensor_state(
 
 
 @pytest.mark.asyncio
-async def test_set_city_details_sets_city_clean(osm_parser: OSMParserFactory) -> None:
-    """set_city_details should compute a cleaned city value and set ATTR_CITY_CLEAN accordingly."""
-    address = {"city": "City of Springfield"}
-    parser, sensor = osm_parser()
-    await parser.set_city_details(address)
-    assert ATTR_CITY_CLEAN in sensor.attrs
-    assert "Springfield" in sensor.attrs[ATTR_CITY_CLEAN]
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("address", "expected_city", "expected_city_clean"),
     [
+        ({"city": "City of Springfield"}, "City of Springfield", "Springfield City"),
         ({"city": "Springfield Township"}, "Springfield Township", "Springfield"),
         ({"city": "Springfield"}, "Springfield", "Springfield"),
         ({"town": "Shelbyville"}, "Shelbyville", "Shelbyville"),

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -202,32 +202,24 @@ async def test_load_migrates_valid_legacy_json(
 
 
 @pytest.mark.asyncio
-async def test_load_keeps_legacy_json_when_store_save_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Migration returns legacy data and preserves JSON when Store persistence fails."""
-    monkeypatch.setattr("custom_components.places.persistence.Store", _FakeStore)
-    _FakeStore.save_error = OSError("store save failed")
-    hass = _hass_for_legacy_path(tmp_path)
-    legacy_file = legacy_json_path(hass, "entry-4")
-    legacy_file.parent.mkdir(parents=True)
-    legacy_file.write_text(json.dumps({ATTR_CITY: "Legacy City", "unknown": "ignored"}))
-
-    storage = PlacesStorage(hass, "entry-4", "Test")
-    loaded = await storage.async_load()
-
-    assert loaded == {ATTR_CITY: "Legacy City"}
-    assert legacy_file.exists()
-    assert _FakeStore.last_saved is None
-
-
-@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("save_error", "save_without_write", "expected_last_saved"),
+    [
+        (OSError("store save failed"), False, None),
+        (None, True, {ATTR_CITY: "Legacy City"}),
+    ],
+)
 async def test_load_keeps_legacy_json_when_store_save_is_not_durable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    save_error: OSError | None,
+    save_without_write: bool,
+    expected_last_saved: dict[str, object] | None,
 ) -> None:
-    """Migration preserves legacy JSON when Store save returns without a file write."""
+    """Migration preserves legacy JSON when Store data is not durably saved."""
     monkeypatch.setattr("custom_components.places.persistence.Store", _FakeStore)
-    _FakeStore.save_without_write = True
+    _FakeStore.save_error = save_error
+    _FakeStore.save_without_write = save_without_write
     hass = _hass_for_legacy_path(tmp_path)
     legacy_file = legacy_json_path(hass, "entry-4")
     legacy_file.parent.mkdir(parents=True)
@@ -238,7 +230,7 @@ async def test_load_keeps_legacy_json_when_store_save_is_not_durable(
 
     assert loaded == {ATTR_CITY: "Legacy City"}
     assert legacy_file.exists()
-    assert _FakeStore.last_saved == {ATTR_CITY: "Legacy City"}
+    assert _FakeStore.last_saved == expected_last_saved
 
 
 @pytest.mark.asyncio
@@ -371,34 +363,14 @@ async def test_load_degrades_when_legacy_read_raises_oserror(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("remove_error", [None, OSError("store remove failed")])
 async def test_load_ignores_non_mapping_store_data_and_migrates_legacy(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, remove_error: OSError | None
 ) -> None:
     """Invalid Store snapshots are removed and legacy JSON is migrated when available."""
     monkeypatch.setattr("custom_components.places.persistence.Store", _FakeStore)
     _FakeStore.next_data = ["bad", "payload"]
-    hass = _hass_for_legacy_path(tmp_path)
-    legacy_file = legacy_json_path(hass, "entry-8")
-    legacy_file.parent.mkdir(parents=True)
-    legacy_file.write_text(json.dumps({ATTR_CITY: "Legacy City", "unknown": "ignored"}))
-
-    storage = PlacesStorage(hass, "entry-8", "Test")
-    loaded = await storage.async_load()
-
-    assert loaded == {ATTR_CITY: "Legacy City"}
-    assert _FakeStore.remove_calls == 1
-    assert _FakeStore.last_saved == {ATTR_CITY: "Legacy City"}
-    assert not legacy_file.exists()
-
-
-@pytest.mark.asyncio
-async def test_load_migrates_legacy_when_invalid_store_cleanup_fails(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Invalid Store cleanup failures do not prevent legacy JSON migration."""
-    monkeypatch.setattr("custom_components.places.persistence.Store", _FakeStore)
-    _FakeStore.next_data = ["bad", "payload"]
-    _FakeStore.remove_error = OSError("store remove failed")
+    _FakeStore.remove_error = remove_error
     hass = _hass_for_legacy_path(tmp_path)
     legacy_file = legacy_json_path(hass, "entry-8")
     legacy_file.parent.mkdir(parents=True)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -259,14 +259,21 @@ def test_import_persisted_attributes(
     assert "d" not in places_instance._internal_attr
 
 
-def test_get_attr_returns_default(places_instance: Places) -> None:
-    """Test that get_attr returns the specified default value when the attribute is missing."""
-    assert places_instance.get_attr("missing", default="default") == "default"
-
-
-def test_get_attr_none_when_blank_and_no_default(places_instance: Places) -> None:
-    """Test that get_attr returns None when the attribute is missing and no default is provided."""
-    assert places_instance.get_attr("missing") is None
+@pytest.mark.parametrize(
+    ("default", "expected"),
+    [
+        ("default", "default"),
+        (None, None),
+    ],
+)
+def test_get_attr_returns_default_for_missing_attribute(
+    places_instance: Places, default: str | None, expected: str | None
+) -> None:
+    """Test that get_attr returns the expected value when the attribute is missing."""
+    if default is None:
+        assert places_instance.get_attr("missing") is expected
+    else:
+        assert places_instance.get_attr("missing", default=default) == expected
 
 
 def test_set_attr_overwrites_value(places_instance: Places) -> None:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -551,41 +551,6 @@ async def test_async_setup_entry_places_param(
     assert kwargs.get("update_before_add") is True
 
 
-def test_exclude_event_types_adds_event() -> None:
-    """Test that exclude_event_types adds EVENT_TYPE to the recorder's exclude_event_types set."""
-
-    class Recorder:
-        """Minimal recorder object exposing the event exclusion set."""
-
-        def __init__(self) -> None:
-            """Initialize an empty set of excluded event types."""
-            self.exclude_event_types: set[str] = set()
-
-    recorder = Recorder()
-    hass = MagicMock()
-    hass.data = {RECORDER_INSTANCE: recorder}
-    places_instance = MagicMock(spec=Places)
-    places_instance._hass = hass
-    places_instance.get_attr = MagicMock(return_value="TestName")
-    Places.exclude_event_types(places_instance)
-
-    # Assert EVENT_TYPE was added
-    assert EVENT_TYPE in recorder.exclude_event_types
-
-
-def test_exclude_event_types_no_recorder() -> None:
-    """Test that exclude_event_types does nothing when no recorder instance is present in hass.data."""
-    hass = MagicMock()
-    hass.data = {}
-    places_instance = MagicMock(spec=Places)
-    places_instance._hass = hass
-    places_instance.get_attr = MagicMock(return_value="TestName")
-    Places.exclude_event_types(places_instance)
-
-    # Nothing should happen, no error
-    assert RECORDER_INSTANCE not in hass.data
-
-
 @pytest.mark.parametrize(
     ("recorder_present", "expected_in_set"),
     [

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -195,19 +195,14 @@ async def _assert_tracker_state_can_proceed_with_coordinates(
     assert result is UpdateStatus.PROCEED
 
 
-async def test_tracker_state_object_unknown_with_coordinates_can_proceed(
-    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
+@pytest.mark.parametrize("tracker_state", [STATE_UNKNOWN, STATE_UNAVAILABLE])
+async def test_tracker_state_object_with_coordinates_can_proceed(
+    mock_hass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    sensor: MockSensor,
+    tracker_state: str,
 ) -> None:
     """HA state-like objects with unknown/unavailable state still use coordinates."""
     await _assert_tracker_state_can_proceed_with_coordinates(
-        mock_hass, mock_config_entry, sensor, STATE_UNKNOWN
-    )
-
-
-async def test_tracker_state_object_unavailable_with_coordinates_can_proceed(
-    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
-) -> None:
-    """HA state-like objects with unavailable state still use coordinates."""
-    await _assert_tracker_state_can_proceed_with_coordinates(
-        mock_hass, mock_config_entry, sensor, STATE_UNAVAILABLE
+        mock_hass, mock_config_entry, sensor, tracker_state
     )

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -50,34 +50,34 @@ class _TrackerAttributesWithoutDefault:
         return self._values.get(key)
 
 
-async def test_tracker_missing_skips_update(
-    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
-) -> None:
-    """Missing tracked entities skip update without coordinates."""
-    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.missing"
-    mock_hass.states.get.return_value = None
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-
-    result = await updater.is_devicetracker_set()
-
-    assert result is UpdateStatus.SKIP
-
-
-@pytest.mark.parametrize("missing_tracker_id", [None, ""])
-async def test_tracker_blank_id_skips_without_state_lookup(
+@pytest.mark.parametrize(
+    ("tracker_id", "state_lookup_result", "expect_state_lookup"),
+    [
+        ("device_tracker.missing", None, True),
+        (None, None, False),
+        ("", None, False),
+    ],
+)
+async def test_tracker_missing_or_blank_id_skips_update(
     mock_hass: MagicMock,
     mock_config_entry: MockConfigEntry,
     sensor: MockSensor,
-    missing_tracker_id: str | None,
+    tracker_id: str | None,
+    state_lookup_result: object | None,
+    expect_state_lookup: bool,
 ) -> None:
-    """Blank tracked entity IDs skip update before querying HA states."""
-    sensor.attrs[CONF_DEVICETRACKER_ID] = missing_tracker_id
+    """Missing entities and blank tracked entity IDs skip updates."""
+    sensor.attrs[CONF_DEVICETRACKER_ID] = tracker_id
+    mock_hass.states.get.return_value = state_lookup_result
     updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
 
     result = await updater.is_devicetracker_set()
 
     assert result is UpdateStatus.SKIP
-    mock_hass.states.get.assert_not_called()
+    if expect_state_lookup:
+        mock_hass.states.get.assert_called_once_with(tracker_id)
+    else:
+        mock_hass.states.get.assert_not_called()
 
 
 async def test_tracker_invalid_coordinates_skip_update(

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -1106,6 +1106,7 @@ async def test_is_tracker_available_param(
     [
         (None, False),
         ({CONF_LATITUDE: None, CONF_LONGITUDE: None}, False),
+        ({CONF_LATITUDE: "a", CONF_LONGITUDE: 2.0}, False),
         ({CONF_LATITUDE: 1.0, CONF_LONGITUDE: 2.0}, True),
     ],
 )
@@ -1825,19 +1826,6 @@ async def test_is_tracker_available_valid(
     mock_hass.states.get.return_value = state
     result = await updater.is_tracker_available()
     assert result is True
-
-
-@pytest.mark.asyncio
-async def test_has_valid_coordinates_non_numeric(
-    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
-) -> None:
-    """Returns False when latitude not numeric though attribute exists."""
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-    tracker = MagicMock()
-    tracker.attributes = {CONF_LATITUDE: "a", CONF_LONGITUDE: 2.0}
-    mock_hass.states.get.return_value = tracker
-    result = await updater.has_valid_coordinates()
-    assert result is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -313,8 +313,7 @@ async def test_check_device_tracker_and_update_coords_param(
         result = await updater.check_device_tracker_and_update_coords()
     assert result == expected
     mocks["update_coordinates"].assert_awaited_once()
-    if gps_result == UpdateStatus.PROCEED:
-        mocks["get_gps_accuracy"].assert_awaited_once()
+    mocks["get_gps_accuracy"].assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -375,6 +374,8 @@ async def test_get_gps_accuracy_variants(
 
     result = await updater.get_gps_accuracy()
     assert result == expected
+    if tracker_attrs is not None:
+        assert sensor.attrs[ATTR_GPS_ACCURACY] == float(tracker_attrs[ATTR_GPS_ACCURACY])
 
 
 @pytest.mark.asyncio
@@ -1386,67 +1387,6 @@ async def test_calculate_travel_distance_variants(
         for call in sensor.set_attr.call_args_list
     )
     assert found
-
-
-@pytest.mark.asyncio
-async def test_get_gps_accuracy_zero_accuracy_skip(
-    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
-) -> None:
-    """GPS accuracy 0 with use_gps True causes SKIP."""
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-    tracker_state = MagicMock()
-    tracker_state.attributes = {ATTR_GPS_ACCURACY: 0}
-    mock_hass.states.get.return_value = tracker_state
-    # Populate required attributes
-    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.test"
-    sensor.attrs[CONF_USE_GPS] = True
-    # is_attr_blank should evaluate based on actual attrs (don't force False globally)
-    sensor.is_attr_blank.side_effect = lambda k: (
-        k not in sensor.attrs
-        or sensor.attrs.get(k)
-        in (
-            None,
-            "",
-        )
-    )
-    result = await updater.get_gps_accuracy()
-    assert result == UpdateStatus.SKIP
-
-
-@pytest.mark.asyncio
-async def test_check_device_tracker_and_update_coords_get_gps_accuracy_skip(
-    mock_hass: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    sensor: MockSensor,
-    stubbed_updater: StubbedUpdater,
-) -> None:
-    """If get_gps_accuracy returns SKIP that status is propagated."""
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-    with stubbed_updater(
-        updater,
-        [
-            ("is_devicetracker_set", {"return_value": UpdateStatus.PROCEED}),
-            ("update_coordinates", {}),
-            ("get_gps_accuracy", {"return_value": UpdateStatus.SKIP}),
-        ],
-    ) as mocks:
-        result = await updater.check_device_tracker_and_update_coords()
-    assert result == UpdateStatus.SKIP
-    mocks["update_coordinates"].assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_update_coordinates_device_tracker_missing(
-    mock_hass: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
-    sensor: MockSensor,
-) -> None:
-    """update_coordinates logs warning and returns when tracker missing."""
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-    mock_hass.states.get.return_value = None
-    await updater.update_coordinates()
-    assert any("Device tracker entity not found" in r.message for r in caplog.records)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Simplifies the test suite by removing redundant one-off tests and folding duplicated scenarios into existing parameterized coverage. This keeps behavior coverage intact while reducing test maintenance noise.

## What Changed
- Removed duplicate tests already covered by parameterized cases in sensor, tracker, update sensor, integration, config flow, display option, parse OSM, persistence, and OSM client tests.
- Added missing parameter rows where one-off edge cases had useful assertions, including GPS accuracy, nonnumeric coordinates, legacy persistence failure modes, cached OSM payload shapes, tracker state variants, and city-clean normalization.
- Preserved specific regression assertions while consolidating repeated setup and duplicated test bodies.

## Why
The suite had several AI-generated cleanup candidates: standalone tests that repeated the same setup and behavior already covered elsewhere, plus adjacent tests differing only by one input value.

Parameterizing those cases keeps the coverage explicit while making the suite easier to scan and maintain.
