### PR TITLE
ci: validate uv lock consistency

### DIFF
--- a/.github/workflows/uv-lock-check.yml
+++ b/.github/workflows/uv-lock-check.yml
@@ -1,0 +1,29 @@
+name: Validate uv lock
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  uv-lock-check:
+    name: Validate uv lock consistency
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v10.0.0
+        with:
+          python-version: "3.14"
+
+      - name: Check uv lock consistency
+        run: uv lock --check


### PR DESCRIPTION
## Summary

Adds a non-mutating GitHub Actions check that verifies `uv.lock` stays consistent with the dependency metadata on every pull request.

## What Changed

- Added a dedicated `uv lock --check` workflow for pull requests, `main` pushes, and manual runs.
- Uses a credential-free checkout and read-only repository permissions.

## Why

The check catches stale lockfiles independently of the coverage workflow, including dependency and bot pull requests that intentionally skip the full test job. Dependabot remains responsible for automated lockfile updates.