### PR TITLE
Migrate legacy Places snapshots to Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 .tox
 .venv
 .vscode
+.worktrees/
 [Dd]esktop.ini
 *.lnk
 *.pyc

--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -24,6 +24,7 @@ from .const import (
     PLATFORMS,
 )
 from .coordinator import PlacesUpdateCoordinator
+from .migration import async_migrate_legacy_snapshot
 from .persistence import PlacesStorage
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -51,6 +52,25 @@ def _ensure_osm_runtime_state(hass: HomeAssistant) -> None:
             "last_query": 0.0,
         },
     )
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate a Places config entry to the current version.
+
+    Args:
+        hass: Home Assistant instance.
+        entry: Config entry to migrate.
+
+    Returns:
+        ``True`` when migration completes.
+    """
+    if entry.version != 1:
+        return True
+
+    name = entry.data.get(CONF_NAME, entry.entry_id)
+    await async_migrate_legacy_snapshot(hass, entry.entry_id, name)
+    hass.config_entries.async_update_entry(entry, version=2, minor_version=1)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/places/config_flow.py
+++ b/custom_components/places/config_flow.py
@@ -380,7 +380,7 @@ async def validate_display_options(display_options: str, errors: dict[str, Any])
 class PlacesConfigFlow(ConfigFlow, domain=DOMAIN):
     """Create new Places config entries from UI input."""
 
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: MutableMapping[str, Any] | None = None

--- a/custom_components/places/migration.py
+++ b/custom_components/places/migration.py
@@ -88,9 +88,7 @@ def _remove_legacy_snapshot(path: Path, name: str) -> None:
 
     """
     try:
-        path.unlink()
-    except FileNotFoundError:
-        pass
+        path.unlink(missing_ok=True)
     except OSError as error:
         _LOGGER.warning(
             "(%s) Could not remove legacy snapshot (%s): %s: %s",

--- a/custom_components/places/migration.py
+++ b/custom_components/places/migration.py
@@ -1,0 +1,188 @@
+"""Migrate legacy Places JSON snapshots to Home Assistant Store."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import errno
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.storage import Store
+from homeassistant.util import slugify
+
+from .const import DOMAIN
+from .persistence import STORE_VERSION, STORE_WRITE_ERRORS, normalize_snapshot, store_key
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def legacy_json_path(hass: HomeAssistant, entry_id: str) -> Path:
+    """Return the legacy JSON snapshot path for a config entry.
+
+    Args:
+        hass: Home Assistant instance.
+        entry_id: Config entry ID used for the legacy filename.
+
+    Returns:
+        Path to the legacy JSON snapshot.
+    """
+    return Path(
+        hass.config.path(
+            "custom_components",
+            DOMAIN,
+            "json_sensors",
+            f"{DOMAIN}-{slugify(entry_id)}.json",
+        )
+    )
+
+
+def _read_legacy_snapshot(path: Path, name: str) -> Mapping[str, Any] | None:
+    """Read a legacy JSON snapshot when it is valid.
+
+    Args:
+        path: Legacy JSON snapshot path.
+        name: Sensor name used for contextual logging.
+
+    Returns:
+        Snapshot mapping, or ``None`` when missing or invalid.
+
+    Raises:
+        OSError: If the snapshot cannot be read for a reason other than absence.
+    """
+    try:
+        with path.open(encoding="utf-8") as snapshot_file:
+            snapshot = json.load(snapshot_file)
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        _LOGGER.warning(
+            "(%s) Invalid legacy snapshot (%s): %s: %s",
+            name,
+            path,
+            type(error).__name__,
+            error,
+        )
+        return None
+
+    if not isinstance(snapshot, Mapping):
+        _LOGGER.warning(
+            "(%s) Invalid legacy snapshot root (%s): %s",
+            name,
+            path,
+            type(snapshot).__name__,
+        )
+        return None
+    return snapshot
+
+
+def _remove_legacy_snapshot(path: Path, name: str) -> bool:
+    """Remove a legacy snapshot and its directory when empty.
+
+    Args:
+        path: Legacy JSON snapshot path.
+        name: Sensor name used for contextual logging.
+
+    Returns:
+        Whether cleanup completed without an unexpected filesystem error.
+    """
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError as error:
+        _LOGGER.warning(
+            "(%s) Could not remove legacy snapshot (%s): %s: %s",
+            name,
+            path,
+            type(error).__name__,
+            error,
+        )
+        return False
+
+    try:
+        path.parent.rmdir()
+    except FileNotFoundError:
+        pass
+    except OSError as error:
+        if error.errno != errno.ENOTEMPTY:
+            _LOGGER.warning(
+                "(%s) Could not remove legacy snapshot directory (%s): %s: %s",
+                name,
+                path.parent,
+                type(error).__name__,
+                error,
+            )
+            return False
+    return True
+
+
+async def async_migrate_legacy_snapshot(hass: HomeAssistant, entry_id: str, name: str) -> None:
+    """Migrate one legacy JSON snapshot to Home Assistant Store.
+
+    Args:
+        hass: Home Assistant instance.
+        entry_id: Config entry ID used for persistence naming.
+        name: Sensor name used for contextual logging.
+    """
+    path = legacy_json_path(hass, entry_id)
+    store: Store[dict[str, Any]] = Store(
+        hass,
+        STORE_VERSION,
+        store_key(entry_id),
+        atomic_writes=True,
+        serialize_in_event_loop=False,
+    )
+    try:
+        try:
+            store_data = await store.async_load()
+        except (*STORE_WRITE_ERRORS, HomeAssistantError) as error:
+            _LOGGER.warning(
+                "(%s) Could not load Store before migrating %s: %s: %s",
+                name,
+                path,
+                type(error).__name__,
+                error,
+            )
+            return
+        if store_data is not None:
+            return
+
+        try:
+            snapshot = await hass.async_add_executor_job(_read_legacy_snapshot, path, name)
+        except OSError as error:
+            _LOGGER.warning(
+                "(%s) Could not read legacy snapshot (%s): %s: %s",
+                name,
+                path,
+                type(error).__name__,
+                error,
+            )
+            return
+        if snapshot is None:
+            return
+
+        try:
+            await store.async_save(normalize_snapshot(snapshot))
+        except STORE_WRITE_ERRORS as error:
+            _LOGGER.warning(
+                "(%s) Could not save migrated snapshot (%s): %s: %s",
+                name,
+                path,
+                type(error).__name__,
+                error,
+            )
+    finally:
+        try:
+            await hass.async_add_executor_job(_remove_legacy_snapshot, path, name)
+        except OSError as error:
+            _LOGGER.warning(
+                "(%s) Could not clean up legacy snapshot (%s): %s: %s",
+                name,
+                path,
+                type(error).__name__,
+                error,
+            )

--- a/custom_components/places/migration.py
+++ b/custom_components/places/migration.py
@@ -14,7 +14,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.storage import Store
 from homeassistant.util import slugify
 
-from .const import DOMAIN
+from .const import ATTR_DISTANCE_FROM_HOME, ATTR_DISTANCE_TRAVELED, DOMAIN
 from .persistence import STORE_VERSION, STORE_WRITE_ERRORS, normalize_snapshot, store_key
 
 _LOGGER = logging.getLogger(__name__)
@@ -149,7 +149,14 @@ async def async_migrate_legacy_snapshot(hass: HomeAssistant, entry_id: str, name
             )
             return
         if store_data is not None:
-            return
+            if isinstance(store_data, Mapping):
+                return
+            _LOGGER.warning(
+                "(%s) Invalid Store snapshot root is %s; continuing legacy migration (%s)",
+                name,
+                type(store_data).__name__,
+                path,
+            )
 
         try:
             snapshot = await hass.async_add_executor_job(_read_legacy_snapshot, path, name)
@@ -166,6 +173,11 @@ async def async_migrate_legacy_snapshot(hass: HomeAssistant, entry_id: str, name
             return
 
         try:
+            snapshot = dict(snapshot)
+            if ATTR_DISTANCE_FROM_HOME not in snapshot and "distance_from_home_m" in snapshot:
+                snapshot[ATTR_DISTANCE_FROM_HOME] = snapshot["distance_from_home_m"]
+            if ATTR_DISTANCE_TRAVELED not in snapshot and "distance_traveled_m" in snapshot:
+                snapshot[ATTR_DISTANCE_TRAVELED] = snapshot["distance_traveled_m"]
             await store.async_save(normalize_snapshot(snapshot))
         except STORE_WRITE_ERRORS as error:
             _LOGGER.warning(

--- a/custom_components/places/migration.py
+++ b/custom_components/places/migration.py
@@ -139,7 +139,12 @@ async def async_migrate_legacy_snapshot(hass: HomeAssistant, entry_id: str, name
     try:
         try:
             store_data = await store.async_load()
-        except (*STORE_WRITE_ERRORS, HomeAssistantError) as error:
+        except (
+            *STORE_WRITE_ERRORS,
+            HomeAssistantError,
+            KeyError,
+            NotImplementedError,
+        ) as error:
             _LOGGER.warning(
                 "(%s) Could not load Store before migrating %s: %s: %s",
                 name,

--- a/custom_components/places/migration.py
+++ b/custom_components/places/migration.py
@@ -79,15 +79,13 @@ def _read_legacy_snapshot(path: Path, name: str) -> Mapping[str, Any] | None:
     return snapshot
 
 
-def _remove_legacy_snapshot(path: Path, name: str) -> bool:
+def _remove_legacy_snapshot(path: Path, name: str) -> None:
     """Remove a legacy snapshot and its directory when empty.
 
     Args:
         path: Legacy JSON snapshot path.
         name: Sensor name used for contextual logging.
 
-    Returns:
-        Whether cleanup completed without an unexpected filesystem error.
     """
     try:
         path.unlink()
@@ -101,7 +99,7 @@ def _remove_legacy_snapshot(path: Path, name: str) -> bool:
             type(error).__name__,
             error,
         )
-        return False
+        return
 
     try:
         path.parent.rmdir()
@@ -116,8 +114,7 @@ def _remove_legacy_snapshot(path: Path, name: str) -> bool:
                 type(error).__name__,
                 error,
             )
-            return False
-    return True
+            return
 
 
 async def async_migrate_legacy_snapshot(hass: HomeAssistant, entry_id: str, name: str) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.places import (
     _ensure_osm_runtime_state,
+    async_migrate_entry,
     async_remove_entry,
     async_remove_extended_entity,
     async_setup_entry,
@@ -119,6 +120,44 @@ def reset_fake_storage() -> None:
     _FakeSetupPlacesStorage.instances = []
     _FakeSetupPlacesStorage.load_result = {}
     _FakeCoordinator.instances = []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("version", "update_calls"), [(1, 1), (2, 0)])
+async def test_async_migrate_entry_gates_legacy_snapshot_migration_by_version(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_hass: MagicMock,
+    version: int,
+    update_calls: int,
+) -> None:
+    """Config-entry migration should run only for legacy entry versions."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=version,
+        data={CONF_NAME: "Test Place"},
+    )
+    migrate_legacy_snapshot = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.places.async_migrate_legacy_snapshot",
+        migrate_legacy_snapshot,
+    )
+
+    result = await async_migrate_entry(mock_hass, entry)
+
+    assert result is True
+    assert migrate_legacy_snapshot.await_count == update_calls
+    assert mock_hass.config_entries.async_update_entry.call_count == update_calls
+    if version == 1:
+        migrate_legacy_snapshot.assert_awaited_once_with(
+            mock_hass,
+            entry.entry_id,
+            "Test Place",
+        )
+        mock_hass.config_entries.async_update_entry.assert_called_once_with(
+            entry,
+            version=2,
+            minor_version=1,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,3 +1,4 @@
+# mypy: disable-error-code="func-returns-value"
 """Tests for one-time legacy JSON snapshot migration."""
 
 from __future__ import annotations
@@ -7,10 +8,11 @@ from pathlib import Path
 from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
-from custom_components.places.migration import async_migrate_legacy_snapshot, legacy_json_path
+from homeassistant.exceptions import HomeAssistantError
 import pytest
 
 from custom_components.places.const import ATTR_CITY
+from custom_components.places.migration import async_migrate_legacy_snapshot, legacy_json_path
 
 
 class _FakeStore:
@@ -18,6 +20,7 @@ class _FakeStore:
 
     next_data: object | None = None
     saved: ClassVar[list[dict[str, object]]] = []
+    load_error: ClassVar[HomeAssistantError | None] = None
     save_error: OSError | None = None
 
     def __init__(
@@ -35,6 +38,9 @@ class _FakeStore:
 
     async def async_load(self) -> object | None:
         """Return configured Store data."""
+        load_error = type(self).load_error
+        if load_error is not None:
+            raise load_error
         return type(self).next_data
 
     async def async_save(self, data: dict[str, object]) -> None:
@@ -50,6 +56,7 @@ def reset_fake_store_state() -> None:
     """Reset shared fake Store state for each test."""
     _FakeStore.next_data = None
     _FakeStore.saved = []
+    _FakeStore.load_error = None
     _FakeStore.save_error = None
 
 
@@ -108,6 +115,25 @@ async def test_unusable_snapshot_is_removed_without_save(
 
 
 @pytest.mark.asyncio
+async def test_invalid_utf8_snapshot_is_removed_without_save(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A snapshot containing invalid UTF-8 is discarded without a Store write."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry-invalid-utf8")
+    path.parent.mkdir(parents=True)
+    path.write_bytes(b"\xff")
+
+    result = await async_migrate_legacy_snapshot(hass, "entry-invalid-utf8", "Test Place")
+
+    assert result is None
+    assert _FakeStore.saved == []
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+@pytest.mark.asyncio
 async def test_store_write_error_still_removes_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -119,6 +145,25 @@ async def test_store_write_error_still_removes_snapshot(
     _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
 
     result = await async_migrate_legacy_snapshot(hass, "entry-3", "Test Place")
+
+    assert result is None
+    assert _FakeStore.saved == []
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_store_load_error_still_removes_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Store load failure does not leave the legacy source behind."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    _FakeStore.load_error = HomeAssistantError("load failed")
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry-load-error")
+    _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
+
+    result = await async_migrate_legacy_snapshot(hass, "entry-load-error", "Test Place")
 
     assert result is None
     assert _FakeStore.saved == []

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -10,7 +10,11 @@ from unittest.mock import AsyncMock, MagicMock
 from homeassistant.exceptions import HomeAssistantError
 import pytest
 
-from custom_components.places.const import ATTR_CITY
+from custom_components.places.const import (
+    ATTR_CITY,
+    ATTR_DISTANCE_FROM_HOME,
+    ATTR_DISTANCE_TRAVELED,
+)
 from custom_components.places.migration import async_migrate_legacy_snapshot, legacy_json_path
 
 
@@ -187,6 +191,56 @@ async def test_existing_store_data_wins_and_legacy_snapshot_is_removed(
     await async_migrate_legacy_snapshot(hass, "entry-4", "Test Place")
 
     assert _FakeStore.saved == []
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_invalid_store_data_is_replaced_by_legacy_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-mapping Store root does not discard a valid legacy snapshot."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    _FakeStore.next_data = ["invalid"]
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry-invalid-store")
+    _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
+
+    await async_migrate_legacy_snapshot(hass, "entry-invalid-store", "Test Place")
+
+    assert _FakeStore.saved == [{ATTR_CITY: "Legacy City"}]
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_legacy_distance_keys_are_normalized_before_store_save(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Legacy meter distance keys are copied to the current persisted names."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry-distance")
+    _write_legacy_snapshot(
+        path,
+        json.dumps(
+            {
+                ATTR_CITY: "Legacy City",
+                "distance_from_home_m": 12.5,
+                "distance_traveled_m": 3.25,
+            }
+        ),
+    )
+
+    await async_migrate_legacy_snapshot(hass, "entry-distance", "Test Place")
+
+    assert _FakeStore.saved == [
+        {
+            ATTR_CITY: "Legacy City",
+            ATTR_DISTANCE_FROM_HOME: 12.5,
+            ATTR_DISTANCE_TRAVELED: 3.25,
+        }
+    ]
     assert not path.exists()
     assert not path.parent.exists()
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,161 @@
+"""Tests for one-time legacy JSON snapshot migration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.places.migration import async_migrate_legacy_snapshot, legacy_json_path
+import pytest
+
+from custom_components.places.const import ATTR_CITY
+
+
+class _FakeStore:
+    """Small Store test double for legacy snapshot migration."""
+
+    next_data: object | None = None
+    saved: ClassVar[list[dict[str, object]]] = []
+    save_error: OSError | None = None
+
+    def __init__(
+        self,
+        _hass: MagicMock,
+        _version: int,
+        _key: str,
+        *,
+        atomic_writes: bool,
+        serialize_in_event_loop: bool,
+    ) -> None:
+        """Initialize the fake with the Store constructor contract."""
+        self.atomic_writes = atomic_writes
+        self.serialize_in_event_loop = serialize_in_event_loop
+
+    async def async_load(self) -> object | None:
+        """Return configured Store data."""
+        return type(self).next_data
+
+    async def async_save(self, data: dict[str, object]) -> None:
+        """Record saved data or raise the configured write error."""
+        save_error = type(self).save_error
+        if save_error is not None:
+            raise save_error
+        type(self).saved.append(data)
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_store_state() -> None:
+    """Reset shared fake Store state for each test."""
+    _FakeStore.next_data = None
+    _FakeStore.saved = []
+    _FakeStore.save_error = None
+
+
+def _hass_for_legacy_path(tmp_path: Path) -> MagicMock:
+    """Return a Home Assistant mock with config path and executor passthrough."""
+    hass = MagicMock()
+    hass.config.path.side_effect = lambda *parts: str(tmp_path.joinpath(*parts))
+    hass.async_add_executor_job = AsyncMock(side_effect=lambda func, *args: func(*args))
+    return hass
+
+
+def _write_legacy_snapshot(path: Path, contents: str) -> None:
+    """Write a legacy snapshot and create its containing folder."""
+    path.parent.mkdir(parents=True)
+    path.write_text(contents)
+
+
+@pytest.mark.asyncio
+async def test_valid_snapshot_is_saved_then_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A valid legacy object is normalized, saved, and removed."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry 1")
+    _write_legacy_snapshot(
+        path,
+        json.dumps({ATTR_CITY: "Legacy City", "unknown": "ignored"}),
+    )
+
+    result = await async_migrate_legacy_snapshot(hass, "entry 1", "Test Place")
+
+    assert result is None
+    assert _FakeStore.saved == [{ATTR_CITY: "Legacy City"}]
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("contents", ["{", json.dumps(["not", "an", "object"])])
+async def test_unusable_snapshot_is_removed_without_save(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, contents: str
+) -> None:
+    """Malformed and non-object snapshots are discarded without a Store write."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry-2")
+    _write_legacy_snapshot(path, contents)
+
+    result = await async_migrate_legacy_snapshot(hass, "entry-2", "Test Place")
+
+    assert result is None
+    assert _FakeStore.saved == []
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_store_write_error_still_removes_snapshot(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Store write failure does not leave the legacy source behind."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    _FakeStore.save_error = OSError("write failed")
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry-3")
+    _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
+
+    result = await async_migrate_legacy_snapshot(hass, "entry-3", "Test Place")
+
+    assert result is None
+    assert _FakeStore.saved == []
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_existing_store_data_wins_and_legacy_snapshot_is_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Existing Store data prevents stale JSON from being saved."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    _FakeStore.next_data = {}
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry-4")
+    _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
+
+    result = await async_migrate_legacy_snapshot(hass, "entry-4", "Test Place")
+
+    assert result is None
+    assert _FakeStore.saved == []
+    assert not path.exists()
+    assert not path.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_error_is_swallowed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cleanup failure is swallowed after one removal attempt."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    cleanup = MagicMock(side_effect=OSError("cleanup failed"))
+    monkeypatch.setattr("custom_components.places.migration._remove_legacy_snapshot", cleanup)
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry-5")
+    _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
+
+    result = await async_migrate_legacy_snapshot(hass, "entry-5", "Test Place")
+
+    assert result is None
+    cleanup.assert_called_once_with(path, "Test Place")

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -20,7 +20,7 @@ class _FakeStore:
 
     next_data: object | None = None
     saved: ClassVar[list[dict[str, object]]] = []
-    load_error: ClassVar[HomeAssistantError | None] = None
+    load_error: ClassVar[Exception | None] = None
     save_error: OSError | None = None
 
     def __init__(
@@ -153,12 +153,21 @@ async def test_store_write_error_still_removes_snapshot(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "load_error",
+    [
+        HomeAssistantError("load failed"),
+        KeyError("version"),
+        NotImplementedError("migration unsupported"),
+    ],
+    ids=["home-assistant", "missing-version", "unsupported-migration"],
+)
 async def test_store_load_error_still_removes_snapshot(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, load_error: Exception
 ) -> None:
     """A Store load failure does not leave the legacy source behind."""
     monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
-    _FakeStore.load_error = HomeAssistantError("load failed")
+    _FakeStore.load_error = load_error
     hass = _hass_for_legacy_path(tmp_path)
     path = legacy_json_path(hass, "entry-load-error")
     _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -32,8 +32,7 @@ class _FakeStore:
         serialize_in_event_loop: bool,
     ) -> None:
         """Initialize the fake with the Store constructor contract."""
-        self.atomic_writes = atomic_writes
-        self.serialize_in_event_loop = serialize_in_event_loop
+        _ = atomic_writes, serialize_in_event_loop
 
     async def async_load(self) -> object | None:
         """Return configured Store data."""

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,4 +1,3 @@
-# mypy: disable-error-code="func-returns-value"
 """Tests for one-time legacy JSON snapshot migration."""
 
 from __future__ import annotations
@@ -87,9 +86,8 @@ async def test_valid_snapshot_is_saved_then_removed(
         json.dumps({ATTR_CITY: "Legacy City", "unknown": "ignored"}),
     )
 
-    result = await async_migrate_legacy_snapshot(hass, "entry 1", "Test Place")
+    await async_migrate_legacy_snapshot(hass, "entry 1", "Test Place")
 
-    assert result is None
     assert _FakeStore.saved == [{ATTR_CITY: "Legacy City"}]
     assert not path.exists()
     assert not path.parent.exists()
@@ -106,9 +104,8 @@ async def test_unusable_snapshot_is_removed_without_save(
     path = legacy_json_path(hass, "entry-2")
     _write_legacy_snapshot(path, contents)
 
-    result = await async_migrate_legacy_snapshot(hass, "entry-2", "Test Place")
+    await async_migrate_legacy_snapshot(hass, "entry-2", "Test Place")
 
-    assert result is None
     assert _FakeStore.saved == []
     assert not path.exists()
     assert not path.parent.exists()
@@ -125,9 +122,8 @@ async def test_invalid_utf8_snapshot_is_removed_without_save(
     path.parent.mkdir(parents=True)
     path.write_bytes(b"\xff")
 
-    result = await async_migrate_legacy_snapshot(hass, "entry-invalid-utf8", "Test Place")
+    await async_migrate_legacy_snapshot(hass, "entry-invalid-utf8", "Test Place")
 
-    assert result is None
     assert _FakeStore.saved == []
     assert not path.exists()
     assert not path.parent.exists()
@@ -144,9 +140,8 @@ async def test_store_write_error_still_removes_snapshot(
     path = legacy_json_path(hass, "entry-3")
     _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
 
-    result = await async_migrate_legacy_snapshot(hass, "entry-3", "Test Place")
+    await async_migrate_legacy_snapshot(hass, "entry-3", "Test Place")
 
-    assert result is None
     assert _FakeStore.saved == []
     assert not path.exists()
     assert not path.parent.exists()
@@ -172,9 +167,8 @@ async def test_store_load_error_still_removes_snapshot(
     path = legacy_json_path(hass, "entry-load-error")
     _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
 
-    result = await async_migrate_legacy_snapshot(hass, "entry-load-error", "Test Place")
+    await async_migrate_legacy_snapshot(hass, "entry-load-error", "Test Place")
 
-    assert result is None
     assert _FakeStore.saved == []
     assert not path.exists()
     assert not path.parent.exists()
@@ -191,9 +185,8 @@ async def test_existing_store_data_wins_and_legacy_snapshot_is_removed(
     path = legacy_json_path(hass, "entry-4")
     _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
 
-    result = await async_migrate_legacy_snapshot(hass, "entry-4", "Test Place")
+    await async_migrate_legacy_snapshot(hass, "entry-4", "Test Place")
 
-    assert result is None
     assert _FakeStore.saved == []
     assert not path.exists()
     assert not path.parent.exists()
@@ -209,7 +202,6 @@ async def test_cleanup_error_is_swallowed(tmp_path: Path, monkeypatch: pytest.Mo
     path = legacy_json_path(hass, "entry-5")
     _write_legacy_snapshot(path, json.dumps({ATTR_CITY: "Legacy City"}))
 
-    result = await async_migrate_legacy_snapshot(hass, "entry-5", "Test Place")
+    await async_migrate_legacy_snapshot(hass, "entry-5", "Test Place")
 
-    assert result is None
     cleanup.assert_called_once_with(path, "Test Place")

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 from pathlib import Path
 from typing import ClassVar
@@ -15,7 +16,12 @@ from custom_components.places.const import (
     ATTR_DISTANCE_FROM_HOME,
     ATTR_DISTANCE_TRAVELED,
 )
-from custom_components.places.migration import async_migrate_legacy_snapshot, legacy_json_path
+from custom_components.places.migration import (
+    _read_legacy_snapshot,
+    _remove_legacy_snapshot,
+    async_migrate_legacy_snapshot,
+    legacy_json_path,
+)
 
 
 class _FakeStore:
@@ -74,6 +80,65 @@ def _write_legacy_snapshot(path: Path, contents: str) -> None:
     """Write a legacy snapshot and create its containing folder."""
     path.parent.mkdir(parents=True)
     path.write_text(contents)
+
+
+def test_missing_legacy_snapshot_returns_none(tmp_path: Path) -> None:
+    """A missing legacy snapshot is treated as absent."""
+    assert _read_legacy_snapshot(tmp_path / "missing.json", "Test Place") is None
+
+
+def test_snapshot_cleanup_stops_when_unlink_fails() -> None:
+    """A snapshot unlink error prevents the parent directory removal attempt."""
+    path = MagicMock(spec=Path)
+    path.unlink.side_effect = OSError("unlink failed")
+
+    _remove_legacy_snapshot(path, "Test Place")
+
+    path.unlink.assert_called_once_with(missing_ok=True)
+    path.parent.rmdir.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("parent_error", "expected_warning"),
+    [
+        (FileNotFoundError(), False),
+        (OSError(errno.ENOTEMPTY, "directory not empty"), False),
+        (OSError(errno.EACCES, "permission denied"), True),
+    ],
+    ids=["parent-missing", "parent-not-empty", "parent-remove-error"],
+)
+def test_snapshot_cleanup_handles_parent_directory_errors(
+    parent_error: OSError, expected_warning: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Parent directory cleanup errors do not escape migration cleanup."""
+    path = MagicMock(spec=Path)
+    path.parent = MagicMock(spec=Path)
+    path.parent.rmdir.side_effect = parent_error
+
+    _remove_legacy_snapshot(path, "Test Place")
+
+    path.unlink.assert_called_once_with(missing_ok=True)
+    path.parent.rmdir.assert_called_once_with()
+    assert ("Could not remove legacy snapshot directory" in caplog.text) is expected_warning
+
+
+@pytest.mark.asyncio
+async def test_legacy_snapshot_read_error_is_contained(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy snapshot read error is contained and still triggers cleanup."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    read = MagicMock(side_effect=OSError("read failed"))
+    cleanup = MagicMock()
+    monkeypatch.setattr("custom_components.places.migration._read_legacy_snapshot", read)
+    monkeypatch.setattr("custom_components.places.migration._remove_legacy_snapshot", cleanup)
+    hass = _hass_for_legacy_path(tmp_path)
+    path = legacy_json_path(hass, "entry-read-error")
+
+    await async_migrate_legacy_snapshot(hass, "entry-read-error", "Test Place")
+
+    read.assert_called_once_with(path, "Test Place")
+    cleanup.assert_called_once_with(path, "Test Place")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Migrates legacy Places JSON snapshots into Home Assistant Store during the config-entry upgrade from version 1 to version 2.

## What Changed

- Added a one-time Store-first migration for legacy `json_sensors/places-<entry-id>.json` snapshots.
- Preserves valid Store mappings, including an empty mapping, as authoritative.
- Normalizes valid legacy snapshots and translates legacy meter-based distance keys.
- Handles invalid Store roots, missing or malformed JSON, decoding failures, Store errors, and cleanup failures without blocking entry upgrades.
- Removes migrated or unusable legacy files and cleans empty legacy folders.
- Added config-entry version gating and comprehensive migration/version regression tests.
- Added `.worktrees/` to `.gitignore`.

## Why

The revamp uses Store-only runtime persistence. Existing installations need their legacy snapshots moved once without overwriting authoritative Store data or leaving entries stuck after a migration error.

## Validation

- `/Users/snuffy2/GitHub/places/.venv/bin/python -m pytest` — 460 passed in 2.11s, no warnings, 93% coverage.
- `/Users/snuffy2/GitHub/places/.venv/bin/python -m prek run -a` — all configured hooks passed.
- `git diff --check` — passed.