### PR TITLE
fix: preserve zone attrs on rollback when tracker is stationary

### DIFF
--- a/custom_components/places/pipeline.py
+++ b/custom_components/places/pipeline.py
@@ -61,9 +61,25 @@ class PlacesUpdatePipeline:
                         "(%s) No entity update needed, Previous State = New State",
                         sensor.get_attr(CONF_NAME),
                     )
-                    await self.updater.rollback_update(previous_attr, now, proceed_with_update)
+                    # Reached the update end (PROCEED) with no state change, so the
+                    # freshly resolved zone is still valid - preserve it.
+                    await self.updater.rollback_update(
+                        previous_attr, now, proceed_with_update, preserve_zone_attrs=True
+                    )
             else:
-                await self.updater.rollback_update(previous_attr, now, proceed_with_update)
+                # Non-PROCEED skip. get_zone_details() runs unconditionally at the
+                # top of determine_update_criteria(), so the zone is freshly
+                # resolved for both SKIP (e.g. bad lat/long) and SKIP_SET_STATIONARY
+                # here. Preserve it on both; on the early check_device_tracker SKIP
+                # path get_zone_details hasn't run, so the snapshot equals what
+                # previous_attr restores and the re-apply is a no-op.
+                await self.updater.rollback_update(
+                    previous_attr,
+                    now,
+                    proceed_with_update,
+                    preserve_zone_attrs=proceed_with_update
+                    in (UpdateStatus.SKIP, UpdateStatus.SKIP_SET_STATIONARY),
+                )
         except Exception:
             # This orchestration boundary must rollback partial state for any
             # phase failure, then re-raise so Home Assistant can report it.

--- a/custom_components/places/update_sensor.py
+++ b/custom_components/places/update_sensor.py
@@ -636,7 +636,32 @@ class PlacesUpdater:
             now: Current update timestamp.
             proceed_with_update: Status that caused the update to stop.
         """
+        # Zone membership (devicetracker_zone / devicetracker_zone_name) can change
+        # without the device moving — e.g. a zone's radius was edited, a zone was
+        # created/removed, or a passive zone toggled. get_zone_details() resolves the
+        # current zone early in determine_update_criteria(), but when the update is then
+        # skipped because the coordinates are unchanged, restore_previous_attr() below
+        # would discard that fresh resolution and reinstate a now-stale zone. Snapshot
+        # the zone attrs computed this cycle so they survive the rollback.
+        zone_attrs_snapshot: dict[str, Any] = {
+            ATTR_DEVICETRACKER_ZONE: self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE),
+            ATTR_DEVICETRACKER_ZONE_NAME: self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE_NAME),
+        }
         await self.sensor.restore_previous_attr(previous_attr)
+        if (
+            self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE)
+            != zone_attrs_snapshot[ATTR_DEVICETRACKER_ZONE]
+        ):
+            self.sensor.set_attr(
+                ATTR_DEVICETRACKER_ZONE, zone_attrs_snapshot[ATTR_DEVICETRACKER_ZONE]
+            )
+        if (
+            self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE_NAME)
+            != zone_attrs_snapshot[ATTR_DEVICETRACKER_ZONE_NAME]
+        ):
+            self.sensor.set_attr(
+                ATTR_DEVICETRACKER_ZONE_NAME, zone_attrs_snapshot[ATTR_DEVICETRACKER_ZONE_NAME]
+            )
         _LOGGER.debug(
             "(%s) Reverting attributes back to before the update started",
             self.sensor.get_attr(CONF_NAME),

--- a/custom_components/places/update_sensor.py
+++ b/custom_components/places/update_sensor.py
@@ -628,6 +628,8 @@ class PlacesUpdater:
         previous_attr: MutableMapping[str, Any],
         now: datetime,
         proceed_with_update: UpdateStatus,
+        *,
+        preserve_zone_attrs: bool = False,
     ) -> None:
         """Restore prior attributes and perform time-based skipped-update adjustments.
 
@@ -635,33 +637,24 @@ class PlacesUpdater:
             previous_attr: Attribute snapshot from before the update started.
             now: Current update timestamp.
             proceed_with_update: Status that caused the update to stop.
+            preserve_zone_attrs: If True, keep the freshly resolved
+                devicetracker_zone and devicetracker_zone_name across
+                restore_previous_attr(). Set on the non-exception paths where
+                get_zone_details() has run this cycle (stationary skip,
+                bad-coords skip, no-state-change); leave False on the exception
+                path, which may carry a half-applied zone pair that must not
+                survive.
         """
-        # Zone membership (devicetracker_zone / devicetracker_zone_name) can change
-        # without the device moving — e.g. a zone's radius was edited, a zone was
-        # created/removed, or a passive zone toggled. get_zone_details() resolves the
-        # current zone early in determine_update_criteria(), but when the update is then
-        # skipped because the coordinates are unchanged, restore_previous_attr() below
-        # would discard that fresh resolution and reinstate a now-stale zone. Snapshot
-        # the zone attrs computed this cycle so they survive the rollback.
-        zone_attrs_snapshot: dict[str, Any] = {
-            ATTR_DEVICETRACKER_ZONE: self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE),
-            ATTR_DEVICETRACKER_ZONE_NAME: self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE_NAME),
-        }
+        zone = zone_name = None
+        if preserve_zone_attrs:
+            zone = self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE)
+            zone_name = self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE_NAME)
         await self.sensor.restore_previous_attr(previous_attr)
-        if (
-            self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE)
-            != zone_attrs_snapshot[ATTR_DEVICETRACKER_ZONE]
-        ):
-            self.sensor.set_attr(
-                ATTR_DEVICETRACKER_ZONE, zone_attrs_snapshot[ATTR_DEVICETRACKER_ZONE]
-            )
-        if (
-            self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE_NAME)
-            != zone_attrs_snapshot[ATTR_DEVICETRACKER_ZONE_NAME]
-        ):
-            self.sensor.set_attr(
-                ATTR_DEVICETRACKER_ZONE_NAME, zone_attrs_snapshot[ATTR_DEVICETRACKER_ZONE_NAME]
-            )
+        if preserve_zone_attrs:
+            if self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE) != zone:
+                self.sensor.set_attr(ATTR_DEVICETRACKER_ZONE, zone)
+            if self.sensor.get_attr(ATTR_DEVICETRACKER_ZONE_NAME) != zone_name:
+                self.sensor.set_attr(ATTR_DEVICETRACKER_ZONE_NAME, zone_name)
         _LOGGER.debug(
             "(%s) Reverting attributes back to before the update started",
             self.sensor.get_attr(CONF_NAME),

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -735,6 +735,83 @@ async def test_rollback_update_calls_restore_and_helpers(
     mocks["change_show_time_to_date"].assert_not_awaited()
 
 
+@pytest.mark.parametrize(
+    (
+        "live_zone",
+        "live_zone_name",
+        "previous_attr",
+        "proceed_with_update",
+        "preserve_zone_attrs",
+        "expected_zone",
+        "expected_zone_name",
+    ),
+    [
+        # Stationary skip (preserve=True): fresh zone survives; the unrelated
+        # previous_attr key (ATTR_LATITUDE) is still restored.
+        ("new_zone", "New Zone Name",
+         {ATTR_DEVICETRACKER_ZONE: "not_home", ATTR_DEVICETRACKER_ZONE_NAME: "Away",
+          ATTR_LATITUDE: 11.0},
+         UpdateStatus.SKIP_SET_STATIONARY, True,
+         "new_zone", "New Zone Name"),
+        # Bad-coords skip (preserve=True, status SKIP): get_zone_details already
+        # ran, so the fresh zone must survive here too - not just on the
+        # stationary path.
+        ("new_zone", "New Zone Name",
+         {ATTR_DEVICETRACKER_ZONE: "not_home", ATTR_DEVICETRACKER_ZONE_NAME: "Away",
+          ATTR_LATITUDE: 11.0},
+         UpdateStatus.SKIP, True,
+         "new_zone", "New Zone Name"),
+        # Exception path (preserve=False default): previous_attr's clean zone
+        # values win; a transient/mid-failure value on the sensor must NOT survive.
+        ("transient_zone", "Transient",
+         {ATTR_DEVICETRACKER_ZONE: "home", ATTR_DEVICETRACKER_ZONE_NAME: "Home",
+          ATTR_LATITUDE: 11.0},
+         UpdateStatus.SKIP_SET_STATIONARY, False,
+         "home", "Home"),
+    ],
+    ids=[
+        "stationary_skip_preserves_zone_and_unrelated",
+        "bad_coords_skip_preserves_zone",
+        "error_path_restores_previous",
+    ],
+)
+@pytest.mark.asyncio
+async def test_rollback_update_zone_attrs_preserve_policy(
+    mock_hass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    sensor: MockSensor,
+    stubbed_updater: StubbedUpdater,
+    live_zone: str,
+    live_zone_name: str,
+    previous_attr: dict,
+    proceed_with_update: UpdateStatus,
+    preserve_zone_attrs: bool,
+    expected_zone: str,
+    expected_zone_name: str,
+) -> None:
+    """zone attrs survive rollback when preserve_zone_attrs is set; unrelated attrs always restore."""
+    updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
+    sensor.attrs[ATTR_DEVICETRACKER_ZONE] = live_zone
+    sensor.attrs[ATTR_DEVICETRACKER_ZONE_NAME] = live_zone_name
+    with stubbed_updater(
+        updater,
+        [
+            ("get_seconds_from_last_change", {"return_value": 100}),
+            ("change_dot_to_stationary", {}),
+        ],
+    ):
+        await updater.rollback_update(
+            previous_attr,
+            datetime.now(tz=UTC),
+            proceed_with_update,
+            preserve_zone_attrs=preserve_zone_attrs,
+        )
+    assert sensor.attrs[ATTR_DEVICETRACKER_ZONE] == expected_zone
+    assert sensor.attrs[ATTR_DEVICETRACKER_ZONE_NAME] == expected_zone_name
+    # Unrelated attribute from previous_attr is always restored, regardless of preserve.
+    assert sensor.attrs[ATTR_LATITUDE] == 11.0
+
+
 @pytest.mark.asyncio
 async def test_build_osm_url_returns_url(
     mock_hass: MagicMock, mock_config_entry: MockConfigEntry, sensor: MockSensor

--- a/tests/test_update_sensor.py
+++ b/tests/test_update_sensor.py
@@ -748,26 +748,50 @@ async def test_rollback_update_calls_restore_and_helpers(
     [
         # Stationary skip (preserve=True): fresh zone survives; the unrelated
         # previous_attr key (ATTR_LATITUDE) is still restored.
-        ("new_zone", "New Zone Name",
-         {ATTR_DEVICETRACKER_ZONE: "not_home", ATTR_DEVICETRACKER_ZONE_NAME: "Away",
-          ATTR_LATITUDE: 11.0},
-         UpdateStatus.SKIP_SET_STATIONARY, True,
-         "new_zone", "New Zone Name"),
+        (
+            "new_zone",
+            "New Zone Name",
+            {
+                ATTR_DEVICETRACKER_ZONE: "not_home",
+                ATTR_DEVICETRACKER_ZONE_NAME: "Away",
+                ATTR_LATITUDE: 11.0,
+            },
+            UpdateStatus.SKIP_SET_STATIONARY,
+            True,
+            "new_zone",
+            "New Zone Name",
+        ),
         # Bad-coords skip (preserve=True, status SKIP): get_zone_details already
         # ran, so the fresh zone must survive here too - not just on the
         # stationary path.
-        ("new_zone", "New Zone Name",
-         {ATTR_DEVICETRACKER_ZONE: "not_home", ATTR_DEVICETRACKER_ZONE_NAME: "Away",
-          ATTR_LATITUDE: 11.0},
-         UpdateStatus.SKIP, True,
-         "new_zone", "New Zone Name"),
+        (
+            "new_zone",
+            "New Zone Name",
+            {
+                ATTR_DEVICETRACKER_ZONE: "not_home",
+                ATTR_DEVICETRACKER_ZONE_NAME: "Away",
+                ATTR_LATITUDE: 11.0,
+            },
+            UpdateStatus.SKIP,
+            True,
+            "new_zone",
+            "New Zone Name",
+        ),
         # Exception path (preserve=False default): previous_attr's clean zone
         # values win; a transient/mid-failure value on the sensor must NOT survive.
-        ("transient_zone", "Transient",
-         {ATTR_DEVICETRACKER_ZONE: "home", ATTR_DEVICETRACKER_ZONE_NAME: "Home",
-          ATTR_LATITUDE: 11.0},
-         UpdateStatus.SKIP_SET_STATIONARY, False,
-         "home", "Home"),
+        (
+            "transient_zone",
+            "Transient",
+            {
+                ATTR_DEVICETRACKER_ZONE: "home",
+                ATTR_DEVICETRACKER_ZONE_NAME: "Home",
+                ATTR_LATITUDE: 11.0,
+            },
+            UpdateStatus.SKIP_SET_STATIONARY,
+            False,
+            "home",
+            "Home",
+        ),
     ],
     ids=[
         "stationary_skip_preserves_zone_and_unrelated",
@@ -789,7 +813,7 @@ async def test_rollback_update_zone_attrs_preserve_policy(
     expected_zone: str,
     expected_zone_name: str,
 ) -> None:
-    """zone attrs survive rollback when preserve_zone_attrs is set; unrelated attrs always restore."""
+    """Zone attrs survive rollback when preserve_zone_attrs is set; unrelated attrs always restore."""
     updater = PlacesUpdater(mock_hass, mock_config_entry, sensor)
     sensor.attrs[ATTR_DEVICETRACKER_ZONE] = live_zone
     sensor.attrs[ATTR_DEVICETRACKER_ZONE_NAME] = live_zone_name


### PR DESCRIPTION
## Related issue

Fixes #445

## Problem

When a tracked entity is **stationary**, `devicetracker_zone` / `devicetracker_zone_name` stop tracking reality. If the entity's zone membership changes *without the entity moving* — a zone radius is edited, a zone is created or removed over it, a passive zone is toggled — the sensor keeps reporting the **previous** zone (typically `not_home`) until the entity physically moves again. Full diagnosis and reproduction in #445.

## Root cause

`get_zone_details()` correctly resolves the current zone early in `determine_update_criteria()`, but when the update is then skipped because coordinates are unchanged (`SKIP_SET_STATIONARY`), `rollback_update()` → `restore_previous_attr()` discards that fresh resolution and reinstates the stale zone. The correct zone is computed every cycle and then thrown away while the device is stationary.

## Change

Snapshot `devicetracker_zone` / `devicetracker_zone_name` before `restore_previous_attr()` and re-apply them afterward. Rollback semantics are preserved for every other attribute (OSM geocode, distance, direction, etc.); only zone membership is exempted from the "stationary → reinstate previous" rule, because zone membership is legitimately independent of coordinate movement.

Minimal: 25 lines in `rollback_update`, no other behaviour touched.

## Checklist

- [x] Branched from `master`
- [x] `ruff format` clean
- [x] `ruff check` clean
- [ ] Tests (none exist for `rollback_update` currently; happy to add if maintainers point at the preferred test location/style)

## Notes / alternatives considered

An alternative is to change `determine_if_update_needed` so it does not return `SKIP_SET_STATIONARY` when zone membership changed since the last commit (compare current vs previous `devicetracker_zone`). That would let the full update proceed (OSM + state refresh) on a zone change. I went with the more surgical rollback-scoped fix to avoid widening the blast radius, but I'm happy to switch approaches if the maintainers prefer the other one.