### PR TITLE
Add prek autoupdate auto-merge

### DIFF
--- a/.github/workflows/prek-autoupdate-auto-merge.yml
+++ b/.github/workflows/prek-autoupdate-auto-merge.yml
@@ -1,0 +1,82 @@
+name: prek Autoupdate auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: prek-autoupdate-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify-prek-update:
+    if: >-
+      github.event.repository.fork == false &&
+      github.event.pull_request.user.login == 'prek-autoupdate-bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref == 'chore/prek-updates' &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Verify that only a native prek config changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          changed_files="$(gh api --paginate \
+            "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
+            --jq '.[].filename')"
+          case "${changed_files}" in
+            prek.toml | .pre-commit-config.yaml) ;;
+            *)
+              echo "Refusing auto-merge; changed files were:"
+              echo "${changed_files}"
+              exit 1
+              ;;
+          esac
+
+  enable-auto-merge:
+    needs: verify-prek-update
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash --match-head-commit "${HEAD_SHA}" "${PR_URL}"
+
+  disable-auto-merge:
+    if: >-
+      always() &&
+      needs.verify-prek-update.result == 'failure' &&
+      github.event.repository.fork == false &&
+      github.event.pull_request.user.login == 'prek-autoupdate-bot' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.head.ref == 'chore/prek-updates' &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
+    needs: verify-prek-update
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Disable an existing auto-merge request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          auto_merge_enabled="$(gh pr view "${PR_URL}" --json autoMergeRequest --jq '.autoMergeRequest != null')"
+          if [[ "${auto_merge_enabled}" == true ]]; then
+            gh pr merge --disable-auto "${PR_URL}"
+          else
+            echo "Auto-merge is not enabled."
+          fi

--- a/.github/workflows/prek_autoupdate.yml
+++ b/.github/workflows/prek_autoupdate.yml
@@ -30,4 +30,6 @@ jobs:
         id: prek-autoupdate
         uses: Snuffy2/prek-autoupdate@v2
         with:
+          token: ${{ secrets.PREK_AUTOUPDATE_TOKEN }}
+          author-login: prek-autoupdate-bot
           update-day: "3"

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -10,7 +10,11 @@ on:
 jobs:
   tests:
     name: pytest and coverage report
-    if: ${{ !(github.event_name == 'pull_request' && ( contains(github.event.pull_request.labels.*.name, 'dependencies') || github.event.pull_request.user.type == 'Bot' )) }}
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login == 'prek-autoupdate-bot' ||
+      !(contains(github.event.pull_request.labels.*.name, 'dependencies') ||
+      github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     permissions:
       # Gives the action the necessary permissions for publishing new
@@ -39,7 +43,10 @@ jobs:
         run: uv run --locked --group pytest pytest
 
       - name: 'Generate coverage Comment (and possibly Post to PR)'
-        if: github.event_name != 'workflow_dispatch'
+        if: >-
+          github.event_name != 'workflow_dispatch' &&
+          (github.event_name != 'pull_request' ||
+          github.event.pull_request.user.login != 'prek-autoupdate-bot')
         id: coverage_comment
         uses: py-cov-action/python-coverage-comment-action@v3
         with:


### PR DESCRIPTION
## Summary

Adds tightly scoped auto-merge for native prek configuration updates created by the dedicated autoupdate bot. Those bot pull requests now run the normal pytest job while avoiding coverage-comment publication.

## What Changed

- Added a guarded auto-merge workflow limited to repository-local `chore/prek-updates` pull requests against the default branch that change exactly one native prek configuration file
- Configured prek autoupdate to use `PREK_AUTOUPDATE_TOKEN` and author commits as `prek-autoupdate-bot` while preserving the existing schedule and update day
- Allowed `prek-autoupdate-bot` pull requests through the pytest job while skipping the coverage-comment action for those pull requests
- Added failure handling that disables an existing auto-merge request when changed-file verification fails

## Why

Automated prek updates should receive the repository's normal test signal and merge without manual intervention only when they match the expected bot identity, branch, base, repository, and changed-file boundary. Separating verification from the write-capable merge jobs keeps the automation narrowly scoped.
