### PR TITLE
Rename formatted address display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Key | Required | Default | Description |
 `Sensor Name` | `Yes` | | Friendly name of the places sensor
 `Tracked Entity ID` | `Yes` | | The location entity to track. **Must** have `latitude` and `longitude` as attributes. Supports these entities: `device_tracker`, `person`, `sensor`, `variable` & `zone`
 `Email Address` | `No` | | OpenStreetMap API key (your email address).
-`Display Options` | `No` | `zone_name`, `place` | Display options: `formatted_place` *(exclusive option)*, `driving` *(can be used with formatted_place or other options)*, `zone` or `zone_name`, `place`, `place_name`, `street_number`, `street`, `city`, `county`, `state`, `postal_code`, `country`, `formatted_address`, `do_not_show_not_home`<br /><br />**See optional Advanced Display Options below to use more complex display logic.**
+`Display Options` | `No` | `zone_name`, `place` | Display options: `formatted_place` *(exclusive option)*, `driving` *(can be used with formatted_place or other options)*, `zone` or `zone_name`, `place`, `place_name`, `street_number`, `street`, `city`, `county`, `state`, `postal_code`, `country`, `osm_formatted_address`, `do_not_show_not_home`<br /><br />**See optional Advanced Display Options below to use more complex display logic.**
 `Home Zone` | `No` | `zone.home` | Used to calculate distance from home and direction of travel
 `Map Provider` | `No` | `apple` | `google`, `apple`, `osm`
 `Map Zoom` | `No` | `18` | Level of zoom for the generated map link <1-20>

--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Callable
 import logging
+import re
 
 import cachetools
 from homeassistant.components.recorder import DATA_INSTANCE
@@ -73,6 +74,18 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_migrate_legacy_snapshot(hass, entry.entry_id, name)
     update_kwargs: dict = {"version": 2, "minor_version": 1}
     display_options = entry.data.get(CONF_DISPLAY_OPTIONS, "")
+    migrated_display_options = re.sub(
+        r"\bformatted_address\b",
+        "osm_formatted_address",
+        display_options,
+        flags=re.IGNORECASE,
+    )
+    if migrated_display_options != display_options:
+        update_kwargs["data"] = {
+            **entry.data,
+            CONF_DISPLAY_OPTIONS: migrated_display_options,
+        }
+    display_options = migrated_display_options
     options = [option.strip().lower() for option in display_options.split(",")]
     if "do_not_reorder" in options:
         migrated_options_list: list[str] = []

--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -74,12 +74,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await async_migrate_legacy_snapshot(hass, entry.entry_id, name)
     update_kwargs: dict = {"version": 2, "minor_version": 1}
     display_options = entry.data.get(CONF_DISPLAY_OPTIONS, "")
-    migrated_display_options = re.sub(
-        r"\bformatted_address\b",
-        "osm_formatted_address",
-        display_options,
-        flags=re.IGNORECASE,
-    )
+    migrated_display_options = _migrate_formatted_address_display_options(display_options)
     if migrated_display_options != display_options:
         update_kwargs["data"] = {
             **entry.data,
@@ -115,6 +110,35 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         update_kwargs["data"] = {**entry.data, CONF_DISPLAY_OPTIONS: migrated_options}
     hass.config_entries.async_update_entry(entry, **update_kwargs)
     return True
+
+
+def _migrate_formatted_address_display_options(raw_display_options: str) -> str:
+    """Migrate ``formatted_address`` tokens while preserving literal filter values.
+
+    Args:
+        raw_display_options: The raw display-options string to migrate.
+
+    Returns:
+        The migrated display-options string with display-option identifiers renamed where safe.
+    """
+    out: list[str] = []
+    paren_depth = 0
+    last = 0
+    for match in re.finditer(r"(?i)\bformatted_address\b", raw_display_options):
+        segment = raw_display_options[last : match.start()]
+        out.append(segment)
+        paren_depth = max(
+            0,
+            paren_depth + segment.count("(") - segment.count(")"),
+        )
+        out.append(
+            "osm_formatted_address"
+            if paren_depth == 0 or raw_display_options[match.end() :].lstrip().startswith("(")
+            else match.group()
+        )
+        last = match.end()
+    out.append(raw_display_options[last:])
+    return "".join(out)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/places/basic_options.py
+++ b/custom_components/places/basic_options.py
@@ -141,7 +141,7 @@ class BasicOptionsParser:
             "region": ATTR_REGION,
             "postal_code": "postal_code",
             "country": "country",
-            "formatted_address": "formatted_address",
+            "osm_formatted_address": "formatted_address",
         }.items():
             self._add_to_display(user_display, attr_key, option_key=option_key)
 

--- a/custom_components/places/const.py
+++ b/custom_components/places/const.py
@@ -309,7 +309,7 @@ DISPLAY_OPTIONS_MAP: MutableMapping[str, str] = {
     "neighbourhood": ATTR_PLACE_NEIGHBOURHOOD,
     "place_neighborhood": ATTR_PLACE_NEIGHBOURHOOD,
     "place_neighbourhood": ATTR_PLACE_NEIGHBOURHOOD,
-    "formatted_address": ATTR_FORMATTED_ADDRESS,
+    "osm_formatted_address": ATTR_FORMATTED_ADDRESS,
     "city": ATTR_CITY,
     "city_clean": ATTR_CITY_CLEAN,
     "postal_town": ATTR_POSTAL_TOWN,

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -79,7 +79,7 @@ async def test_do_brackets_and_parens_count_match(
 @pytest.mark.parametrize(
     ("key", "expected"),
     [
-        ("formatted_address", "123 Any Street"),
+        ("osm_formatted_address", "123 Any Street"),
         ("zone_name", "Home"),
         ("province", "Virginia"),
         ("missing", None),

--- a/tests/test_display_options_integration.py
+++ b/tests/test_display_options_integration.py
@@ -179,6 +179,11 @@ async def render_display_option(
         ),
         ("formatted_place", "Roy Spiegel MSW, Fort Lee, NJ"),
         (
+            "osm_formatted_address",
+            "Roy Spiegel MSW, 1, Bridge Plaza North, Koreatown, Fort Lee, Bergen County, "
+            "New Jersey, 07024, United States",
+        ),
+        (
             README_PLACE_ADVANCED,
             "Roy Spiegel MSW, House, Koreatown, 1 Bridge Plaza North",
         ),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -181,6 +181,21 @@ async def test_async_migrate_entry_gates_legacy_snapshot_migration_by_version(
                 CONF_DISPLAY_OPTIONS: "osm_formatted_address, city",
             },
         ),
+        ("type(formatted_address)[city]", None),
+        (
+            "formatted_address[city]",
+            {
+                CONF_NAME: "Test Place",
+                CONF_DISPLAY_OPTIONS: "osm_formatted_address[city]",
+            },
+        ),
+        (
+            "type(formatted_address(formatted_address), city)",
+            {
+                CONF_NAME: "Test Place",
+                CONF_DISPLAY_OPTIONS: "type(osm_formatted_address(formatted_address), city)",
+            },
+        ),
         (
             "do_not_reorder, formatted_address, city",
             {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -175,6 +175,20 @@ async def test_async_migrate_entry_gates_legacy_snapshot_migration_by_version(
             {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "formatted_place, driving"},
         ),
         (
+            "formatted_address, city",
+            {
+                CONF_NAME: "Test Place",
+                CONF_DISPLAY_OPTIONS: "osm_formatted_address, city",
+            },
+        ),
+        (
+            "do_not_reorder, formatted_address, city",
+            {
+                CONF_NAME: "Test Place",
+                CONF_DISPLAY_OPTIONS: "osm_formatted_address[], city",
+            },
+        ),
+        (
             "do_not_reorder, city, state",
             {CONF_NAME: "Test Place", CONF_DISPLAY_OPTIONS: "city[], state"},
         ),


### PR DESCRIPTION
## Summary
Renames the OpenStreetMap formatted-address display option to `osm_formatted_address` and migrates existing version 1 configurations during their version 2 upgrade.

## What Changed
- Replaced the `formatted_address` display-option key with `osm_formatted_address` while retaining the underlying entity attribute
- Updated basic and advanced display-option rendering for the renamed key
- Migrated semantic display-option identifiers without changing literal advanced-filter values
- Added regression coverage for basic, fallback, nested-filter, and legacy ordered-option migrations
- Updated the documented display-option name

## Why
The new name makes the OpenStreetMap source explicit and distinguishes the display option from the underlying attribute. Restricting migration to semantic option identifiers preserves existing advanced-filter comparisons during upgrade.