### PR TITLE
Skip Dependabot auto-merge on forks

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   verify-locked-dependencies:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.event.repository.fork == false && github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Prevents the Dependabot lockfile auto-merge workflow from running in repositories that are forks while preserving its behavior in the canonical repository.

## What Changed
- Added a repository fork guard to the Dependabot verification job.

## Why
Forks inherit workflow files but generally should not automatically merge their own Dependabot pull requests. Gating the first job keeps the workflow reusable while ensuring its dependent auto-merge job is skipped in fork repositories.