### PR TITLE
Generalize Dependabot auto-merge guard

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   verify-dependency-update:
     if: >-
-      github.repository == 'Snuffy2/places' &&
+      github.event.repository.fork == false &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.base.ref == github.event.repository.default_branch


### PR DESCRIPTION
## Summary
Generalizes Dependabot auto-merge so the workflow works in any non-fork repository, including the upstream project.

## What Changed

- Replaced the hard-coded repository name check with a non-fork guard.
- Kept the existing Dependabot-author, same-repository-head, and default-branch safeguards.

## Why

The workflow should allow trusted Dependabot updates in the upstream repository without enabling auto-merge in forks.