### PR TITLE
Fix release coverage and cancelled setup cleanup

### DIFF
--- a/.github/workflows/post_coverage_to_pr.yml
+++ b/.github/workflows/post_coverage_to_pr.yml
@@ -12,15 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     permissions:
-      # Gives the action the necessary permissions for publishing new
-      # comments in pull requests.
+      # Posts or updates the artifact-generated coverage comment when the PR
+      # workflow could not comment directly, such as for a fork PR.
       pull-requests: write
-      # Gives the action the necessary permissions for editing existing
-      # comments (to avoid publishing multiple comments in the same PR)
+      # Required by the coverage action when updating an existing comment.
       contents: write
-      # Gives the action the necessary permissions for looking up the
-      # workflow that launched this workflow, and download the related
-      # artifact that contains the comment to be published
+      # Reads the triggering workflow run and downloads its comment artifact.
       actions: read
     steps:
       # DO NOT run actions/checkout here, for security reasons

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -17,20 +17,20 @@ jobs:
       github.event.pull_request.user.type == 'Bot')
     runs-on: ubuntu-latest
     permissions:
-      # Gives the action the necessary permissions for publishing new
-      # comments in pull requests.
+      # Lets the action post or update coverage comments directly on trusted
+      # same-repository PRs. Fork PR comments use the workflow_run publisher.
       pull-requests: write
-      # Gives the action the necessary permissions for pushing data to the
-      # python-coverage-comment-action branch, and for editing existing
-      # comments (to avoid publishing multiple comments in the same PR)
+      # Lets trusted main pushes update python-coverage-comment-action-data.
+      # PR checkouts do not persist this write-capable Git credential.
       contents: write
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v7
         with:
-          # Only trusted main pushes update the coverage data branch. PR test
-          # code must not run with a persisted write credential.
+          # Git authentication is needed only when a trusted main push updates
+          # the data branch. PR comment API authentication comes from the
+          # GITHUB_TOKEN passed directly to the coverage action below.
           persist-credentials: ${{ github.event_name == 'push' }}
 
       - name: Setup uv (with caching)

--- a/.github/workflows/pytest_coverage.yml
+++ b/.github/workflows/pytest_coverage.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v7
         with:
-          persist-credentials: false
+          # Only trusted main pushes update the coverage data branch. PR test
+          # code must not run with a persisted write credential.
+          persist-credentials: ${{ github.event_name == 'push' }}
 
       - name: Setup uv (with caching)
         uses: astral-sh/setup-uv@v10.0.0

--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -181,6 +181,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ``True`` when setup completes successfully.
 
     Raises:
+        asyncio.CancelledError:
+            Re-raised after failed-setup cleanup completes.
         Exception:
             Propagated when the operation fails.
     """
@@ -197,6 +199,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await coordinator.async_added_to_hass()
+    except asyncio.CancelledError:
+        try:
+            await coordinator.async_shutdown()
+        except Exception:
+            _LOGGER.exception("Cleanup failed after subscription cancellation for %s", name)
+        finally:
+            entry.runtime_data = None
+        raise
     except Exception:
         # Keep setup failure paths observable while ensuring listener cleanup always runs.
         _LOGGER.exception("Unable to subscribe to tracker updates for %s", name)
@@ -211,6 +221,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
         await coordinator.async_request_refresh()
+    except asyncio.CancelledError:
+        await _async_cleanup_failed_setup(hass, entry, coordinator)
+        raise
     except Exception:
         # Keep entry teardown behavior deterministic before re-raising setup failures.
         _LOGGER.exception("Entry setup failed for %s", name)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -784,6 +784,115 @@ async def test_async_setup_entry_unloads_platforms_when_initial_refresh_fails(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("failure_point", ["forward", "refresh"])
+async def test_async_setup_entry_cleans_up_when_setup_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_hass: MagicMock,
+    mock_entry: MockConfigEntry,
+    failure_point: str,
+) -> None:
+    """Cancellation after subscription should clean up before propagating.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch):
+            Pytest fixture for replacing dependencies.
+        mock_hass (MagicMock):
+            Mocked Home Assistant runtime.
+        mock_entry (MockConfigEntry):
+            Places configuration entry used by the test.
+        failure_point (str):
+            Setup operation that raises cancellation.
+    """
+    monkeypatch.setattr("custom_components.places.PlacesStorage", _FakeSetupPlacesStorage)
+    monkeypatch.setattr("custom_components.places.PlacesUpdateCoordinator", _FakeCoordinator)
+    call_order: list[str] = []
+
+    async def raise_setup_cancellation(*_args: object, **_kwargs: object) -> None:
+        """Cancel the setup operation under test.
+
+        Args:
+            *_args (object):
+                Positional arguments supplied by the operation under test.
+            **_kwargs (object):
+                Keyword arguments supplied by the operation under test.
+
+        Raises:
+            asyncio.CancelledError:
+                Always raised to emulate setup cancellation.
+        """
+        raise asyncio.CancelledError("setup cancelled")
+
+    async def mark_prepare_unload() -> None:
+        """Record coordinator preparation for failed setup cleanup."""
+        call_order.append("prepare_unload")
+
+    async def mark_unload(_entry: MockConfigEntry, _platforms: list[str]) -> bool:
+        """Record platform unloading during failed setup cleanup.
+
+        Args:
+            _entry (MockConfigEntry):
+                Configuration entry whose platforms are unloaded.
+            _platforms (list[str]):
+                Platform names being unloaded.
+
+        Returns:
+            bool:
+                ``True`` to indicate the platforms were unloaded.
+        """
+        call_order.append("unload_platforms")
+        return True
+
+    async def mark_shutdown() -> None:
+        """Record coordinator shutdown during failed setup cleanup."""
+        call_order.append("shutdown")
+
+    original_init = _FakeCoordinator.__init__
+
+    def init_with_cleanup_recording(
+        self: _FakeCoordinator,
+        hass: object,
+        config_entry: MockConfigEntry,
+        imported_attributes: dict[str, object],
+        persistence: _FakeSetupPlacesStorage | MagicMock,
+    ) -> None:
+        """Install cleanup hooks and an optional refresh cancellation hook.
+
+        Args:
+            self (_FakeCoordinator):
+                Fake coordinator receiving the configured hooks.
+            hass (object):
+                Mocked Home Assistant runtime.
+            config_entry (MockConfigEntry):
+                Places configuration entry used by the test.
+            imported_attributes (dict[str, object]):
+                Persisted attributes imported at startup.
+            persistence (_FakeSetupPlacesStorage | MagicMock):
+                Places persistence manager used by the test.
+        """
+        original_init(self, hass, config_entry, imported_attributes, persistence)
+        self.async_prepare_unload.side_effect = mark_prepare_unload
+        self.async_shutdown.side_effect = mark_shutdown
+        if failure_point == "refresh":
+            self.async_request_refresh.side_effect = raise_setup_cancellation
+
+    monkeypatch.setattr(_FakeCoordinator, "__init__", init_with_cleanup_recording)
+    mock_hass.config_entries.async_unload_platforms.side_effect = mark_unload
+    if failure_point == "forward":
+        mock_hass.config_entries.async_forward_entry_setups.side_effect = raise_setup_cancellation
+
+    with pytest.raises(asyncio.CancelledError, match="setup cancelled"):
+        await async_setup_entry(mock_hass, mock_entry)
+
+    coordinator = _FakeCoordinator.instances[0]
+    coordinator.async_added_to_hass.assert_awaited_once_with()
+    coordinator.async_prepare_unload.assert_awaited_once_with()
+    mock_hass.config_entries.async_unload_platforms.assert_awaited_once_with(mock_entry, PLATFORMS)
+    coordinator.async_shutdown.assert_awaited_once_with()
+    assert call_order == ["prepare_unload", "unload_platforms", "shutdown"]
+    assert mock_entry.runtime_data is None
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_shuts_down_when_subscription_step_fails(
     monkeypatch: pytest.MonkeyPatch,
     mock_hass: MagicMock,
@@ -840,6 +949,72 @@ async def test_async_setup_entry_shuts_down_when_subscription_step_fails(
     monkeypatch.setattr(_FakeCoordinator, "__init__", init_with_failing_subscription)
 
     with pytest.raises(RuntimeError, match="subscribe boom"):
+        await async_setup_entry(mock_hass, mock_entry)
+
+    coordinator = _FakeCoordinator.instances[0]
+    coordinator.async_added_to_hass.assert_awaited_once_with()
+    coordinator.async_shutdown.assert_awaited_once_with()
+    mock_hass.config_entries.async_unload_platforms.assert_not_awaited()
+    assert mock_entry.runtime_data is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_shuts_down_when_subscription_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_hass: MagicMock,
+    mock_entry: MockConfigEntry,
+) -> None:
+    """Subscription cancellation should shut down without unloading platforms.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch):
+            Pytest fixture for replacing dependencies.
+        mock_hass (MagicMock):
+            Mocked Home Assistant runtime.
+        mock_entry (MockConfigEntry):
+            Places configuration entry used by the test.
+    """
+    monkeypatch.setattr("custom_components.places.PlacesStorage", _FakeSetupPlacesStorage)
+    monkeypatch.setattr("custom_components.places.PlacesUpdateCoordinator", _FakeCoordinator)
+
+    async def raise_subscription_cancellation() -> None:
+        """Cancel tracker subscription setup.
+
+        Raises:
+            asyncio.CancelledError:
+                Always raised to emulate subscription cancellation.
+        """
+        raise asyncio.CancelledError("subscription cancelled")
+
+    original_init = _FakeCoordinator.__init__
+
+    def init_with_cancelled_subscription(
+        self: _FakeCoordinator,
+        hass: object,
+        config_entry: MockConfigEntry,
+        imported_attributes: dict[str, object],
+        persistence: _FakeSetupPlacesStorage | MagicMock,
+    ) -> None:
+        """Install a cancelled ``async_added_to_hass`` hook.
+
+        Args:
+            self (_FakeCoordinator):
+                Fake coordinator receiving the subscription hook.
+            hass (object):
+                Mocked Home Assistant runtime.
+            config_entry (MockConfigEntry):
+                Places configuration entry used by the test.
+            imported_attributes (dict[str, object]):
+                Persisted attributes imported at startup.
+            persistence (_FakeSetupPlacesStorage | MagicMock):
+                Places persistence manager used by the test.
+        """
+        original_init(self, hass, config_entry, imported_attributes, persistence)
+        self.async_added_to_hass.side_effect = raise_subscription_cancellation
+
+    monkeypatch.setattr(_FakeCoordinator, "__init__", init_with_cancelled_subscription)
+
+    with pytest.raises(asyncio.CancelledError, match="subscription cancelled"):
         await async_setup_entry(mock_hass, mock_entry)
 
     coordinator = _FakeCoordinator.instances[0]


### PR DESCRIPTION
## Summary

Restores reliable coverage publication on trusted main pushes and makes config-entry setup cancellation clean up partial runtime state before propagating.

## What Changed

- Persist checkout Git credentials only for trusted pushes so the coverage action can update its data branch without exposing a persisted write credential to PR-controlled tests.
- Clarify how the test workflow and trusted follow-up workflow divide coverage-data updates from PR comment publication.
- Clean up coordinator state when setup is cancelled during tracker subscription, platform forwarding, or the initial refresh.
- Add regression coverage for each cancellation boundary and verify the correct shutdown and platform-unload behavior.

## Why

Recent main runs passed pytest but failed when the coverage action attempted to push its data branch without Git authentication. At the same time, cancellation during config-entry setup could leave runtime data, subscriptions, or partially forwarded platforms behind.

The workflow change restores the required authentication only for trusted main pushes, while the setup change reuses the established cleanup paths and preserves cancellation propagation.
