### PR TITLE
Add integration usage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
   <img alt="places Logo" src="https://github.com/custom-components/places/raw/master/logo/icon.png">
 </picture>
 
+[![Integration Usage][integration-usage-shield]][releases]
+
 [![GitHub Downloads][downloads-shield]][releases]
 [![GitHub Latest Downloads][downloads-latest-shield]][releases]
 [![GitHub Release][releases-shield]][releases]
@@ -286,6 +288,7 @@ python -m pip install --group dev -e .
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
 ***
 
+[integration-usage-shield]: https://img.shields.io/badge/dynamic/json?color=41BDF5&logo=home-assistant&label=integration%20usage&suffix=%20installs&cacheSeconds=15600&url=https%3A%2F%2Fanalytics.home-assistant.io%2Fcustom_integrations.json&query=%24.places.total&style=for-the-badge
 [downloads-shield]: https://img.shields.io/github/downloads/custom-components/places/total?style=for-the-badge&label=total%20downloads
 [downloads-latest-shield]: https://img.shields.io/github/downloads-pre/custom-components/places/latest/total?style=for-the-badge
 [releases]: https://github.com/custom-components/places/releases


### PR DESCRIPTION
## Summary

Adds a Home Assistant integration usage badge to the README so visitors can see Places adoption alongside the existing download badges.

## What Changed

- Added a dynamic shields.io badge sourced from Home Assistant analytics.
- Added the badge reference URL to the README link definitions.

## Why

The README already surfaces download metrics; the integration usage badge adds a direct signal of active Home Assistant installs without changing runtime code.

## Validation

- `/Users/snuffy2/GitHub/places/.venv/bin/python -m prek run -a` — all hooks passed.
- `git diff --check upstream/master...HEAD` — passed.