### PR TITLE
Fix display options after config reload

### DIFF
--- a/custom_components/places/__init__.py
+++ b/custom_components/places/__init__.py
@@ -189,10 +189,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _ensure_osm_runtime_state(hass)
     name = entry.data.get(CONF_NAME, entry.entry_id)
     persistence = PlacesStorage(hass=hass, entry_id=entry.entry_id, name=name)
+    imported_attributes = await persistence.async_load()
+    has_restored_attributes = bool(imported_attributes)
     coordinator = PlacesUpdateCoordinator(
         hass=hass,
         config_entry=entry,
-        imported_attributes=await persistence.async_load(),
+        imported_attributes=imported_attributes,
         persistence=persistence,
     )
     entry.runtime_data = coordinator
@@ -219,6 +221,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise
 
     try:
+        if has_restored_attributes:
+            await coordinator.async_render_display_state()
+            coordinator.publish_update()
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
         await coordinator.async_request_refresh()
     except asyncio.CancelledError:

--- a/custom_components/places/coordinator.py
+++ b/custom_components/places/coordinator.py
@@ -301,7 +301,7 @@ class PlacesUpdateCoordinator(DataUpdateCoordinator[PlacesData]):
                     self.config[key] = value
                     self.set_attr(key, value)
                     self.set_attr(ATTR_DISPLAY_OPTIONS, value)
-                    await self.async_render_display_state()
+                    await self._async_render_display_state_locked()
                 elif key == CONF_MAP_PROVIDER:
                     value_str = str(value).strip().lower()
                     if value_str not in MAP_PROVIDER_OPTIONS:
@@ -791,6 +791,11 @@ class PlacesUpdateCoordinator(DataUpdateCoordinator[PlacesData]):
 
     async def async_render_display_state(self) -> None:
         """Render configured display options and apply state time formatting."""
+        async with self._update_lock:
+            await self._async_render_display_state_locked()
+
+    async def _async_render_display_state_locked(self) -> None:
+        """Render display state while the caller holds ``_update_lock``."""
         await self.process_display_options()
         updater = PlacesUpdater(self.hass, self.config_entry, self)
         await updater.async_apply_show_time()

--- a/custom_components/places/coordinator.py
+++ b/custom_components/places/coordinator.py
@@ -301,9 +301,7 @@ class PlacesUpdateCoordinator(DataUpdateCoordinator[PlacesData]):
                     self.config[key] = value
                     self.set_attr(key, value)
                     self.set_attr(ATTR_DISPLAY_OPTIONS, value)
-                    updater = PlacesUpdater(self.hass, self.config_entry, self)
-                    await self.process_display_options()
-                    await updater.async_apply_show_time()
+                    await self.async_render_display_state()
                 elif key == CONF_MAP_PROVIDER:
                     value_str = str(value).strip().lower()
                     if value_str not in MAP_PROVIDER_OPTIONS:
@@ -790,6 +788,12 @@ class PlacesUpdateCoordinator(DataUpdateCoordinator[PlacesData]):
         if not self.is_attr_blank(ATTR_DEVICETRACKER_ZONE_NAME):
             self.set_attr(ATTR_NATIVE_VALUE, self.get_attr(ATTR_DEVICETRACKER_ZONE_NAME))
             self._native_value = self.get_attr_safe_str(ATTR_NATIVE_VALUE) or None
+
+    async def async_render_display_state(self) -> None:
+        """Render configured display options and apply state time formatting."""
+        await self.process_display_options()
+        updater = PlacesUpdater(self.hass, self.config_entry, self)
+        await updater.async_apply_show_time()
 
     async def restore_previous_attr(self, previous_attr: MutableMapping[str, Any]) -> None:
         """Restore a prior runtime attribute snapshot after rollback.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -557,6 +557,14 @@ async def test_async_setup_entry_calls_forward_setups(
         """Record coordinator subscription before platform forwarding."""
         call_order.append("subscribe")
 
+    async def record_render() -> None:
+        """Record restored display-state rendering before platform forwarding."""
+        call_order.append("render")
+
+    def record_publish() -> None:
+        """Record restored-state publication before platform forwarding."""
+        call_order.append("publish")
+
     async def record_forward(*_args: object, **_kwargs: object) -> None:
         """Record platform forwarding after subscription.
 
@@ -593,6 +601,8 @@ async def test_async_setup_entry_calls_forward_setups(
         """
         original_init(self, hass, config_entry, imported_attributes, persistence)
         self.async_added_to_hass.side_effect = record_subscription
+        self.async_render_display_state.side_effect = record_render
+        self.publish_update.side_effect = record_publish
 
     monkeypatch.setattr(_FakeCoordinator, "__init__", init_with_recorded_subscription)
     mock_hass.config_entries.async_forward_entry_setups.side_effect = record_forward
@@ -616,7 +626,7 @@ async def test_async_setup_entry_calls_forward_setups(
     mock_hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(
         mock_entry, PLATFORMS
     )
-    assert call_order == ["subscribe", "forward"]
+    assert call_order == ["subscribe", "render", "publish", "forward"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -655,6 +655,7 @@ async def test_async_setup_entry_renders_current_options_from_persisted_location
     monkeypatch: pytest.MonkeyPatch,
     mock_hass: MagicMock,
     display_options: str,
+    *,
     show_time: bool,
     persisted_native_value: str,
     last_changed: str | None,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for the custom_components.places module."""
 
 import asyncio
+from datetime import UTC, datetime
 import logging
 from typing import ClassVar
 from unittest.mock import AsyncMock, MagicMock
@@ -19,16 +20,24 @@ from custom_components.places import (
     async_unload_entry,
 )
 from custom_components.places.const import (
+    ATTR_CITY,
+    ATTR_DEVICETRACKER_ZONE,
+    ATTR_DEVICETRACKER_ZONE_NAME,
+    ATTR_LAST_CHANGED,
+    ATTR_NATIVE_VALUE,
     CONF_API_KEY,
+    CONF_DEVICETRACKER_ID,
     CONF_DISPLAY_OPTIONS,
     CONF_EXTENDED_ATTR,
     CONF_NAME,
+    CONF_SHOW_TIME,
     DEFAULT_DISPLAY_OPTIONS,
     DOMAIN,
     OSM_CACHE,
     OSM_THROTTLE,
     PLATFORMS,
 )
+from custom_components.places.coordinator import PlacesUpdateCoordinator
 from tests.conftest import assert_awaited_count
 
 
@@ -154,6 +163,8 @@ class _FakeCoordinator:
         self.imported_attributes = imported_attributes
         self.persistence = persistence
         self.async_added_to_hass = AsyncMock()
+        self.async_render_display_state = AsyncMock()
+        self.publish_update = MagicMock()
         self.async_request_refresh = AsyncMock()
         self.async_prepare_unload = AsyncMock()
         self.async_resume_after_failed_unload = AsyncMock()
@@ -599,11 +610,89 @@ async def test_async_setup_entry_calls_forward_setups(
     assert mock_entry.runtime_data.imported_attributes == {"native_value": "Restored"}
     assert mock_entry.runtime_data.persistence is _FakeSetupPlacesStorage.instances[0]
     mock_entry.runtime_data.async_added_to_hass.assert_awaited_once_with()
+    mock_entry.runtime_data.async_render_display_state.assert_awaited_once_with()
+    mock_entry.runtime_data.publish_update.assert_called_once_with()
     mock_entry.runtime_data.async_request_refresh.assert_awaited_once_with()
     mock_hass.config_entries.async_forward_entry_setups.assert_awaited_once_with(
         mock_entry, PLATFORMS
     )
     assert call_order == ["subscribe", "forward"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("show_time", "persisted_native_value", "last_changed", "expected_state"),
+    [
+        (False, "Home", None, "Sample City"),
+        (
+            True,
+            "Home (since 11:00)",
+            "2026-08-23 12:00:00+00:00",
+            "Sample City (since 12:00)",
+        ),
+    ],
+    ids=("advanced-options", "show-time"),
+)
+async def test_async_setup_entry_renders_current_options_from_persisted_location(
+    monkeypatch: pytest.MonkeyPatch,
+    mock_hass: MagicMock,
+    show_time: bool,
+    persisted_native_value: str,
+    last_changed: str | None,
+    expected_state: str,
+) -> None:
+    """Setup should rerender restored data without waiting for tracker movement.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch):
+            Pytest fixture for replacing setup dependencies.
+        mock_hass (MagicMock):
+            Mocked Home Assistant runtime.
+        show_time (bool):
+            Whether the rendered state should include last-change time.
+        persisted_native_value (str):
+            Stale display state restored from Store.
+        last_changed (str | None):
+            Persisted timestamp used by show-time formatting when configured.
+        expected_state (str):
+            Display state expected from current config and restored location data.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: "Test Place",
+            CONF_DEVICETRACKER_ID: "person.test",
+            CONF_DISPLAY_OPTIONS: "city[]",
+            CONF_SHOW_TIME: show_time,
+        },
+    )
+    _FakeSetupPlacesStorage.load_result = {
+        ATTR_NATIVE_VALUE: persisted_native_value,
+        ATTR_CITY: "Sample City",
+        ATTR_DEVICETRACKER_ZONE: "home",
+        ATTR_DEVICETRACKER_ZONE_NAME: "Home",
+    }
+    if last_changed is not None:
+        _FakeSetupPlacesStorage.load_result[ATTR_LAST_CHANGED] = last_changed
+    monkeypatch.setattr("custom_components.places.PlacesStorage", _FakeSetupPlacesStorage)
+    monkeypatch.setattr(
+        PlacesUpdateCoordinator,
+        "async_added_to_hass",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        PlacesUpdateCoordinator,
+        "async_request_refresh",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "custom_components.places.update_sensor.PlacesUpdater.get_current_time",
+        AsyncMock(return_value=datetime(2026, 8, 23, 13, 0, tzinfo=UTC)),
+    )
+
+    await async_setup_entry(mock_hass, entry)
+
+    assert entry.runtime_data.data.native_value == expected_state
 
 
 def test_ensure_osm_runtime_state_preserves_existing_state(mock_hass: MagicMock) -> None:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -621,21 +621,30 @@ async def test_async_setup_entry_calls_forward_setups(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("show_time", "persisted_native_value", "last_changed", "expected_state"),
+    (
+        "display_options",
+        "show_time",
+        "persisted_native_value",
+        "last_changed",
+        "expected_state",
+    ),
     [
-        (False, "Home", None, "Sample City"),
+        ("city[]", False, "Home", None, "Sample City"),
         (
+            "city[]",
             True,
             "Home (since 11:00)",
             "2026-08-23 12:00:00+00:00",
             "Sample City (since 12:00)",
         ),
+        ("zone_name", False, "Stale Home", None, "Home"),
     ],
-    ids=("advanced-options", "show-time"),
+    ids=("advanced-options", "show-time", "zone-name-fallback"),
 )
 async def test_async_setup_entry_renders_current_options_from_persisted_location(
     monkeypatch: pytest.MonkeyPatch,
     mock_hass: MagicMock,
+    display_options: str,
     show_time: bool,
     persisted_native_value: str,
     last_changed: str | None,
@@ -648,6 +657,8 @@ async def test_async_setup_entry_renders_current_options_from_persisted_location
             Pytest fixture for replacing setup dependencies.
         mock_hass (MagicMock):
             Mocked Home Assistant runtime.
+        display_options (str):
+            Current display options used to rerender restored location data.
         show_time (bool):
             Whether the rendered state should include last-change time.
         persisted_native_value (str):
@@ -662,7 +673,7 @@ async def test_async_setup_entry_renders_current_options_from_persisted_location
         data={
             CONF_NAME: "Test Place",
             CONF_DEVICETRACKER_ID: "person.test",
-            CONF_DISPLAY_OPTIONS: "city[]",
+            CONF_DISPLAY_OPTIONS: display_options,
             CONF_SHOW_TIME: show_time,
         },
     )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -282,6 +282,34 @@ async def test_coordinator_updates_setting_locally(
     coordinator.async_request_refresh.assert_not_awaited()
 
 
+async def test_coordinator_render_display_state_waits_for_update_lock(
+    mock_hass: MagicMock,
+) -> None:
+    """Public display rendering must serialize with coordinator updates.
+
+    Args:
+        mock_hass (MagicMock):
+            Mocked Home Assistant runtime.
+    """
+    mock_hass.states.get.return_value = None
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="entry123",
+        data={"name": "TestSensor", "devicetracker_id": "person.test"},
+    )
+    coordinator = PlacesUpdateCoordinator(mock_hass, entry, {}, MagicMock())
+    coordinator.process_display_options = AsyncMock()
+
+    async with coordinator._update_lock:
+        render_task = asyncio.create_task(coordinator.async_render_display_state())
+        await asyncio.sleep(0)
+        coordinator.process_display_options.assert_not_awaited()
+
+    await render_task
+
+    coordinator.process_display_options.assert_awaited_once_with()
+
+
 async def test_coordinator_normalizes_and_validates_map_provider(mock_hass: MagicMock) -> None:
     """Direct setting updates normalize valid providers and reject unsupported ones.
 


### PR DESCRIPTION
## Summary

Fixes config-entry reloads so the main Places entity immediately reflects updated display options, including advanced formats such as `city[]`. Restored location data is re-rendered before platform setup and serialized with tracker updates to prevent stale or racing state.

## What Changed

- Re-render restored location attributes using the current display and show-time options during setup
- Publish the corrected state before forwarding entity platforms
- Serialize display rendering with coordinator tracker updates
- Reuse the same lock-held rendering path for runtime setting changes
- Add regression tests for advanced display options, show-time formatting, zone-name fallback, setup ordering, and concurrent rendering

## Why

After changing display options, a config-entry reload could restore the previous native state from storage. If the tracked entity had not moved, the first refresh could skip reverse geocoding, leaving the main entity at a stale value such as `Home` even though `city[]` was saved and the restored attributes already contained the city.

Rendering directly from restored attributes applies the new configuration immediately without requiring movement, another network lookup, or a manual force update. Coordinating that render under the update lock prevents it from racing tracker-driven state changes.
