### PR TITLE
Fix legacy distance migration

### DIFF
--- a/custom_components/places/migration.py
+++ b/custom_components/places/migration.py
@@ -20,6 +20,19 @@ from .persistence import STORE_VERSION, STORE_WRITE_ERRORS, normalize_snapshot, 
 _LOGGER = logging.getLogger(__name__)
 
 
+def _normalize_legacy_distance_keys(snapshot: dict[str, Any]) -> bool:
+    """Rename legacy meter distance keys to their current persisted names."""
+    changed = False
+    for legacy_key, current_key in (
+        ("distance_from_home_m", ATTR_DISTANCE_FROM_HOME),
+        ("distance_traveled_m", ATTR_DISTANCE_TRAVELED),
+    ):
+        if legacy_key in snapshot:
+            snapshot.setdefault(current_key, snapshot.pop(legacy_key))
+            changed = True
+    return changed
+
+
 def legacy_json_path(hass: HomeAssistant, entry_id: str) -> Path:
     """Return the legacy JSON snapshot path for a config entry.
 
@@ -150,6 +163,18 @@ async def async_migrate_legacy_snapshot(hass: HomeAssistant, entry_id: str, name
             return
         if store_data is not None:
             if isinstance(store_data, Mapping):
+                stored_snapshot = dict(store_data)
+                if _normalize_legacy_distance_keys(stored_snapshot):
+                    try:
+                        await store.async_save(normalize_snapshot(stored_snapshot))
+                    except STORE_WRITE_ERRORS as error:
+                        _LOGGER.warning(
+                            "(%s) Could not update migrated Store snapshot (%s): %s: %s",
+                            name,
+                            path,
+                            type(error).__name__,
+                            error,
+                        )
                 return
             _LOGGER.warning(
                 "(%s) Invalid Store snapshot root is %s; continuing legacy migration (%s)",
@@ -174,10 +199,7 @@ async def async_migrate_legacy_snapshot(hass: HomeAssistant, entry_id: str, name
 
         try:
             snapshot = dict(snapshot)
-            if ATTR_DISTANCE_FROM_HOME not in snapshot and "distance_from_home_m" in snapshot:
-                snapshot[ATTR_DISTANCE_FROM_HOME] = snapshot["distance_from_home_m"]
-            if ATTR_DISTANCE_TRAVELED not in snapshot and "distance_traveled_m" in snapshot:
-                snapshot[ATTR_DISTANCE_TRAVELED] = snapshot["distance_traveled_m"]
+            _normalize_legacy_distance_keys(snapshot)
             await store.async_save(normalize_snapshot(snapshot))
         except STORE_WRITE_ERRORS as error:
             _LOGGER.warning(

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -261,6 +261,30 @@ async def test_existing_store_data_wins_and_legacy_snapshot_is_removed(
 
 
 @pytest.mark.asyncio
+async def test_existing_store_legacy_distance_keys_are_normalized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Legacy meter distance keys already in Store are migrated in place."""
+    monkeypatch.setattr("custom_components.places.migration.Store", _FakeStore)
+    _FakeStore.next_data = {
+        ATTR_CITY: "Legacy City",
+        "distance_from_home_m": 12.5,
+        "distance_traveled_m": 3.25,
+    }
+    hass = _hass_for_legacy_path(tmp_path)
+
+    await async_migrate_legacy_snapshot(hass, "entry-store-distance", "Test Place")
+
+    assert _FakeStore.saved == [
+        {
+            ATTR_CITY: "Legacy City",
+            ATTR_DISTANCE_FROM_HOME: 12.5,
+            ATTR_DISTANCE_TRAVELED: 3.25,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_invalid_store_data_is_replaced_by_legacy_snapshot(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
Fixes legacy Places distance attributes that remained under their meter-suffixed keys after migration, preventing them from being restored by the redesigned entity model.

## What Changed
- Normalize `distance_from_home_m` and `distance_traveled_m` to their current persisted attribute names during legacy migration
- Repair already-created Store snapshots containing the legacy distance keys
- Preserve canonical distance values when both canonical and legacy keys exist
- Add regression coverage for existing Store snapshots with legacy distance keys

## Why
The migration previously returned immediately whenever Store data already existed. Snapshots created with legacy meter-suffixed distance keys therefore bypassed normalization and the coordinator reported those values as not imported.

Keeping the correction inside the one-time migration preserves the Store-only runtime persistence model and avoids adding legacy aliases to normal coordinator imports.