### PR TITLE
Optimize test suite

### DIFF
--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -240,6 +240,7 @@ async def test_parse_parens_and_bracket(
         (["Home", "Restaurant"], None, None, "Home, Restaurant"),
         ([None, "Home", "", "Restaurant"], None, None, "Home, Restaurant"),
         (["Home", "123", "Main St"], 1, 1, "Home, 123, Main St"),
+        (["123", "Main St"], 1, 0, "123 Main St"),
     ],
 )
 async def test_compile_state_variants(
@@ -507,20 +508,6 @@ async def test_get_option_state_incl_attr_blank_causes_exclusion(sensor: MockSen
     parser = AdvancedOptionsParser(sensor, "")
     out = await parser.get_option_state("zone_name", incl_attr={"place_type": ["restaurant"]})
     assert out is None
-
-
-@pytest.mark.asyncio
-async def test_compile_state_space_when_street_indices_match(sensor: MockSensor) -> None:
-    """Use a space separator when street indices align after increment."""
-    sensor.attrs = {}
-    parser = AdvancedOptionsParser(sensor, "")
-    parser.state_list = ["123", "Main St"]
-    # Set indices so after increment _street_num_i becomes 0 and matches _street_i=0 for first element? Need both to match second element, so set before increment to 0 so becomes 1 then set _street_i=1
-    parser._street_num_i = 0  # will increment to 1 in compile_state
-    parser._street_i = 1
-    result = await parser.compile_state()
-    # Two items only; index 1 meets condition so space used
-    assert result == "123 Main St"
 
 
 @pytest.mark.asyncio

--- a/tests/test_advanced_options.py
+++ b/tests/test_advanced_options.py
@@ -25,12 +25,6 @@ class AdvancedParserFactory(Protocol):
 
 
 @pytest.fixture
-def sensor() -> MockSensor:
-    """Shared sensor fixture returning a configured MockSensor instance."""
-    return mock_sensor()
-
-
-@pytest.fixture
 def advanced_parser() -> AdvancedParserFactory:
     """Factory fixture to create an AdvancedOptionsParser and its sensor.
 

--- a/tests/test_basic_options.py
+++ b/tests/test_basic_options.py
@@ -201,19 +201,6 @@ def test_add_type_or_category(
     [
         ({"street": "Main St", "street_number": ""}, "Main St"),
         ({"street": "Main St", "street_number": "123"}, "123 Main St"),
-    ],
-)
-def test_add_street_info(attrs: Attrs, expected: str, basic_parser: BasicParserFactory) -> None:
-    """Test that `add_street_info` appends the correct street info to the list."""
-    parser, sensor = basic_parser(attrs=attrs)
-    arr: list[str] = []
-    parser.add_street_info(arr, sensor)
-    assert expected in arr
-
-
-@pytest.mark.parametrize(
-    ("attrs", "expected"),
-    [
         (
             {
                 "place_category": "highway",
@@ -234,10 +221,8 @@ def test_add_street_info(attrs: Attrs, expected: str, basic_parser: BasicParserF
         ),
     ],
 )
-def test_add_street_info_highway(
-    attrs: Attrs, expected: str, basic_parser: BasicParserFactory
-) -> None:
-    """Prefer route_number for highways and motorways when street is empty."""
+def test_add_street_info(attrs: Attrs, expected: str, basic_parser: BasicParserFactory) -> None:
+    """Append normal, numbered, or highway route street info to the list."""
     parser, sensor = basic_parser(attrs=attrs)
     arr: list[str] = []
     parser.add_street_info(arr, sensor)

--- a/tests/test_basic_options.py
+++ b/tests/test_basic_options.py
@@ -61,13 +61,13 @@ def basic_parser() -> BasicParserFactory:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("attrs", "in_zone", "options", "expected_contains"),
+    ("attrs", "in_zone", "options", "expected"),
     [
         (
             {},
             False,
             ["driving", "zone_name", "zone", "place"],
-            [],
+            "",
         ),
         (
             {
@@ -80,13 +80,13 @@ def basic_parser() -> BasicParserFactory:
             },
             False,
             ["driving", "zone_name", "place", "street", "city"],
-            ["Driving", "Home", "Park", "Downtown", "Main St", "Springfield"],
+            "Driving, Home, Park, Downtown, Main St, Springfield",
         ),
         (
             {"zone_name": "Work"},
             True,
             ["zone_name"],
-            ["Work"],
+            "Work",
         ),
     ],
 )
@@ -94,34 +94,30 @@ async def test_build_display_scenarios(
     attrs: Attrs,
     in_zone: bool,
     options: Sequence[str],
-    expected_contains: Sequence[str],
+    expected: str,
     sensor: MockSensor,
 ) -> None:
-    """Parametrized scenarios for BasicOptionsParser.build_display covering blank, populated, reorder, and in-zone cases."""
+    """Parametrized scenarios for BasicOptionsParser.build_display output."""
     # Mutate shared sensor fixture for this scenario
     sensor.attrs = dict(attrs or {})
     sensor._in_zone = in_zone
     parser = BasicOptionsParser(sensor, attrs, options)
     result = await parser.build_display()
-    for substr in expected_contains:
-        assert substr in result
+    assert result == expected
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("scenario", "attrs", "in_zone", "options", "display_list", "expected_contains", "expected_eq"),
+    ("attrs", "in_zone", "options", "display_list", "expected"),
     [
         (
-            "place_name",
             {ATTR_PLACE_NAME: "Central Park"},
             False,
             ["place"],
             ["driving"],
-            ["Central Park"],
-            None,
+            "Central Park",
         ),
         (
-            "type_category",
             {
                 "place_type": "restaurant",
                 "place_category": "food",
@@ -132,44 +128,32 @@ async def test_build_display_scenarios(
             False,
             ["place"],
             None,
-            ["Elm St", "Metropolis"],
-            None,
+            "Restaurant, Elm St, Metropolis",
         ),
         (
-            "in_zone",
             {"zone_name": "Home"},
             True,
             ["zone_name"],
             None,
-            [],
             "Home",
         ),
     ],
 )
 async def test_build_formatted_place_variants(
-    scenario: str,
     attrs: Attrs,
     in_zone: bool,
     options: Sequence[str],
     display_list: Sequence[str] | None,
-    expected_contains: Sequence[str],
-    expected_eq: str | None,
+    expected: str,
     sensor: MockSensor,
 ) -> None:
-    """Parametrized scenarios for BasicOptionsParser.build_formatted_place."""
+    """Parametrized exact outputs for BasicOptionsParser.build_formatted_place."""
     sensor.attrs = dict(attrs or {})
     sensor._in_zone = in_zone
     sensor.display_options_list = display_list or []
     parser = BasicOptionsParser(sensor, attrs, options)
     result = await parser.build_formatted_place()
-    if expected_eq is not None:
-        assert result == expected_eq
-        return
-    # Special-case: type_category accepts either Type or Category wording
-    if scenario == "type_category":
-        assert ("Restaurant" in result) or ("Food" in result)
-    for substr in expected_contains:
-        assert substr in result
+    assert result == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_basic_options.py
+++ b/tests/test_basic_options.py
@@ -26,12 +26,6 @@ class BasicParserFactory(Protocol):
 
 
 @pytest.fixture
-def sensor() -> MockSensor:
-    """Shared sensor fixture returning a configured MockSensor instance."""
-    return mock_sensor()
-
-
-@pytest.fixture
 def basic_parser() -> BasicParserFactory:
     """Factory fixture to create a BasicOptionsParser and its backing sensor.
 

--- a/tests/test_basic_options.py
+++ b/tests/test_basic_options.py
@@ -61,14 +61,13 @@ def basic_parser() -> BasicParserFactory:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("attrs", "in_zone", "options", "expected_contains", "expected_eq"),
+    ("attrs", "in_zone", "options", "expected_contains"),
     [
         (
             {},
             False,
             ["driving", "zone_name", "zone", "place"],
             [],
-            None,
         ),
         (
             {
@@ -82,14 +81,12 @@ def basic_parser() -> BasicParserFactory:
             False,
             ["driving", "zone_name", "place", "street", "city"],
             ["Driving", "Home", "Park", "Downtown", "Main St", "Springfield"],
-            None,
         ),
         (
             {"zone_name": "Work"},
             True,
             ["zone_name"],
             ["Work"],
-            None,
         ),
     ],
 )
@@ -98,7 +95,6 @@ async def test_build_display_scenarios(
     in_zone: bool,
     options: Sequence[str],
     expected_contains: Sequence[str],
-    expected_eq: str | None,
     sensor: MockSensor,
 ) -> None:
     """Parametrized scenarios for BasicOptionsParser.build_display covering blank, populated, reorder, and in-zone cases."""
@@ -107,11 +103,8 @@ async def test_build_display_scenarios(
     sensor._in_zone = in_zone
     parser = BasicOptionsParser(sensor, attrs, options)
     result = await parser.build_display()
-    if expected_eq is not None:
-        assert result == expected_eq
-    else:
-        for substr in expected_contains:
-            assert substr in result
+    for substr in expected_contains:
+        assert substr in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_display_options_integration.py
+++ b/tests/test_display_options_integration.py
@@ -207,16 +207,13 @@ async def test_display_options_state_render(
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("patch_entity_registry")
-async def test_basic_and_advanced_place_options_include_neighborhood(
+async def test_basic_place_option_includes_neighborhood(
     mock_hass: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Basic and advanced place options should retain neighborhood context."""
+    """Basic place options should retain neighborhood context."""
     basic_state = await render_display_option(mock_hass, monkeypatch, "place")
-    advanced_state = await render_display_option(mock_hass, monkeypatch, README_PLACE_ADVANCED)
 
     assert basic_state
-    assert advanced_state
-    assert "Koreatown" in advanced_state
     assert "Koreatown" in basic_state
 
 

--- a/tests/test_parse_osm.py
+++ b/tests/test_parse_osm.py
@@ -52,12 +52,6 @@ class OSMParserFactory(Protocol):
 
 
 @pytest.fixture
-def sensor() -> MockSensor:
-    """Shared sensor fixture returning a configured MockSensor instance."""
-    return mock_sensor()
-
-
-@pytest.fixture
 def osm_parser() -> OSMParserFactory:
     """Factory fixture to create an OSMParser and its sensor.
 

--- a/tests/test_parse_osm.py
+++ b/tests/test_parse_osm.py
@@ -353,31 +353,6 @@ async def test_set_city_details_variants(
 @pytest.mark.parametrize(
     ("address", "expected_attr", "expected_value"),
     [
-        ({"town": "Shelbyville"}, ATTR_CITY, "Shelbyville"),
-        ({"village": "Ogdenville"}, ATTR_CITY, "Ogdenville"),
-    ],
-)
-async def test_set_city_details_postal_town(
-    osm_parser: OSMParserFactory, address: Address, expected_attr: AttrName, expected_value: object
-) -> None:
-    """Test that set_city_details sets the correct city attribute for postal towns and villages.
-
-    Args:
-        osm_parser: Factory fixture for creating the parser and sensor.
-        address: The address dictionary containing town or village information.
-        expected_attr: The expected attribute to be set (e.g., ATTR_CITY).
-        expected_value: The expected value to be set for the attribute.
-
-    """
-    parser, sensor = osm_parser()
-    await parser.set_city_details(address)
-    assert sensor.attrs[expected_attr] == expected_value
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("address", "expected_attr", "expected_value"),
-    [
         ({"neighbourhood": "Downtown"}, ATTR_PLACE_NEIGHBOURHOOD, "Downtown"),
         ({"suburb": "Westside"}, ATTR_POSTAL_TOWN, "Westside"),
         ({"quarter": "East End"}, ATTR_PLACE_NEIGHBOURHOOD, "East End"),

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -150,17 +150,16 @@ def _write_fake_store_snapshot(path: Path, data: dict[str, object]) -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("entry_id", "store_data", "expected"),
+    ("store_data", "expected"),
     [
-        ("entry-1", {ATTR_CITY: "Store City"}, {ATTR_CITY: "Store City"}),
-        ("entry-5", None, {}),
+        ({ATTR_CITY: "Store City"}, {ATTR_CITY: "Store City"}),
+        (None, {}),
     ],
     ids=["existing-store-data", "missing-store-data"],
 )
 async def test_load_returns_store_data_or_empty(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    entry_id: str,
     store_data: object | None,
     expected: dict[str, object],
 ) -> None:
@@ -169,7 +168,7 @@ async def test_load_returns_store_data_or_empty(
     _FakeStore.next_data = store_data
     hass = _hass_for_store_path(tmp_path)
 
-    storage = PlacesStorage(hass, entry_id, "Test")
+    storage = PlacesStorage(hass, "entry-1", "Test")
     loaded = await storage.async_load()
 
     assert loaded == expected

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -149,31 +149,30 @@ def _write_fake_store_snapshot(path: Path, data: dict[str, object]) -> None:
 
 
 @pytest.mark.asyncio
-async def test_load_uses_store_data(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Existing Store data is loaded."""
-    monkeypatch.setattr("custom_components.places.persistence.Store", _FakeStore)
-    _FakeStore.next_data = {ATTR_CITY: "Store City"}
-    hass = _hass_for_store_path(tmp_path)
-
-    storage = PlacesStorage(hass, "entry-1", "Test")
-    loaded = await storage.async_load()
-
-    assert loaded == {ATTR_CITY: "Store City"}
-    assert _FakeStore.last_saved is None
-
-
-@pytest.mark.asyncio
-async def test_load_missing_store_data_returns_empty(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("entry_id", "store_data", "expected"),
+    [
+        ("entry-1", {ATTR_CITY: "Store City"}, {ATTR_CITY: "Store City"}),
+        ("entry-5", None, {}),
+    ],
+    ids=["existing-store-data", "missing-store-data"],
+)
+async def test_load_returns_store_data_or_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    entry_id: str,
+    store_data: object | None,
+    expected: dict[str, object],
 ) -> None:
-    """Missing Store data returns an empty mapping."""
+    """Load existing Store data or return an empty mapping when missing."""
     monkeypatch.setattr("custom_components.places.persistence.Store", _FakeStore)
+    _FakeStore.next_data = store_data
     hass = _hass_for_store_path(tmp_path)
 
-    storage = PlacesStorage(hass, "entry-5", "Test")
+    storage = PlacesStorage(hass, entry_id, "Test")
     loaded = await storage.async_load()
 
-    assert loaded == {}
+    assert loaded == expected
     assert _FakeStore.last_saved is None
 
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -49,11 +49,11 @@ class _TrackerAttributesWithoutDefault:
 
 
 @pytest.mark.parametrize(
-    ("tracker_id", "state_lookup_result", "expect_state_lookup"),
+    ("tracker_id", "expect_state_lookup"),
     [
-        ("device_tracker.missing", None, True),
-        (None, None, False),
-        ("", None, False),
+        ("device_tracker.missing", True),
+        (None, False),
+        ("", False),
     ],
 )
 async def test_tracker_missing_or_blank_id_skips_update(
@@ -61,12 +61,11 @@ async def test_tracker_missing_or_blank_id_skips_update(
     mock_config_entry: MockConfigEntry,
     sensor: MockSensor,
     tracker_id: str | None,
-    state_lookup_result: object | None,
     expect_state_lookup: bool,
 ) -> None:
     """Missing entities and blank tracked entity IDs skip updates."""
     sensor.attrs[CONF_DEVICETRACKER_ID] = tracker_id
-    mock_hass.states.get.return_value = state_lookup_result
+    mock_hass.states.get.return_value = None
     updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
 
     result = await updater.is_devicetracker_set()

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -14,11 +14,9 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.places.const import (
-    ATTR_GPS_ACCURACY as PLACES_GPS_ACCURACY,
     ATTR_LATITUDE as PLACES_ATTR_LATITUDE,
     ATTR_LONGITUDE as PLACES_ATTR_LONGITUDE,
     CONF_DEVICETRACKER_ID,
-    CONF_USE_GPS,
     UpdateStatus,
 )
 from custom_components.places.tracker import TrackerSnapshot, TrackerStatus
@@ -95,23 +93,6 @@ async def test_tracker_invalid_coordinates_skip_update(
 
     assert result is False
     assert gate_result is UpdateStatus.SKIP
-
-
-async def test_tracker_zero_gps_accuracy_skips_when_enabled(
-    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
-) -> None:
-    """GPS accuracy zero preserves the existing skip behavior."""
-    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.person"
-    sensor.attrs[CONF_USE_GPS] = True
-    tracker = MagicMock()
-    tracker.attributes = {ATTR_GPS_ACCURACY: 0}
-    mock_hass.states.get.return_value = tracker
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-
-    result = await updater.get_gps_accuracy()
-
-    assert result is UpdateStatus.SKIP
-    assert sensor.attrs[PLACES_GPS_ACCURACY] == 0.0
 
 
 async def test_tracker_attributes_with_get_only_preserves_ok_path(

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -1153,24 +1153,6 @@ async def test_check_device_tracker_and_update_coords_param(
 
 
 @pytest.mark.asyncio
-async def test_get_gps_accuracy_sets_accuracy(
-    mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor
-) -> None:
-    """Retrieve GPS accuracy and set sensor attribute when available."""
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-    tracker_state = MagicMock()
-    tracker_state.attributes = {ATTR_GPS_ACCURACY: 5.0}
-    mock_hass.states.get.return_value = tracker_state
-    sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.test"
-    sensor.is_attr_blank.return_value = False
-    sensor.get_attr.return_value = True
-    sensor.get_attr_safe_float.return_value = 5.0
-    result = await updater.get_gps_accuracy()
-    assert result == UpdateStatus.PROCEED
-    assert sensor.attrs[ATTR_GPS_ACCURACY] == 5.0
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("tracker_attrs", "use_gps", "expected"),
     [

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -1154,18 +1154,19 @@ async def test_check_device_tracker_and_update_coords_param(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("tracker_attrs", "use_gps", "expected"),
+    ("tracker_attrs", "expected"),
     [
-        ({ATTR_GPS_ACCURACY: 5.0}, True, UpdateStatus.PROCEED),
-        ({ATTR_GPS_ACCURACY: 0}, True, UpdateStatus.SKIP),
+        ({ATTR_GPS_ACCURACY: 5.0}, UpdateStatus.PROCEED),
+        ({ATTR_GPS_ACCURACY: 0}, UpdateStatus.SKIP),
+        (None, UpdateStatus.PROCEED),
     ],
+    ids=["valid-accuracy", "zero-accuracy", "missing-tracker"],
 )
 async def test_get_gps_accuracy_variants(
     mock_hass: MagicMock,
     mock_config_entry: MockConfigEntry,
     sensor: MockSensor,
     tracker_attrs: dict[str, object] | None,
-    use_gps: bool,
     expected: object,
 ) -> None:
     """Parametrized variants for get_gps_accuracy: valid accuracy, zero accuracy, and missing tracker."""
@@ -1178,7 +1179,7 @@ async def test_get_gps_accuracy_variants(
 
     # Populate required attributes where relevant
     sensor.attrs[CONF_DEVICETRACKER_ID] = "device_tracker.test"
-    sensor.attrs[CONF_USE_GPS] = use_gps
+    sensor.attrs[CONF_USE_GPS] = True
 
     # is_attr_blank should evaluate based on actual attrs
     sensor.is_attr_blank.side_effect = lambda k: (
@@ -2306,23 +2307,6 @@ async def test_rollback_update_triggers_helpers(
 
 
 @pytest.mark.asyncio
-async def test_get_extended_attr_unknown_type(
-    mock_hass: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
-    sensor: MockSensor,
-) -> None:
-    """Logs warning for unknown OSM type and returns early."""
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-    sensor.is_attr_blank.side_effect = lambda k: False
-    sensor.get_attr_safe_str.side_effect = lambda k: "foo"
-    sensor.get_attr.side_effect = lambda k: (
-        "123" if k == ATTR_OSM_ID else "foo" if k == ATTR_OSM_TYPE else None
-    )
-    await updater.get_extended_attr()
-    assert any("Unknown OSM type" in r.message for r in caplog.records)
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("osm_type", "expect_call", "expect_log"),

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -1525,35 +1525,6 @@ async def test_should_update_state_param(
 
 
 @pytest.mark.asyncio
-async def test_rollback_update_calls_restore_and_helpers(
-    mock_hass: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    sensor: MockSensor,
-    stubbed_updater: StubbedUpdater,
-) -> None:
-    """Restore previous attributes and conditionally call helper routines."""
-    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
-    with stubbed_updater(
-        updater,
-        [
-            ("get_seconds_from_last_change", {"return_value": 100}),
-            ("change_dot_to_stationary", {}),
-            ("change_show_time_to_date", {}),
-        ],
-    ) as mocks:
-        # Ensure show_time is False and direction is not 'stationary' so change_dot_to_stationary runs
-        sensor.get_attr.side_effect = lambda k: False
-        await updater.rollback_update(
-            {"a": 1}, datetime.now(tz=UTC), UpdateStatus.SKIP_SET_STATIONARY
-        )
-    sensor.restore_previous_attr.assert_awaited_once()
-    # Based on the test setup (proceed SKIP_SET_STATIONARY, default direction not 'stationary', seconds=100),
-    # change_dot_to_stationary should have been awaited once; show_time helper should not be awaited.
-    mocks["change_dot_to_stationary"].assert_awaited_once()
-    mocks["change_show_time_to_date"].assert_not_awaited()
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("previous_attr", "status", "now"),
     [
@@ -2323,6 +2294,7 @@ async def test_rollback_update_triggers_helpers(
         # show_time controls whether change_show_time_to_date should be called
         sensor.get_attr.side_effect = lambda k: show_time if k == CONF_SHOW_TIME else False
         await updater.rollback_update({}, datetime.now(tz=UTC), status)
+    sensor.restore_previous_attr.assert_awaited_once_with({})
     if expect_dot:
         mocks["change_dot_to_stationary"].assert_awaited_once()
     else:


### PR DESCRIPTION
## Summary

Streamlines the Places test suite by removing duplicate coverage, consolidating equivalent cases, and strengthening deterministic display assertions. The suite is smaller and easier to maintain while preserving behavior and overall coverage.

## What Changed

- Reused shared fixtures instead of redefining identical local fixtures
- Removed duplicate GPS accuracy, city detail, rollback helper, OSM-type, and advanced rendering tests
- Consolidated persistence, parser, tracker, and display scenarios into focused parameterized tables
- Replaced weak substring and no-op checks with exact output assertions where rendering is deterministic
- Added explicit missing-tracker GPS coverage
- Preserved distinct error boundaries, integration paths, and grounded fallback behavior where consolidation would weaken diagnostics

## Why

Several tests exercised the same behavior through duplicated setup or carried invariant parameters and branches. Keeping one clear behavioral contract per case reduces maintenance overhead and brittle repetition without sacrificing meaningful regression coverage.