### PR TITLE
Update GitHub maintenance workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,5 @@ updates:
     # Workflow files stored in the default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 10

--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -2,18 +2,32 @@ name: prek Autoupdate
 
 on:
   schedule:
-    - cron: '0 5 * * *'
+    - cron: '0 2 * * *'
   push:
     branches:
       - main
       - master
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: prek-autoupdate-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   prek-autoupdate:
-    uses: Snuffy2/prek-autoupdate/.github/workflows/prek_autoupdate.yml@v1
-    permissions:
-      contents: write
-      pull-requests: write
-    with:
-      update-day: "3"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Update prek hooks
+        id: prek-autoupdate
+        uses: Snuffy2/prek-autoupdate@v2
+        with:
+          update-day: "3"


### PR DESCRIPTION
## Summary

Updates automated dependency and prek hook maintenance to use a quieter weekly cadence and the current prek-autoupdate action.

## What Changed

- Run GitHub Actions Dependabot updates weekly instead of daily.
- Replace the reusable prek-autoupdate workflow with `Snuffy2/prek-autoupdate@v2`.
- Add the checkout, permissions, and concurrency configuration required by the standalone action.
- Keep prek hook updates on Wednesday while moving the scheduled workflow earlier.

## Why

This keeps repository maintenance current while reducing unnecessary Dependabot activity and aligning prek updates with the simplified v2 action contract.