### PR TITLE
Improve README and translation spell checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ These can be nested.
 
 * To recreate `place`:
 
-```
+```text
 name_no_dupe, category(-, place), type(-, yes), neighborhood, house_number, street
 ```
 
 * To recreate `formatted_place`:
 
-```
+```text
 zone_name[driving, name_no_dupe[type(-, unclassified, category(-, highway))[category(-, highway)], house_number, route_number(type(+, motorway, trunk))[street[route_number]], neighborhood(type(house))], city_clean[county], state_abbr]
 ```
 
@@ -244,7 +244,7 @@ __Note:__ `place` and `formatted_place` are not valid fields in the advanced dis
 * The OpenStreetMap database is very flexible with regards to tag_names in their database schema.  If you come across a set of coordinates that do not parse properly, you can enable debug logging (see below) to see the actual JSON that is returned from the query.
 * The OpenStreetMap API requests that you include your valid e-mail address in each API call if you are making a large numbers of requests.  They say that this information will be kept confidential and only used to contact you in the event of a problem, see their Usage Policy for more details.
 * The map link that gets generated for Google, Apple or OpenStreetMaps has a push pin marking the users location.
-* When no `language` value is given, default language will be in the location's local language. When a comma separated list of languages is provided - the component will attempt to fill each address field in desired languages by order.
+* When no `language` value is given, default language will be in the location's local language. When a comma-separated list of languages is provided - the component will attempt to fill each address field in desired languages by order.
 * Translations are partial in OpenStreetMap database. For each field, if a translation is missing in first requested language it will be resolved with a language following in the provided list, defaulting to local language if no matching translations were found for the list.
 * To enable debug logging for this component, add the following to your `configuration.yaml` file
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ensure that [HACS](https://hacs.xyz/) is installed
 
 <a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=custom-components&repository=places" target="_blank" rel="noreferrer noopener"><img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Open your Home Assistant instance to download the places integration." /></a>
 
-Download the `places` integrtation
+Download the `places` integration
 
 Restart Home Assistant
 
@@ -35,7 +35,7 @@ Restart Home Assistant
 
 Repeat as needed to create additional `places` entries
 
-Options can be changed for existing `places` entries in Home Assistant Integrations clicking the Gear after the desired  `places` entry.
+Options for existing places entries can be changed by clicking the gear icon next to the desired entry under Settings > Devices & services > `places` integration.
 
 ## Configuration Options
 
@@ -153,7 +153,7 @@ __Note:__ `place` and `formatted_place` are not valid fields in the advanced dis
 
 ```json
 {
-  "formatted_address": "Richmond Hill GO Station, 6, Newkirk Road, Beverley Acres, Richmond Hill, York Region, Ontario, L4C 1B3, Canada",
+  "formatted_address": "Richmond Hill GO Station, 6, Cherry Road, Beverley Acres, Richmond Hill, York Region, Ontario, L4C 1B3, Canada",
   "friendly_name": "sharon",
   "current_latitude": "43.874149009154095",
   "distance_from_home_km": 7.24,
@@ -180,7 +180,7 @@ __Note:__ `place` and `formatted_place` are not valid fields in the advanced dis
   "place_type": "building",
   "previous_latitude": "43.86684124904056",
   "place_name": "Richmond Hill GO Station",
-  "street": "Newkirk Road",
+  "street": "Cherry Road",
   "city": "Richmond Hill",
   "home_zone": "zone.sharon_home"
 }
@@ -213,14 +213,14 @@ __Note:__ `place` and `formatted_place` are not valid fields in the advanced dis
           url: '{{ trigger.event.data.map_link }}'
           hide_thumbnail: false
 
-- alias: ReverseLocateAidan
+- alias: ReverseLocateFred
   initial_state: 'on'
   trigger:
     platform: event
     event_type: places_state_update
   condition:
     condition: template
-    value_template: '{{ trigger.event.data.entity == "aidan" }}'
+    value_template: '{{ trigger.event.data.entity == "fred" }}'
   action:
   - service: notify.ios_jim_iphone8
     data_template:

--- a/README.md
+++ b/README.md
@@ -13,56 +13,29 @@
 [![Coverage][coverage-shield]][coverage]
 [![License][license-shield]](LICENSE)
 [![hacs][hacsbadge]][hacs]
-[![Community Forum][community-forum-shield]](community-forum)
 
 _Component to integrate with OpenStreetMap Reverse Geocode and create a sensor with numerous address and place attributes from a device_tracker, person, or sensor_
 
-## Installation
-### HACS *(recommended)*
-1. Ensure that [HACS](https://hacs.xyz/) is installed
-1. [Click Here](https://my.home-assistant.io/redirect/hacs_repository/?owner=custom-components&repository=places) to directly open `places` in HACS **or**<br/>
-  a. Navigate to HACS<br/>
-  b. Click `+ Explore & Download Repositories`<br/>
-  c. Find the `places` integration <br/>
-1. Click `Download`
-1. Restart Home Assistant
-1. See [Configuration](#configuration) below
 
-<details>
-<summary><h3>Manual</h3></summary>
+## Installation via HACS
 
-You probably <u>do not</u> want to do this! Use the HACS method above unless you know what you are doing and have a good reason as to why you are installing manually
+Ensure that [HACS](https://hacs.xyz/) is installed
 
-1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`)
-1. If you do not have a `custom_components` directory there, you need to create it
-1. In the `custom_components` directory create a new folder called `places`
-1. Download _all_ the files from the `custom_components/places/` directory in this repository
-1. Place the files you downloaded in the new directory you created
-1. Restart Home Assistant
-1. See [Configuration](#configuration) below
+<a href="https://my.home-assistant.io/redirect/hacs_repository/?owner=custom-components&repository=places" target="_blank" rel="noreferrer noopener"><img src="https://my.home-assistant.io/badges/hacs_repository.svg" alt="Open your Home Assistant instance to download the places integration." /></a>
 
-Using your HA configuration directory as a starting point you should now also have this:
-```text
-custom_components/places/__init__.py
-custom_components/places/config_flow.py
-custom_components/places/const.py
-custom_components/places/manifest.json
-custom_components/places/sensor.py
-custom_components/places/strings.json
-custom_components/places/translations
-custom_components/places/translations/en.json
-```
-</details>
+Download the `places` integrtation
+
+Restart Home Assistant
 
 ## Configuration
-**Configuration is done in the Integrations section of Home Assistant.**
-1. [Click Here](https://my.home-assistant.io/redirect/config_flow_start/?domain=places) to directly add a `places` sensor **or**<br/>
-  a. In Home Assistant, go to Settings -> [Integrations](https://my.home-assistant.io/redirect/integrations/)<br/>
-  b. Click `+ Add Integrations` and select `places`<br/>
-1. Add your configuration ([see Configuration Options below](#configuration-options))
-1. Click `Submit`
-* Repeat as needed to create additional `places` sensors
-* Options can be changed for existing `places` sensors in Home Assistant Integrations by selecting `Configure` under the desired  `places` sensor.
+
+<a href="https://my.home-assistant.io/redirect/config_flow_start/?domain=places" target="_blank" rel="noreferrer noopener"><img src="https://my.home-assistant.io/badges/config_flow_start.svg" alt="Open your Home Assistant instance to create a places entry." /></a>
+
+[See Configuration Options below](#configuration-options)
+
+Repeat as needed to create additional `places` entries
+
+Options can be changed for existing `places` entries in Home Assistant Integrations clicking the Gear after the desired  `places` entry.
 
 ## Configuration Options
 
@@ -87,13 +60,16 @@ To use, simply enter your advanced options into the `display_options` text area.
 __Tip:__ _Build your advanced display options string in a text editor and copy/paste it into display_options field as it is pretty small._
 
 ### __Brackets [ ]:__ Fields to show if initial field is blank or empty<br />
+
 These can be nested.
+
 #### Examples
 
 * `name[type]` will show the name, but if name is blank, will show the type instead. If type is also blank, nothing will show for that field
 * `name[type[category]]` will show the name, but if name is blank, will show the type instead, but if type is blank, will show the category. If category is also blank, nothing will show for that field.
 
 ### __Parenthesis ( ):__ Inclusion/Exclusion Logic to filter the field<br />
+
 #### To include/exclude based on the main field
 
 * __Include:__ Set the first item inside the parenthesis to + to only show the field if it equals one of the states listed
@@ -129,10 +105,13 @@ These can be nested.
 ### Brackets and Parenthesis can also be combined
 
 * To recreate `place`:
+
 ```
 name_no_dupe, category(-, place), type(-, yes), neighborhood, house_number, street
 ```
+
 * To recreate `formatted_place`:
+
 ```
 zone_name[driving, name_no_dupe[type(-, unclassified, category(-, highway))[category(-, highway)], house_number, route_number(type(+, motorway, trunk))[street[route_number]], neighborhood(type(house))], city_clean[county], state_abbr]
 ```
@@ -206,12 +185,14 @@ __Note:__ `place` and `formatted_place` are not valid fields in the advanced dis
   "home_zone": "zone.sharon_home"
 }
 ```
+
 </details>
 
 <details>
 <summary>Sample generic `automations.yaml` snippet to send an iOS notify on any device state change</summary>
 
 (the only difference is the second one uses a condition to only trigger for a specific user)
+
 ```yaml
 - alias: ReverseLocateEveryone
   initial_state: 'on'
@@ -254,16 +235,19 @@ __Note:__ `place` and `formatted_place` are not valid fields in the advanced dis
           url: '{{ trigger.event.data.map_link }}'
           hide_thumbnail: false
 ```
+
 </details>
 
 ## Notes
+
 * This component is only useful to those who have device tracking enabled via a mechanism that provides latitude and longitude coordinates (such as the [Home Assistant Mobile App](https://www.home-assistant.io/integrations/mobile_app/), [OwnTracks](https://www.home-assistant.io/integrations/owntracks/), or [iCloud3](https://github.com/gcobb321/icloud3)).
 * The OpenStreetMap database is very flexible with regards to tag_names in their database schema.  If you come across a set of coordinates that do not parse properly, you can enable debug logging (see below) to see the actual JSON that is returned from the query.
 * The OpenStreetMap API requests that you include your valid e-mail address in each API call if you are making a large numbers of requests.  They say that this information will be kept confidential and only used to contact you in the event of a problem, see their Usage Policy for more details.
-* The map link that gets generated for Google, Apple or OpenStreetMaps has a push pin marking the users location. Note that when opening the Apple link on a non-Apple device, it will open in Google Maps.
+* The map link that gets generated for Google, Apple or OpenStreetMaps has a push pin marking the users location.
 * When no `language` value is given, default language will be in the location's local language. When a comma separated list of languages is provided - the component will attempt to fill each address field in desired languages by order.
 * Translations are partial in OpenStreetMap database. For each field, if a translation is missing in first requested language it will be resolved with a language following in the provided list, defaulting to local language if no matching translations were found for the list.
 * To enable debug logging for this component, add the following to your `configuration.yaml` file
+
 ```yaml
 logger:
   default: warning
@@ -281,10 +265,12 @@ python -m pip install --group dev -e .
 ```
 
 ## Prior Contributions:
+
 * Previous Authors: [Jim Thompson](https://github.com/tenly2000) & [Ian Richardson](https://github.com/iantrich)
 * Current Author: [Snuffy2](https://github.com/Snuffy2)
 
 ## Contributions are welcome!
+
 If you want to contribute to this please read the [Contribution guidelines](CONTRIBUTING.md)
 ***
 
@@ -299,7 +285,5 @@ If you want to contribute to this please read the [Contribution guidelines](CONT
 [license-shield]: https://img.shields.io/github/license/custom-components/places?color=blue&style=for-the-badge
 [hacsbadge]: https://img.shields.io/badge/HACS-Default-blue.svg?style=for-the-badge
 [hacs]: https://hacs.xyz
-[community-forum-shield]: https://img.shields.io/badge/community-forum-orange.svg?label=HA%20Community&style=for-the-badge
-[community-forum]: https://community.home-assistant.io/t/reverse-geocode-sensor-places-using-openstreetmap-custom-component
 [coverage]: https://htmlpreview.github.io/?https://github.com/custom-components/places/blob/python-coverage-comment-action-data/htmlcov/index.html
 [coverage-shield]: https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcustom-components%2Fplaces%2Fpython-coverage-comment-action-data%2Fendpoint.json&style=for-the-badge

--- a/cspell.config.toml
+++ b/cspell.config.toml
@@ -1,0 +1,22 @@
+language = "en"
+allowCompoundWords = false
+caseSensitive = false
+words = [
+    "aiohttp",
+    "automations",
+    "conftest",
+    "devicetracker",
+    "docstrings",
+    "entityid",
+    "hacs",
+    "hass",
+    "homeassistant",
+    "licence",
+    "mypy",
+    "neighbourhood",
+    "parameterizing",
+    "prek",
+    "pyproject",
+    "pytest",
+    "venv",
+]

--- a/cspell.config.toml
+++ b/cspell.config.toml
@@ -1,6 +1,14 @@
 language = "en"
 allowCompoundWords = false
 caseSensitive = false
+import = [
+    "@cspell/dict-cs-cz/cspell-ext.json",
+    "@cspell/dict-it-it/cspell-ext.json",
+    "@cspell/dict-ru_ru/cspell-ext.json",
+    "@cspell/dict-sk-sk/cspell-ext.json",
+    "@cspell/dict-uk-ua/cspell-ext.json",
+]
+
 words = [
     "aiohttp",
     "automations",
@@ -14,9 +22,34 @@ words = [
     "licence",
     "mypy",
     "neighbourhood",
+    "nbsp",
     "parameterizing",
     "prek",
     "pyproject",
     "pytest",
     "venv",
 ]
+
+[[overrides]]
+filename = "**/custom_components/places/translations/cs.json"
+language = "cs,en"
+
+[[overrides]]
+filename = "**/custom_components/places/translations/en.json"
+language = "en"
+
+[[overrides]]
+filename = "**/custom_components/places/translations/it.json"
+language = "it,en"
+
+[[overrides]]
+filename = "**/custom_components/places/translations/ru.json"
+language = "ru,en"
+
+[[overrides]]
+filename = "**/custom_components/places/translations/sk.json"
+language = "sk,en"
+
+[[overrides]]
+filename = "**/custom_components/places/translations/uk.json"
+language = "uk,en"

--- a/custom_components/places/translations/cs.json
+++ b/custom_components/places/translations/cs.json
@@ -25,9 +25,9 @@
                     "date_format": "Formát data, který se zobrazí na konci stavu, když se nezmění za 24 hodin",
                     "use_gps_accuracy": "Použití přesnosti GPS"
                 },
-                "description": "Vytvořte nový senzor\nPodrobnosti najdete v [Možnosti konfigurace] ({component_config_url}) na GitHub",
+                "description": "Vytvořte nový senzor\nPodrobnosti najdete v [Možnosti konfigurace]({component_config_url}) na GitHub",
                 "data_description": {
-                    "options": "Podrobnosti najdete v [Možnosti konfigurace] ({component_config_url}) na GitHub",
+                    "options": "Podrobnosti najdete v [Možnosti konfigurace]({component_config_url}) na GitHub",
                     "extended_attr": "Zobrazit rozšířené atributy: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (pokud existují). Poskytuje mnoho dalších atributů pro pokročilou logiku. Upozornění: atributy budou velmi dlouhé!",
                     "use_gps_accuracy": "Tuto možnost vypněte, pokud má váš nástroj pro sledování zařízení atribut přesnosti GPS (gps_accuracy), ale vždy zobrazuje 0, i když jsou zeměpisná šířka a délka správné."
                   }
@@ -60,7 +60,7 @@
                 },
                 "description": "**Aktualizuje se senzor:&nbsp;{sensor_name}**\nPodrobnosti najdete v [Možnosti konfigurace]({component_config_url}) na GitHub",
                 "data_description": {
-                    "options": "Podrobnosti najdete v [Možnosti konfigurace] ({component_config_url}) na GitHub",
+                    "options": "Podrobnosti najdete v [Možnosti konfigurace]({component_config_url}) na GitHub",
                     "extended_attr": "Zobrazit rozšířené atributy: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (pokud existují). Poskytuje mnoho dalších atributů pro pokročilou logiku. Upozornění: atributy budou velmi dlouhé!",
                     "use_gps_accuracy": "Tuto možnost vypněte, pokud má váš nástroj pro sledování zařízení atribut přesnosti GPS (gps_accuracy), ale vždy zobrazuje 0, i když jsou zeměpisná šířka a délka správné."
                   }

--- a/custom_components/places/translations/cs.json
+++ b/custom_components/places/translations/cs.json
@@ -18,18 +18,18 @@
                     "options": "Možnosti zobrazení",
                     "map_provider": "Poskytovatel mapy",
                     "map_zoom": "Přiblížení mapy",
-                    "api_key": "E-mail na použití jako OpenStreetMap API Key (volitelné)",
+                    "api_key": "E-mail použitý jako klíč OpenStreetMap API (volitelné)",
                     "language": "Jazyk (volitelné)",
                     "extended_attr": "Povolit rozšířené atributy",
                     "show_time": "Zobrazit čas poslední aktualizace na konci stavu '(od xx:yy)'",
-                    "date_format": "Formát datumu, který se zobrazí na konci stavu, když se nezmení za 24 hodin",
+                    "date_format": "Formát data, který se zobrazí na konci stavu, když se nezmění za 24 hodin",
                     "use_gps_accuracy": "Použití přesnosti GPS"
                 },
                 "description": "Vytvořte nový senzor\nPodrobnosti najdete v [Možnosti konfigurace] ({component_config_url}) na GitHub",
                 "data_description": {
                     "options": "Podrobnosti najdete v [Možnosti konfigurace] ({component_config_url}) na GitHub",
-                    "extended_attr": "Show extended attributes: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Provides many additional attributes for advanced logic. Warning, this will make the attributes very long!",
-                    "use_gps_accuracy": "Nastavte toto na False, pokud má váš nástroj pro sledování zařízení atribut Přesnost GPS (gps_accuracy), ale vždy zobrazuje 0, i když jsou zeměpisná šířka a délka správné."
+                    "extended_attr": "Zobrazit rozšířené atributy: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (pokud existují). Poskytuje mnoho dalších atributů pro pokročilou logiku. Upozornění: atributy budou velmi dlouhé!",
+                    "use_gps_accuracy": "Tuto možnost vypněte, pokud má váš nástroj pro sledování zařízení atribut přesnosti GPS (gps_accuracy), ale vždy zobrazuje 0, i když jsou zeměpisná šířka a délka správné."
                   }
             }
         }
@@ -51,18 +51,18 @@
                     "options": "Možnosti zobrazení",
                     "map_provider": "Poskytovatel mapy",
                     "map_zoom": "Přiblížení mapy",
-                    "api_key": "E-mail na použití jako OpenStreetMap API Key (volitelné)",
+                    "api_key": "E-mail použitý jako klíč OpenStreetMap API (volitelné)",
                     "language": "Jazyk (volitelné)",
-                    "extended_attr": "Povolit rozšírené atributy",
+                    "extended_attr": "Povolit rozšířené atributy",
                     "show_time": "Zobrazit čas poslední aktualizace na konci stavu '(od xx:yy)'",
-                    "date_format": "Formát datumu, který se zobrazí na konci stavu, když se nezmení za 24 hodín",
+                    "date_format": "Formát data, který se zobrazí na konci stavu, když se nezmění za 24 hodin",
                     "use_gps_accuracy": "Použití přesnosti GPS"
                 },
                 "description": "**Aktualizuje se senzor:&nbsp;{sensor_name}**\nPodrobnosti najdete v [Možnosti konfigurace]({component_config_url}) na GitHub",
                 "data_description": {
                     "options": "Podrobnosti najdete v [Možnosti konfigurace] ({component_config_url}) na GitHub",
-                    "extended_attr": "Show extended attributes: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Provides many additional attributes for advanced logic. Warning, this will make the attributes very long!",
-                    "use_gps_accuracy": "Nastavte toto na False, pokud má váš nástroj pro sledování zařízení atribut Přesnost GPS (gps_accuracy), ale vždy zobrazuje 0, i když jsou zeměpisná šířka a délka správné."
+                    "extended_attr": "Zobrazit rozšířené atributy: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (pokud existují). Poskytuje mnoho dalších atributů pro pokročilou logiku. Upozornění: atributy budou velmi dlouhé!",
+                    "use_gps_accuracy": "Tuto možnost vypněte, pokud má váš nástroj pro sledování zařízení atribut přesnosti GPS (gps_accuracy), ale vždy zobrazuje 0, i když jsou zeměpisná šířka a délka správné."
                   }
             }
         }

--- a/custom_components/places/translations/it.json
+++ b/custom_components/places/translations/it.json
@@ -12,24 +12,24 @@
             "user": {
                 "title": "Places: Sensore OpenStreetMap",
                 "data": {
-                    "name": "Nome del Sensore",
-                    "devicetracker_id": "Entity ID del Dispositivo Tracciato",
-                    "home_zone": "Zona Casa",
-                    "options": "Visualizza Opzioni",
-                    "map_provider": "Provider della Mappa",
-                    "map_zoom": "Zoom della Mappa",
-                    "api_key": "Email da usare per l'API Key di OpenStreetMap API Key (opzionale)",
+                    "name": "Nome del sensore",
+                    "devicetracker_id": "ID dell'entità tracciata",
+                    "home_zone": "Zona di casa",
+                    "options": "Opzioni di visualizzazione",
+                    "map_provider": "Fornitore della mappa",
+                    "map_zoom": "Zoom della mappa",
+                    "api_key": "Email da usare come chiave API di OpenStreetMap (opzionale)",
                     "language": "Lingua (opzionale)",
-                    "use_gps_accuracy": "Usa Precisone GPS",
-                    "extended_attr": "Abilita gli Attributi Estesi",
-                    "show_time": "Mostra l'ultima volta che lo stato è stato aggiornato'(dalle xx:yy)'",
-                    "date_format": "Formato della data da mostrare alla fine dello stato se non è cambiato da >24h"
+                    "use_gps_accuracy": "Usa la precisione GPS",
+                    "extended_attr": "Abilita gli attributi estesi",
+                    "show_time": "Mostra l'ora dell'ultimo aggiornamento alla fine dello stato (dalle xx:yy)",
+                    "date_format": "Formato della data da mostrare alla fine dello stato se non è cambiato da oltre 24 ore"
                 },
-                "description": "Crea un nuovo sensore\nGuarda [Configuration Options]({component_config_url}) su GitHub per i dettagli (in Inglese)",
+                "description": "Crea un nuovo sensore\nConsulta [Opzioni di configurazione]({component_config_url}) su GitHub per i dettagli",
                 "data_description": {
-                    "options": "Guarda [Configuration Options]({component_config_url}) su GitHub per i dettagli (in Inglese)",
-                    "extended_attr": "Mostra gli Attributi Estesi: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Fornisci attributi aggiuntivi per logiche avanzate. Attenzione, questo renderà l'elenco attributi molto lunga!",
-                    "use_gps_accuracy": "Imposta su False se il tuo Device Tracker ha un attributo Precisione GPS (gps_accuracy), ma mostra sempre 0 anche se latitudine e longitudine sono corrette."
+                    "options": "Consulta [Opzioni di configurazione]({component_config_url}) su GitHub per i dettagli",
+                    "extended_attr": "Mostra gli attributi estesi: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (se presenti). Fornisce molti attributi aggiuntivi per logiche avanzate. Attenzione: questo renderà l'elenco degli attributi molto lungo!",
+                    "use_gps_accuracy": "Imposta su falso se il dispositivo di tracciamento dispone di un attributo di precisione GPS (gps_accuracy), ma mostra sempre 0 anche quando latitudine e longitudine sono corrette."
                   }
             }
         }
@@ -46,23 +46,23 @@
             "init": {
                 "title": "Places: Sensore OpenStreetMap",
                 "data": {
-                    "devicetracker_id": "Entity ID del Dispositivo Tracciato",
-                    "home_zone": "Zona Casa",
-                    "options": "Visualizza Opzioni",
-                    "map_provider": "Provider della Mappa",
-                    "map_zoom": "Zoom della Mappa",
-                    "api_key": "Email da usare per l'API Key di OpenStreetMap API Key (opzionale)",
+                    "devicetracker_id": "ID dell'entità tracciata",
+                    "home_zone": "Zona di casa",
+                    "options": "Opzioni di visualizzazione",
+                    "map_provider": "Fornitore della mappa",
+                    "map_zoom": "Zoom della mappa",
+                    "api_key": "Email da usare come chiave API di OpenStreetMap (opzionale)",
                     "language": "Lingua (opzionale)",
-                    "use_gps_accuracy": "Usa Precisone GPS",
-                    "extended_attr": "Abilita gli Attributi Estesi",
-                    "show_time": "Mostra l'ultima volta che lo stato è stato aggiornato'(dalle xx:yy)'",
-                    "date_format": "Formato della data da mostrare alla fine dello stato se non è cambiato da >24h"
+                    "use_gps_accuracy": "Usa la precisione GPS",
+                    "extended_attr": "Abilita gli attributi estesi",
+                    "show_time": "Mostra l'ora dell'ultimo aggiornamento alla fine dello stato (dalle xx:yy)",
+                    "date_format": "Formato della data da mostrare alla fine dello stato se non è cambiato da oltre 24 ore"
                 },
-                "description": "**Aggiornamento sensore:&nbsp;{sensor_name}**\nGuarda [Configuration Options]({component_config_url}) su GitHub per i dettagli (in Inglese)",
+                "description": "**Aggiornamento sensore:&nbsp;{sensor_name}**\nConsulta [Opzioni di configurazione]({component_config_url}) su GitHub per i dettagli",
                 "data_description": {
-                    "options": "Guarda [Configuration Options]({component_config_url}) su GitHub per i dettagli (in Inglese)",
-                    "extended_attr": "Mostra gli Attributi Estesi: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Fornisci attributi aggiuntivi per logiche avanzate. Attenzione, questo renderà l'elenco attributi molto lunga!",
-                    "use_gps_accuracy": "Imposta su False se il tuo Device Tracker ha un attributo Precisione GPS (gps_accuracy), ma mostra sempre 0 anche se latitudine e longitudine sono corrette."
+                    "options": "Consulta [Opzioni di configurazione]({component_config_url}) su GitHub per i dettagli",
+                    "extended_attr": "Mostra gli attributi estesi: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (se presenti). Fornisce molti attributi aggiuntivi per logiche avanzate. Attenzione: questo renderà l'elenco degli attributi molto lungo!",
+                    "use_gps_accuracy": "Imposta su falso se il dispositivo di tracciamento dispone di un attributo di precisione GPS (gps_accuracy), ma mostra sempre 0 anche quando latitudine e longitudine sono corrette."
                   }
             }
         }

--- a/custom_components/places/translations/ru.json
+++ b/custom_components/places/translations/ru.json
@@ -13,7 +13,7 @@
                 "title": "Места: Сенсор OpenStreetMap",
                 "data": {
                     "name": "Название датчика",
-                    "devicetracker_id": "DeviceTracker Идентификатор",
+                    "devicetracker_id": "Идентификатор отслеживаемой сущности",
                     "home_zone": "Домашняя зона",
                     "options": "Показать варианты",
                     "map_provider": "Поставщик карт",
@@ -27,8 +27,8 @@
                 "description": "Создайте новый датчик\nПодробнее см. [Параметры конфигурации]({component_config_url}) на GitHub.",
                 "data_description": {
                     "options": "Подробнее см. [Параметры конфигурации]({component_config_url}) на GitHub",
-                    "extended_attr": "Show extended attributes: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Provides many additional attributes for advanced logic. Warning, this will make the attributes very long!",
-                    "use_gps_accuracy": "Set this to False if your Device Tracker has a GPS Accuracy (gps_accuracy) attribute, but it always shows 0 even if the latitude and longitude are correct."
+                    "extended_attr": "Показывать расширенные атрибуты: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (если они существуют). Они предоставляют множество дополнительных атрибутов для расширенной логики. Внимание: это сделает атрибуты очень длинными!",
+                    "use_gps_accuracy": "Отключите этот параметр, если у вашей отслеживаемой сущности есть атрибут точности GPS (gps_accuracy), но он всегда показывает 0, даже если широта и долгота указаны правильно."
                   }
             }
         }
@@ -45,7 +45,7 @@
             "init": {
                 "title": "Места: Сенсор OpenStreetMap",
                 "data": {
-                    "devicetracker_id": "DeviceTracker Идентификатор",
+                    "devicetracker_id": "Идентификатор отслеживаемой сущности",
                     "home_zone": "Домашняя зона",
                     "options": "Показать варианты",
                     "map_provider": "Поставщик карт",
@@ -59,8 +59,8 @@
                 "description": "**Обновление сенсора:&nbsp;{sensor_name}**\nПодробности см. в [Параметры конфигурации]({component_config_url}) на GitHub.",
                 "data_description": {
                     "options": "Подробнее см. [Параметры конфигурации]({component_config_url}) на GitHub",
-                    "extended_attr": "Show extended attributes: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Provides many additional attributes for advanced logic. Warning, this will make the attributes very long!",
-                    "use_gps_accuracy": "Set this to False if your Device Tracker has a GPS Accuracy (gps_accuracy) attribute, but it always shows 0 even if the latitude and longitude are correct."
+                    "extended_attr": "Показывать расширенные атрибуты: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (если они существуют). Они предоставляют множество дополнительных атрибутов для расширенной логики. Внимание: это сделает атрибуты очень длинными!",
+                    "use_gps_accuracy": "Отключите этот параметр, если у вашей отслеживаемой сущности есть атрибут точности GPS (gps_accuracy), но он всегда показывает 0, даже если широта и долгота указаны правильно."
                   }
             }
         }

--- a/custom_components/places/translations/sk.json
+++ b/custom_components/places/translations/sk.json
@@ -18,7 +18,7 @@
                     "options": "Možnosti zobrazenia",
                     "map_provider": "Poskytovateľ mapy",
                     "map_zoom": "Priblíženie mapy",
-                    "api_key": "E-mail na použitie ako OpenStreetMap API Key (voliteľné)",
+                    "api_key": "E-mail použitý ako kľúč OpenStreetMap API (voliteľné)",
                     "language": "Jazyk (voliteľné)",
                     "extended_attr": "Povoliť rozšírené atribúty",
                     "show_time": "Zobraziť čas poslednej aktualizácie na konci stavu '(od xx:yy)'",
@@ -28,8 +28,8 @@
                 "description": "Vytvorte nový senzor\nPodrobnosti nájdete v [Možnosti konfigurácie] ({component_config_url}) na GitHub",
                 "data_description": {
                     "options": "Podrobnosti nájdete v [Možnosti konfigurácie] ({component_config_url}) na GitHub",
-                    "extended_attr": "Show extended attributes: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Provides many additional attributes for advanced logic. Warning, this will make the attributes very long!",
-                    "use_gps_accuracy": "Set this to False if your Device Tracker has a GPS Accuracy (gps_accuracy) attribute, but it always shows 0 even if the latitude and longitude are correct."
+                    "extended_attr": "Zobraziť rozšírené atribúty: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (ak existujú). Poskytuje mnoho ďalších atribútov pre pokročilú logiku. Upozornenie: atribúty budú veľmi dlhé!",
+                    "use_gps_accuracy": "Túto možnosť vypnite, ak má váš sledovač zariadení atribút presnosti GPS (gps_accuracy), ale vždy zobrazuje 0, aj keď sú zemepisná šírka a dĺžka správne."
                   }
             }
         }
@@ -51,7 +51,7 @@
                     "options": "Možnosti zobrazenia",
                     "map_provider": "Poskytovateľ mapy",
                     "map_zoom": "Priblíženie mapy",
-                    "api_key": "E-mail na použitie ako OpenStreetMap API Key (voliteľné)",
+                    "api_key": "E-mail použitý ako kľúč OpenStreetMap API (voliteľné)",
                     "language": "Jazyk (voliteľné)",
                     "extended_attr": "Povoliť rozšírené atribúty",
                     "show_time": "Zobraziť čas poslednej aktualizácie na konci stavu '(od xx:yy)'",
@@ -61,8 +61,8 @@
                 "description": "**Aktualizuje sa senzor:&nbsp;{sensor_name}**\nPodrobnosti nájdete v [Možnosti konfigurácie]({component_config_url}) na GitHub",
                 "data_description": {
                     "options": "Podrobnosti nájdete v [Možnosti konfigurácie] ({component_config_url}) na GitHub",
-                    "extended_attr": "Show extended attributes: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Provides many additional attributes for advanced logic. Warning, this will make the attributes very long!",
-                    "use_gps_accuracy": "Set this to False if your Device Tracker has a GPS Accuracy (gps_accuracy) attribute, but it always shows 0 even if the latitude and longitude are correct."
+                    "extended_attr": "Zobraziť rozšírené atribúty: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (ak existujú). Poskytuje mnoho ďalších atribútov pre pokročilú logiku. Upozornenie: atribúty budú veľmi dlhé!",
+                    "use_gps_accuracy": "Túto možnosť vypnite, ak má váš sledovač zariadení atribút presnosti GPS (gps_accuracy), ale vždy zobrazuje 0, aj keď sú zemepisná šírka a dĺžka správne."
                   }
             }
         }

--- a/custom_components/places/translations/sk.json
+++ b/custom_components/places/translations/sk.json
@@ -25,9 +25,9 @@
                     "date_format": "Formát dátumu, ktorý sa zobrazí na konci stavu, keď sa nezmení >24 hodín",
                     "use_gps_accuracy": "Použite presnosť GPS"
                 },
-                "description": "Vytvorte nový senzor\nPodrobnosti nájdete v [Možnosti konfigurácie] ({component_config_url}) na GitHub",
+                "description": "Vytvorte nový senzor\nPodrobnosti nájdete v [Možnosti konfigurácie]({component_config_url}) na GitHub",
                 "data_description": {
-                    "options": "Podrobnosti nájdete v [Možnosti konfigurácie] ({component_config_url}) na GitHub",
+                    "options": "Podrobnosti nájdete v [Možnosti konfigurácie]({component_config_url}) na GitHub",
                     "extended_attr": "Zobraziť rozšírené atribúty: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (ak existujú). Poskytuje mnoho ďalších atribútov pre pokročilú logiku. Upozornenie: atribúty budú veľmi dlhé!",
                     "use_gps_accuracy": "Túto možnosť vypnite, ak má váš sledovač zariadení atribút presnosti GPS (gps_accuracy), ale vždy zobrazuje 0, aj keď sú zemepisná šírka a dĺžka správne."
                   }
@@ -60,7 +60,7 @@
                 },
                 "description": "**Aktualizuje sa senzor:&nbsp;{sensor_name}**\nPodrobnosti nájdete v [Možnosti konfigurácie]({component_config_url}) na GitHub",
                 "data_description": {
-                    "options": "Podrobnosti nájdete v [Možnosti konfigurácie] ({component_config_url}) na GitHub",
+                    "options": "Podrobnosti nájdete v [Možnosti konfigurácie]({component_config_url}) na GitHub",
                     "extended_attr": "Zobraziť rozšírené atribúty: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (ak existujú). Poskytuje mnoho ďalších atribútov pre pokročilú logiku. Upozornenie: atribúty budú veľmi dlhé!",
                     "use_gps_accuracy": "Túto možnosť vypnite, ak má váš sledovač zariadení atribút presnosti GPS (gps_accuracy), ale vždy zobrazuje 0, aj keď sú zemepisná šírka a dĺžka správne."
                   }

--- a/custom_components/places/translations/uk.json
+++ b/custom_components/places/translations/uk.json
@@ -3,7 +3,7 @@
     "config": {
         "error": {
             "unknown": "Неочікувана помилка",
-            "bracket_mismatch": "Кількість дужок або круглих дужок не співпадає у розширених параметрах відображення",
+            "bracket_mismatch": "Кількість дужок або круглих дужок не збігається у розширених параметрах відображення",
             "invalid_characters": "Недопустимі символи у розширених параметрах відображення",
             "invalid_syntax": "Неправильний синтаксис у розширених параметрах відображення",
             "invalid_option": "Недопустима опція у розширених параметрах відображення"
@@ -13,22 +13,22 @@
                 "title": "Місця: датчик OpenStreetMap",
                 "data": {
                     "name": "Назва датчика",
-                    "devicetracker_id": "DeviceTracker Ідентифікатор",
+                    "devicetracker_id": "Ідентифікатор відстежуваної сутності",
                     "home_zone": "Домашня зона",
                     "options": "Параметри відображення",
                     "map_provider": "Постачальник карт",
                     "map_zoom": "Масштаб карти",
-                    "api_key": "Електронна пошта для використання як ключа OpenStreetMap API (необов’язково)",
+                    "api_key": "Електронна пошта для використання як ключа OpenStreetMap API (необов'язково)",
                     "language": "Мова (необов'язково)",
                     "extended_attr": "Увімкнути розширені атрибути",
                     "show_time": "Показати час останнього оновлення в кінці стану '(з xx:yy)'",
                     "use_gps_accuracy": "Використовуйте точність GPS"
                 },
-                "description": "Create a new sensor\nДетальніше див. [Параметри конфігурації]({component_config_url}) на GitHub",
+                "description": "Створити новий датчик\nДетальніше див. [Параметри конфігурації]({component_config_url}) на GitHub",
                 "data_description": {
                     "options": "Детальніше див. [Параметри конфігурації]({component_config_url}) на GitHub",
-                    "extended_attr": "Show extended attributes: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Provides many additional attributes for advanced logic. Warning, this will make the attributes very long!",
-                    "use_gps_accuracy": "Set this to False if your Device Tracker has a GPS Accuracy (gps_accuracy) attribute, but it always shows 0 even if the latitude and longitude are correct."
+                    "extended_attr": "Показувати розширені атрибути: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (якщо вони існують). Вони надають багато додаткових атрибутів для розширеної логіки. Увага: це зробить атрибути дуже довгими!",
+                    "use_gps_accuracy": "Вимкніть цей параметр, якщо ваша відстежувана сутність має атрибут точності GPS (gps_accuracy), але він завжди показує 0, навіть якщо широта й довгота правильні."
                   }
             }
         }
@@ -36,7 +36,7 @@
     "options": {
         "error": {
             "unknown": "Неочікувана помилка",
-            "bracket_mismatch": "Кількість дужок або круглих дужок не співпадає у розширених параметрах відображення",
+            "bracket_mismatch": "Кількість дужок або круглих дужок не збігається у розширених параметрах відображення",
             "invalid_characters": "Недопустимі символи у розширених параметрах відображення",
             "invalid_syntax": "Неправильний синтаксис у розширених параметрах відображення",
             "invalid_option": "Недопустима опція у розширених параметрах відображення"
@@ -45,12 +45,12 @@
             "init": {
                 "title": "Місця: датчик OpenStreetMap",
                 "data": {
-                    "devicetracker_id": "DeviceTracker Ідентифікатор",
+                    "devicetracker_id": "Ідентифікатор відстежуваної сутності",
                     "home_zone": "Домашня зона",
                     "options": "Параметри відображення",
                     "map_provider": "Постачальник карт",
                     "map_zoom": "Масштаб карти",
-                    "api_key": "Електронна пошта для використання як ключа OpenStreetMap API (необов’язково)",
+                    "api_key": "Електронна пошта для використання як ключа OpenStreetMap API (необов'язково)",
                     "language": "Мова (необов'язково)",
                     "extended_attr": "Увімкнути розширені атрибути",
                     "show_time": "Показати час останнього оновлення в кінці стану '(з xx:yy)'",
@@ -59,8 +59,8 @@
                 "description": "**Оновлення датчика:&nbsp;{sensor_name}**\nДетальніше див. [Параметри конфігурації]({component_config_url}) на GitHub",
                 "data_description": {
                     "options": "Детальніше див. [Параметри конфігурації]({component_config_url}) на GitHub",
-                    "extended_attr": "Show extended attributes: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (if they exist). Provides many additional attributes for advanced logic. Warning, this will make the attributes very long!",
-                    "use_gps_accuracy": "Set this to False if your Device Tracker has a GPS Accuracy (gps_accuracy) attribute, but it always shows 0 even if the latitude and longitude are correct."
+                    "extended_attr": "Показувати розширені атрибути: wikidata_id, osm_dict, osm_details_dict, wikidata_dict (якщо вони існують). Вони надають багато додаткових атрибутів для розширеної логіки. Увага: це зробить атрибути дуже довгими!",
+                    "use_gps_accuracy": "Вимкніть цей параметр, якщо ваша відстежувана сутність має атрибут точності GPS (gps_accuracy), але він завжди показує 0, навіть якщо широта й довгота правильні."
                   }
             }
         }

--- a/prek.toml
+++ b/prek.toml
@@ -40,7 +40,14 @@ rev = "v10.0.1"
 
 [[repos.hooks]]
 id = "cspell"
-files = "\\.md$"
+files = "(?:\\.md$|custom_components/places/translations/(?:cs|en|it|ru|sk|uk)\\.json$)"
+additional_dependencies = [
+  "@cspell/dict-cs-cz@3.0.8",
+  "@cspell/dict-it-it@3.1.6",
+  "@cspell/dict-ru_ru@2.3.2",
+  "@cspell/dict-sk-sk@1.1.7",
+  "@cspell/dict-uk-ua@4.0.6",
+]
 
 [[repos]]
 repo = "https://github.com/pre-commit/mirrors-mypy"

--- a/prek.toml
+++ b/prek.toml
@@ -35,6 +35,14 @@ rev = "v2.4.2"
 id = "codespell"
 
 [[repos]]
+repo = "https://github.com/streetsidesoftware/cspell-cli"
+rev = "v10.0.1"
+
+[[repos.hooks]]
+id = "cspell"
+files = "\\.md$"
+
+[[repos]]
 repo = "https://github.com/pre-commit/mirrors-mypy"
 rev = "v2.1.0"
 


### PR DESCRIPTION
## Summary
Modernizes the installation and configuration guidance in the README and adds multilingual spell checking for documentation and translation files.

## What Changed
- Simplified the HACS installation and Home Assistant configuration instructions with My Home Assistant badges
- Added cspell to the `prek` checks with dictionaries for supported translation languages
- Corrected spelling, grammar, and untranslated text in Czech, Italian, Russian, Slovak, and Ukrainian translations
- Replaced personal names and location details in README examples with generic values

## Why
Clearer setup instructions make the integration easier to install and configure. Automated multilingual spell checking helps keep documentation and translations consistent as they evolve.