### PR TITLE
Add missing entity icons

### DIFF
--- a/custom_components/places/entity.py
+++ b/custom_components/places/entity.py
@@ -227,24 +227,29 @@ PLACES_ATTRIBUTE_SENSOR_DESCRIPTIONS: tuple[PlacesAttributeSensorEntityDescripti
     ),
     PlacesAttributeSensorEntityDescription(
         key=ATTR_LATITUDE,
+        icon="mdi:latitude",
         entity_registry_enabled_default=False,
     ),
     PlacesAttributeSensorEntityDescription(
         key=ATTR_LONGITUDE,
+        icon="mdi:longitude",
         entity_registry_enabled_default=False,
     ),
     PlacesAttributeSensorEntityDescription(
         key=ATTR_GPS_ACCURACY,
+        icon="mdi:crosshairs-gps",
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.METERS,
         entity_registry_enabled_default=False,
     ),
     PlacesAttributeSensorEntityDescription(
         key=ATTR_LAST_CHANGED,
+        icon="mdi:timer-refresh",
         entity_registry_enabled_default=False,
     ),
     PlacesAttributeSensorEntityDescription(
         key=ATTR_LAST_UPDATED,
+        icon="mdi:timer",
         entity_registry_enabled_default=False,
     ),
     PlacesAttributeSensorEntityDescription(


### PR DESCRIPTION
## Summary
Adds icons to the disabled-by-default location metadata sensors so they display consistently with the rest of the Places entity set.

## What Changed
- Added latitude and longitude icons
- Added a GPS accuracy icon
- Added distinct icons for last changed and last updated timestamps

## Why
These sensors previously relied on generic Home Assistant presentation despite representing well-known values with standard Material Design Icons.