### PR TITLE
Harden automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     versioning-strategy: "lockfile-only"
     groups:
       python-dependencies:
@@ -21,4 +23,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -67,7 +67,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv (with caching)
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -60,27 +60,6 @@ jobs:
               ;;
           esac
 
-      - name: Checkout repository
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Setup uv (with caching)
-        uses: astral-sh/setup-uv@v9.0.0
-        with:
-          python-version: "3.14"
-          enable-cache: true
-          ignore-nothing-to-cache: true
-          cache-dependency-glob: uv.lock
-
-      - name: Run pytest from the lock
-        run: uv run --locked --group pytest pytest
-
-      - name: Run prek from the lock
-        env:
-          UV_LOCKED: "1"
-        run: uv run --locked --group dev prek run -a
-
   enable-auto-merge:
     needs: verify-dependency-update
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot dependency auto-merge
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 concurrency:
@@ -63,7 +63,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Setup uv (with caching)

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,39 +1,69 @@
-name: Dependabot uv lock auto-merge
+name: Dependabot dependency auto-merge
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 concurrency:
-  group: dependabot-uv-lock-${{ github.event.pull_request.number }}
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
-  verify-locked-dependencies:
-    if: github.event.repository.fork == false && github.event.pull_request.user.login == 'dependabot[bot]'
+  verify-dependency-update:
+    if: >-
+      github.repository == 'Snuffy2/places' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     steps:
-      - name: Verify that only uv.lock changed
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v3
+
+      - name: Verify supported dependency update
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_ECOSYSTEM: ${{ steps.dependabot-metadata.outputs.package-ecosystem }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPOSITORY: ${{ github.repository }}
         run: |
           changed_files="$(gh api --paginate \
             "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100" \
             --jq '.[].filename')"
-          if [[ "${changed_files}" != "uv.lock" ]]; then
-            echo "Refusing auto-merge; changed files were:"
-            echo "${changed_files}"
+          [[ -n "${changed_files}" ]] || {
+            echo "Refusing auto-merge; no changed files were reported"
             exit 1
-          fi
+          }
+          case "${PACKAGE_ECOSYSTEM}" in
+            uv)
+              [[ "${changed_files}" == "uv.lock" ]] || {
+                echo "Refusing uv auto-merge; changed files were:"
+                echo "${changed_files}"
+                exit 1
+              }
+              ;;
+            github_actions)
+              invalid_files="$(printf '%s\n' "${changed_files}" | grep -Ev '^\.github/workflows/[^/]+\.ya?ml$' || true)"
+              [[ -z "${invalid_files}" ]] || {
+                echo "Refusing GitHub Actions auto-merge; unexpected files were:"
+                echo "${invalid_files}"
+                exit 1
+              }
+              ;;
+            *)
+              echo "Refusing unsupported ecosystem: ${PACKAGE_ECOSYSTEM}"
+              exit 1
+              ;;
+          esac
 
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Setup uv (with caching)
@@ -53,7 +83,7 @@ jobs:
         run: uv run --locked --group dev prek run -a
 
   enable-auto-merge:
-    needs: verify-locked-dependencies
+    needs: verify-dependency-update
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -62,5 +92,6 @@ jobs:
       - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "${PR_URL}"
+        run: gh pr merge --auto --squash --match-head-commit "${HEAD_SHA}" "${PR_URL}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv (with caching)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v9
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/prek-autofix.yml
+++ b/.github/workflows/prek-autofix.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv (with caching)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v9
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/prek-autofix.yml
+++ b/.github/workflows/prek-autofix.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv (with caching)
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv (with caching)
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup uv (with caching)
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v9
         with:
           python-version: "3.14"
           enable-cache: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,3 +26,4 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
+          ignore: issues

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,4 +26,3 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
-          ignore: issues


### PR DESCRIPTION
## Summary
Hardens automated dependency updates by expanding the guarded Dependabot auto-merge workflow and updating CI to the current `setup-uv` major release. This keeps routine lockfile and GitHub Actions updates moving while relying on required branch checks for final merge safety.

## What Changed
- Add seven-day cooldowns for uv and GitHub Actions Dependabot updates.
- Support both uv lockfile and GitHub Actions updates in the Dependabot auto-merge workflow, with ecosystem-specific changed-file validation.
- Restrict auto-merge to trusted fork-owned Dependabot PRs targeting the default branch and pin each merge request to the verified head commit.
- Update `astral-sh/setup-uv` usage to `v9.0.0` in the prek autofix and pytest coverage workflows.

## Why
Routine dependency updates should remain low-touch without weakening repository safeguards. The workflow now validates the update type and changed-file scope, while required CI checks remain responsible for proving the change before GitHub completes the squash merge.
