### PR TITLE
Remove do_not_reorder display option

### DIFF
--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -12,8 +12,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 
 from .const import (
+    CONF_DISPLAY_OPTIONS,
     CONF_EXTENDED_ATTR,
     CONF_NAME,
+    DEFAULT_DISPLAY_OPTIONS,
     DEFAULT_EXTENDED_ATTR,
     DOMAIN,
     EVENT_TYPE,
@@ -69,7 +71,18 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     name = entry.data.get(CONF_NAME, entry.entry_id)
     await async_migrate_legacy_snapshot(hass, entry.entry_id, name)
-    hass.config_entries.async_update_entry(entry, version=2, minor_version=1)
+    update_kwargs: dict = {"version": 2, "minor_version": 1}
+    display_options = entry.data.get(CONF_DISPLAY_OPTIONS, "")
+    options = [option.strip() for option in display_options.split(",")]
+    if "do_not_reorder" in options:
+        options.remove("do_not_reorder")
+        if options:
+            options[0] += "[]"
+            migrated_options = ", ".join(options)
+        else:
+            migrated_options = DEFAULT_DISPLAY_OPTIONS
+        update_kwargs["data"] = {**entry.data, CONF_DISPLAY_OPTIONS: migrated_options}
+    hass.config_entries.async_update_entry(entry, **update_kwargs)
     return True
 
 

--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -75,7 +75,15 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     display_options = entry.data.get(CONF_DISPLAY_OPTIONS, "")
     options = [option.strip().lower() for option in display_options.split(",")]
     if "do_not_reorder" in options:
-        options = [option for option in options if option != "do_not_reorder"]
+        options = [
+            option
+            for option in options
+            if option
+            not in {
+                "do_not_reorder",
+                "do_not_show_not_home",
+            }
+        ]
         if options:
             options[0] += "[]"
             migrated_options = ", ".join(options)

--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -75,15 +75,24 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     display_options = entry.data.get(CONF_DISPLAY_OPTIONS, "")
     options = [option.strip().lower() for option in display_options.split(",")]
     if "do_not_reorder" in options:
-        options = [
-            option
-            for option in options
-            if option
-            not in {
-                "do_not_reorder",
-                "do_not_show_not_home",
-            }
-        ]
+        migrated_options_list: list[str] = []
+        for option in options:
+            if option in {"do_not_reorder", "do_not_show_not_home"}:
+                continue
+            if option == "place":
+                migrated_options_list.extend(
+                    [
+                        "name_no_dupe",
+                        "category(-, place)",
+                        "type(-, yes)",
+                        "neighborhood",
+                        "house_number",
+                        "street",
+                    ]
+                )
+            else:
+                migrated_options_list.append(option)
+        options = migrated_options_list
         if options:
             if "formatted_place" not in options:
                 options[0] += "[]"

--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -73,9 +73,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_migrate_legacy_snapshot(hass, entry.entry_id, name)
     update_kwargs: dict = {"version": 2, "minor_version": 1}
     display_options = entry.data.get(CONF_DISPLAY_OPTIONS, "")
-    options = [option.strip() for option in display_options.split(",")]
+    options = [option.strip().lower() for option in display_options.split(",")]
     if "do_not_reorder" in options:
-        options.remove("do_not_reorder")
+        options = [option for option in options if option != "do_not_reorder"]
         if options:
             options[0] += "[]"
             migrated_options = ", ".join(options)

--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -85,7 +85,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             }
         ]
         if options:
-            options[0] += "[]"
+            if "formatted_place" not in options:
+                options[0] += "[]"
             migrated_options = ", ".join(options)
         else:
             migrated_options = DEFAULT_DISPLAY_OPTIONS

--- a/custom_components/places/advanced_options.py
+++ b/custom_components/places/advanced_options.py
@@ -206,6 +206,7 @@ class AdvancedOptionsParser:
                 out,
             )
         if out:
+            out = str(out)
             if out == out.lower() and (
                 DISPLAY_OPTIONS_MAP.get(opt) == ATTR_DEVICETRACKER_ZONE_NAME
                 or DISPLAY_OPTIONS_MAP.get(opt) == ATTR_PLACE_TYPE

--- a/custom_components/places/basic_options.py
+++ b/custom_components/places/basic_options.py
@@ -145,21 +145,6 @@ class BasicOptionsParser:
         }.items():
             self._add_to_display(user_display, attr_key, option_key=option_key)
 
-        # Handle "do_not_reorder" option
-        if "do_not_reorder" in self.display_options:
-            user_display = []
-            self.display_options.remove("do_not_reorder")
-            for option in self.display_options:
-                attr_key = (
-                    ATTR_REGION
-                    if option == "state"
-                    else ATTR_PLACE_NEIGHBOURHOOD
-                    if option == "place_neighborhood"
-                    else option
-                )
-                if not self.coordinator.is_attr_blank(attr_key):
-                    user_display.append(self.coordinator.get_attr_safe_str(attr_key))
-
         return ", ".join(user_display)
 
     async def build_formatted_place(self) -> str:

--- a/custom_components/places/const.py
+++ b/custom_components/places/const.py
@@ -309,6 +309,7 @@ DISPLAY_OPTIONS_MAP: MutableMapping[str, str] = {
     "neighbourhood": ATTR_PLACE_NEIGHBOURHOOD,
     "place_neighborhood": ATTR_PLACE_NEIGHBOURHOOD,
     "place_neighbourhood": ATTR_PLACE_NEIGHBOURHOOD,
+    "formatted_address": ATTR_FORMATTED_ADDRESS,
     "city": ATTR_CITY,
     "city_clean": ATTR_CITY_CLEAN,
     "postal_town": ATTR_POSTAL_TOWN,

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -147,6 +147,21 @@ async def test_get_option_state_incl_attr_excl_attr(
 
 
 @pytest.mark.asyncio
+async def test_get_option_state_numeric_values_are_stringified(
+    advanced_parser: AdvancedParserFactory,
+) -> None:
+    """Handle numeric display values by normalizing them before string operations."""
+    attrs = {
+        "latitude": 40.715,
+        "longitude": -74.006,
+        "name": "Test",
+    }
+    parser, _sensor = advanced_parser(attrs=attrs, in_zone=True)
+    out = await parser.get_option_state("latitude")
+    assert out == "40.715"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("key", "expected"),
     [

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -79,6 +79,7 @@ async def test_do_brackets_and_parens_count_match(
 @pytest.mark.parametrize(
     ("key", "expected"),
     [
+        ("formatted_address", "123 Any Street"),
         ("zone_name", "Home"),
         ("province", "Virginia"),
         ("missing", None),
@@ -89,6 +90,7 @@ async def test_get_option_state_basic(
 ) -> None:
     """Return the expected option state for a basic key lookup."""
     attrs = {
+        "formatted_address": "123 Any Street",
         "zone_name": "Home",
         "place_type": "Restaurant",
         "street": "Main St",

--- a/tests/test_basic_options.py
+++ b/tests/test_basic_options.py
@@ -91,13 +91,6 @@ def basic_parser() -> BasicParserFactory:
             None,
         ),
         (
-            {"city": "Springfield", "state": "IL"},
-            False,
-            ["do_not_reorder", "city", "state"],
-            [],
-            "Springfield, IL",
-        ),
-        (
             {"zone_name": "Work"},
             True,
             ["zone_name"],

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -167,6 +167,14 @@ async def test_async_migrate_entry_gates_legacy_snapshot_migration_by_version(
     ("display_options", "expected_data"),
     [
         (
+            "do_not_reorder, formatted_place",
+            {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "formatted_place"},
+        ),
+        (
+            "do_not_reorder, formatted_place, driving",
+            {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "formatted_place, driving"},
+        ),
+        (
             "do_not_reorder, city, state",
             {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "city[], state"},
         ),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -186,6 +186,16 @@ async def test_async_migrate_entry_gates_legacy_snapshot_migration_by_version(
             "do_not_reorder, zone, do_not_show_not_home, city",
             {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "zone[], city"},
         ),
+        (
+            "do_not_reorder, zone_name, place, city",
+            {
+                CONF_NAME: "Test Place",
+                CONF_DISPLAY_OPTIONS: (
+                    "zone_name[], name_no_dupe, category(-, place), type(-, yes), "
+                    "neighborhood, house_number, street, city"
+                ),
+            },
+        ),
         ("city, state", None),
         (
             "do_not_reorder",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -174,6 +174,10 @@ async def test_async_migrate_entry_gates_legacy_snapshot_migration_by_version(
             "Do_Not_Reorder, City, State",
             {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "city[], state"},
         ),
+        (
+            "do_not_reorder, zone, do_not_show_not_home, city",
+            {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "zone[], city"},
+        ),
         ("city, state", None),
         (
             "do_not_reorder",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,8 +20,10 @@ from custom_components.places import (
 )
 from custom_components.places.const import (
     CONF_API_KEY,
+    CONF_DISPLAY_OPTIONS,
     CONF_EXTENDED_ATTR,
     CONF_NAME,
+    DEFAULT_DISPLAY_OPTIONS,
     DOMAIN,
     EVENT_TYPE,
     OSM_CACHE,
@@ -158,6 +160,49 @@ async def test_async_migrate_entry_gates_legacy_snapshot_migration_by_version(
             version=2,
             minor_version=1,
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("display_options", "expected_data"),
+    [
+        (
+            "do_not_reorder, city, state",
+            {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "city[], state"},
+        ),
+        ("city, state", None),
+        (
+            "do_not_reorder",
+            {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: DEFAULT_DISPLAY_OPTIONS},
+        ),
+    ],
+)
+async def test_async_migrate_entry_converts_do_not_reorder_to_advanced_options(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_hass: MagicMock,
+    display_options: str,
+    expected_data: dict[str, object] | None,
+) -> None:
+    """Legacy ordered display options migrate to an advanced expression."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=1,
+        data={CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: display_options},
+    )
+    monkeypatch.setattr(
+        "custom_components.places.async_migrate_legacy_snapshot",
+        AsyncMock(),
+    )
+
+    await async_migrate_entry(mock_hass, entry)
+
+    expected_kwargs: dict[str, object] = {"version": 2, "minor_version": 1}
+    if expected_data is not None:
+        expected_kwargs["data"] = expected_data
+    mock_hass.config_entries.async_update_entry.assert_called_once_with(
+        entry,
+        **expected_kwargs,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -170,6 +170,10 @@ async def test_async_migrate_entry_gates_legacy_snapshot_migration_by_version(
             "do_not_reorder, city, state",
             {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "city[], state"},
         ),
+        (
+            "Do_Not_Reorder, City, State",
+            {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "city[], state"},
+        ),
         ("city, state", None),
         (
             "do_not_reorder",


### PR DESCRIPTION
## Summary

Removes the undocumented `do_not_reorder` display option while preserving existing ordered configurations through config-entry migration.

## What Changed

- Migrates legacy ordered fields to the existing advanced display-option syntax
- Normalizes mixed-case legacy values and removes basic-only migration flags
- Preserves the existing basic `formatted_place` path
- Adds `formatted_address` support to advanced display options
- Removes the obsolete runtime reordering branch
- Adds migration and parser regression coverage

## Why

Ordered fields are already supported by advanced display options, so retaining a separate undocumented runtime flag duplicates behavior and complicates the basic parser.