### PR TITLE
Replace mutable release with dispatch workflow

### DIFF
--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -1,0 +1,130 @@
+"""Validate a release tag and prepare the integration version files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+
+TAG_PATTERN = re.compile(
+    r"^v[0-9]+(?:\.[0-9]+){1,3}(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?(?:[A-Za-z]+[0-9]+)?$"
+)
+MANIFEST_VERSION_PATTERN = re.compile(r'("version"\s*:\s*)"[^"]*"')
+CONST_VERSION_PATTERN = re.compile(r'^(VERSION\s*=\s*)"[^"]*"', re.MULTILINE)
+
+
+def validate_release_tag(tag: str) -> None:
+    """Validate a release tag against the repository's supported formats.
+
+    Args:
+        tag (str):
+            Candidate release tag.
+
+    Raises:
+        ValueError: If the tag does not use a supported version format.
+    """
+    if TAG_PATTERN.fullmatch(tag) is None:
+        msg = f"Invalid release tag: {tag}"
+        raise ValueError(msg)
+
+
+def _replace_version(
+    content: str,
+    pattern: re.Pattern[str],
+    tag: str,
+    path: Path,
+) -> str:
+    """Replace one version declaration while preserving its formatting.
+
+    Args:
+        content (str):
+            Original file content.
+        pattern (re.Pattern[str]):
+            Pattern whose first group precedes the version string.
+        tag (str):
+            Validated release tag.
+        path (Path):
+            Source path used in error messages.
+
+    Returns:
+        str: Content containing the requested release version.
+
+    Raises:
+        ValueError: If the file does not contain exactly one version declaration.
+    """
+    updated, replacements = pattern.subn(lambda match: f'{match.group(1)}"{tag}"', content)
+    if replacements != 1:
+        msg = f"Expected one version declaration in {path}, found {replacements}."
+        raise ValueError(msg)
+    return updated
+
+
+def update_release_versions(repository: Path, tag: str) -> None:
+    """Update manifest.json and const.py to the release tag.
+
+    Both files are validated before either is written, preventing a partial update.
+
+    Args:
+        repository (Path):
+            Repository root containing the integration.
+        tag (str):
+            Requested release tag.
+
+    Raises:
+        ValueError: If the tag or either version declaration is invalid.
+    """
+    validate_release_tag(tag)
+    integration = repository / "custom_components" / "places"
+    manifest_path = integration / "manifest.json"
+    const_path = integration / "const.py"
+
+    manifest = _replace_version(
+        manifest_path.read_text(encoding="utf-8"),
+        MANIFEST_VERSION_PATTERN,
+        tag,
+        manifest_path,
+    )
+    const = _replace_version(
+        const_path.read_text(encoding="utf-8"),
+        CONST_VERSION_PATTERN,
+        tag,
+        const_path,
+    )
+
+    if json.loads(manifest).get("version") != tag:
+        msg = f"Failed to update {manifest_path} to {tag}."
+        raise ValueError(msg)
+
+    manifest_path.write_text(manifest, encoding="utf-8")
+    const_path.write_text(const, encoding="utf-8")
+
+
+def main() -> int:
+    """Run the release preparation command.
+
+    Returns:
+        int: Zero when validation or version preparation succeeds.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="Release tag, such as v3.0.1")
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Validate the tag without updating version files",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.check_only:
+            validate_release_tag(args.tag)
+        else:
+            update_release_versions(Path.cwd(), args.tag)
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,10 @@ jobs:
           fetch-depth: 0
 
       - name: Validate release request
+        id: validate_release_request
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITHUB_SHA: ${{ github.sha }}
           GH_TOKEN: ${{ github.token }}
           RELEASE_REF: ${{ github.ref_name }}
           RELEASE_TAG: ${{ inputs.tag }}
@@ -47,17 +49,45 @@ jobs:
 
           python3 .github/scripts/prepare_release.py --check-only "$RELEASE_TAG"
 
-          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "Release tag already exists: $RELEASE_TAG" >&2
+          release_view_error="$RUNNER_TEMP/release-view-error.txt"
+          if release_is_draft="$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft 2>"$release_view_error")"; then
+            if [[ "$release_is_draft" != "true" ]]; then
+              echo "Published GitHub release already exists: $RELEASE_TAG" >&2
+              exit 1
+            fi
+          elif ! grep -Eq "HTTP 404|release not found" "$release_view_error"; then
+            cat "$release_view_error" >&2
             exit 1
           fi
 
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "GitHub release already exists: $RELEASE_TAG" >&2
+          tag_commit="$(git ls-remote --tags origin "refs/tags/$RELEASE_TAG^{}" | awk 'NF == 2 { print $1 }')"
+          if [[ -n "$tag_commit" ]]; then
+            git fetch --no-tags origin "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+            parent_line="$(git rev-list --parents -n 1 "$tag_commit")"
+            read -r release_commit parent_commit extra_parent <<<"$parent_line"
+            release_subject="$(git log -1 --format=%s "$tag_commit")"
+            if [[ "$release_commit" != "$tag_commit" || -z "$parent_commit" || -n "$extra_parent" || "$parent_commit" != "$GITHUB_SHA" || "$release_subject" != "Release $RELEASE_TAG" ]]; then
+              echo "Existing release tag $RELEASE_TAG is not a release commit directly based on this dispatch revision." >&2
+              exit 1
+            fi
+
+            git checkout --detach "$tag_commit"
+            python3 .github/scripts/prepare_release.py "$RELEASE_TAG"
+            if ! git diff --quiet -- custom_components/places/manifest.json custom_components/places/const.py; then
+              echo "Existing release tag $RELEASE_TAG does not contain matching version files." >&2
+              exit 1
+            fi
+
+            echo "resume_tag=true" >> "$GITHUB_OUTPUT"
+          elif git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Existing release tag $RELEASE_TAG is not an annotated tag with a peeled commit." >&2
             exit 1
+          else
+            echo "resume_tag=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create versioned release commit
+        if: ${{ steps.validate_release_request.outputs.resume_tag != 'true' }}
         env:
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
@@ -82,17 +112,32 @@ jobs:
           unzip -t "$RUNNER_TEMP/places.zip"
 
       - name: Push release tag
+        if: ${{ steps.validate_release_request.outputs.resume_tag != 'true' }}
         env:
           RELEASE_TAG: ${{ inputs.tag }}
         run: git push origin "refs/tags/$RELEASE_TAG"
 
-      - name: Create draft release with HACS archive
+      - name: Create or resume draft release with HACS archive
         env:
           GH_TOKEN: ${{ github.token }}
           IS_PRERELEASE: ${{ inputs.prerelease }}
           RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
+
+          release_view_error="$RUNNER_TEMP/release-view-error.txt"
+          if release_is_draft="$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft 2>"$release_view_error")"; then
+            if [[ "$release_is_draft" != "true" ]]; then
+              echo "Published GitHub release already exists: $RELEASE_TAG" >&2
+              exit 1
+            fi
+
+            gh release upload "$RELEASE_TAG" "$RUNNER_TEMP/places.zip#places.zip" --clobber
+            exit 0
+          elif ! grep -Eq "HTTP 404|release not found" "$release_view_error"; then
+            cat "$release_view_error" >&2
+            exit 1
+          fi
 
           release_args=(
             "$RELEASE_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,98 +1,116 @@
 name: Release
+
+run-name: Release ${{ inputs.tag }}
+
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+    inputs:
+      tag:
+        description: Release tag (for example, v3.0.1 or v3.1.0-beta.1)
+        required: true
+        type: string
+      prerelease:
+        description: Publish as a prerelease
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  update_version_and_create_zip:
+  release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - name: Validate published release metadata
-        if: ${{ github.event_name == 'release' }}
+      - name: Checkout selected revision
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate release request
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_TARGET: ${{ github.event.release.target_commitish }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REF: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
 
-          # Supports established stable, prerelease, four-component, and bN tags.
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+(\.[0-9]+){1,3}(-[0-9A-Za-z]+(\.[0-9A-Za-z]+)*)?([A-Za-z]+[0-9]+)?$ ]]; then
-            echo "Invalid release tag: $RELEASE_TAG" >&2
+          if [[ "$RELEASE_REF" != "$DEFAULT_BRANCH" ]]; then
+            echo "Release workflow must be dispatched from $DEFAULT_BRANCH, not $RELEASE_REF." >&2
             exit 1
           fi
 
-          if [[ "$RELEASE_TARGET" =~ ^[0-9A-Fa-f]{40}$ ]]; then
-            echo "Release target must be a branch, not a commit SHA." >&2
+          python3 .github/scripts/prepare_release.py --check-only "$RELEASE_TAG"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release tag already exists: $RELEASE_TAG" >&2
             exit 1
           fi
 
-          if ! git check-ref-format --branch "$RELEASE_TARGET" >/dev/null; then
-            echo "Invalid release branch: $RELEASE_TARGET" >&2
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "GitHub release already exists: $RELEASE_TAG" >&2
             exit 1
           fi
 
-          if ! git ls-remote --exit-code --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/${RELEASE_TARGET}" >/dev/null; then
-            echo "Release target is not an existing remote branch: $RELEASE_TARGET" >&2
-            exit 1
-          fi
-
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          # Release branches are verified before this PAT-authenticated checkout.
-          ref: ${{ github.event_name == 'release' && github.event.release.target_commitish || github.ref }}
-          token: ${{ secrets.RELEASE_TOKEN }}
-          # Value already defaults to true, but `persist-credentials` is required to push new commits to the repository.
-          persist-credentials: true
-
-      - name: Update Version in Manifest
-        if: ${{ github.event_name == 'release' }}
+      - name: Create versioned release commit
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          sed -i 's/\"version\"\s*\:\s*\".*\"/\"version\"\:\"'"$RELEASE_TAG"'\"/g' ./custom_components/places/manifest.json
+          set -euo pipefail
 
-      - name: Update Version in const.py
-        if: ${{ github.event_name == 'release' }}
+          python3 .github/scripts/prepare_release.py "$RELEASE_TAG"
+
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add custom_components/places/manifest.json custom_components/places/const.py
+          git commit -m "Release $RELEASE_TAG"
+          git tag -a "$RELEASE_TAG" -m "Release $RELEASE_TAG"
+
+      - name: Build HACS archive from release commit
+        run: |
+          set -euo pipefail
+          git archive \
+            --format=zip \
+            --output="$RUNNER_TEMP/places.zip" \
+            HEAD:custom_components/places
+          unzip -t "$RUNNER_TEMP/places.zip"
+
+      - name: Push release tag
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-        run: |
-          sed -i 's/^VERSION \= \".*\"/VERSION \= \"'"$RELEASE_TAG"'\"/' ./custom_components/places/const.py
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: git push origin "refs/tags/$RELEASE_TAG"
 
-      - name: Commit & Push Version Changes
-        if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
-        uses: stefanzweifel/git-auto-commit-action@v7
-        with:
-          branch: ${{ github.event.release.target_commitish }}
-          commit_message: 'Updating to version ${{ github.event.release.tag_name }} [skip ci]'
-
-      - name: Update Release with Version Changes Commit
-        if: ${{ github.event_name == 'release' && github.event.release.prerelease == false }}
+      - name: Create draft release with HACS archive
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          GH_TOKEN: ${{ github.token }}
+          IS_PRERELEASE: ${{ inputs.prerelease }}
+          RELEASE_TAG: ${{ inputs.tag }}
         run: |
-          git tag -f "$RELEASE_TAG"
-          git push -f origin "$RELEASE_TAG"
+          set -euo pipefail
 
-      - name: Create Zip
-        run: |
-          cd "$GITHUB_WORKSPACE/custom_components/places"
-          zip places.zip -r ./
+          release_args=(
+            "$RELEASE_TAG"
+            "$RUNNER_TEMP/places.zip#places.zip"
+            --draft
+            --generate-notes
+            --title "$RELEASE_TAG"
+            --verify-tag
+          )
 
-      - name: Upload Zip to Release
-        if: ${{ github.event_name == 'release' }}
-        uses: softprops/action-gh-release@v3
-        with:
-          files: ./custom_components/places/places.zip
-          tag_name: ${{ github.event.release.tag_name }}
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            release_args+=(--prerelease)
+          fi
 
-      - name: Add Zip to Action
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: places
-          path: ./custom_components/places/places.zip
-          if-no-files-found: error
+          gh release create "${release_args[@]}"
+
+      - name: Publish completed release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: gh release edit "$RELEASE_TAG" --draft=false

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -1,0 +1,105 @@
+"""Tests for release version preparation."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[1] / ".github" / "scripts" / "prepare_release.py"
+SCRIPT_SPEC = importlib.util.spec_from_file_location("prepare_release", SCRIPT_PATH)
+assert SCRIPT_SPEC is not None
+assert SCRIPT_SPEC.loader is not None
+prepare_release = importlib.util.module_from_spec(SCRIPT_SPEC)
+SCRIPT_SPEC.loader.exec_module(prepare_release)
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ["v3.0.1", "v3.1.0-beta.1", "v2.9.4.1", "v3.0.0b1"],
+)
+def test_validate_release_tag_accepts_supported_formats(tag: str) -> None:
+    """Accept version formats already used by the repository.
+
+    Args:
+        tag (str):
+            Supported release tag under test.
+    """
+    prepare_release.validate_release_tag(tag)
+
+
+@pytest.mark.parametrize(
+    "tag",
+    ["", "3.0.1", "v3", "v3.0.1 beta", "v3.0.1;echo-bad"],
+)
+def test_validate_release_tag_rejects_unsupported_formats(tag: str) -> None:
+    """Reject malformed tags before they reach Git or GitHub commands.
+
+    Args:
+        tag (str):
+            Unsupported release tag under test.
+    """
+    with pytest.raises(ValueError, match="Invalid release tag"):
+        prepare_release.validate_release_tag(tag)
+
+
+def _write_version_files(repository: Path, const_content: str | None = None) -> tuple[Path, Path]:
+    """Create representative integration version files.
+
+    Args:
+        repository (Path):
+            Temporary repository root.
+        const_content (str | None):
+            Optional const.py content override.
+
+    Returns:
+        tuple[Path, Path]: Paths to manifest.json and const.py.
+    """
+    integration = repository / "custom_components" / "places"
+    integration.mkdir(parents=True)
+    manifest_path = integration / "manifest.json"
+    const_path = integration / "const.py"
+    manifest_path.write_text(
+        '{\n  "domain": "places",\n  "version" : "v2.9.4"\n}\n',
+        encoding="utf-8",
+    )
+    const_path.write_text(
+        const_content or 'VERSION = "v2.9.4"\nOTHER_VERSION = "v1.0.0"\n',
+        encoding="utf-8",
+    )
+    return manifest_path, const_path
+
+
+def test_update_release_versions_updates_only_release_declarations(tmp_path: Path) -> None:
+    """Update both release declarations without changing unrelated versions.
+
+    Args:
+        tmp_path (Path):
+            Temporary repository root.
+    """
+    manifest_path, const_path = _write_version_files(tmp_path)
+
+    prepare_release.update_release_versions(tmp_path, "v3.0.1")
+
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["version"] == "v3.0.1"
+    assert const_path.read_text(encoding="utf-8") == (
+        'VERSION = "v3.0.1"\nOTHER_VERSION = "v1.0.0"\n'
+    )
+
+
+def test_update_release_versions_does_not_partially_write(tmp_path: Path) -> None:
+    """Leave both files unchanged when either declaration is missing.
+
+    Args:
+        tmp_path (Path):
+            Temporary repository root.
+    """
+    manifest_path, const_path = _write_version_files(tmp_path, 'DOMAIN = "places"\n')
+    original_manifest = manifest_path.read_text(encoding="utf-8")
+    original_const = const_path.read_text(encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Expected one version declaration"):
+        prepare_release.update_release_versions(tmp_path, "v3.0.1")
+
+    assert manifest_path.read_text(encoding="utf-8") == original_manifest
+    assert const_path.read_text(encoding="utf-8") == original_const


### PR DESCRIPTION
## Summary

Replaces the post-publication release mutation flow with a manually dispatched, safely retryable workflow. A single dispatch prepares the versioned tag, HACS archive, and GitHub-generated release notes without requiring a PAT or modifying `main`.

## What Changed

- Added validated `tag` and `prerelease` inputs to the release workflow
- Added a focused helper that atomically updates `manifest.json` and `const.py` for the requested tag
- Created the immutable tag from a version-only release commit without pushing that commit to `main`
- Built `places.zip` from the exact release commit and attached it before publishing the release
- Kept GitHub's built-in generated release notes through `--generate-notes`
- Added safe retry handling for matching tags and draft releases while rejecting mismatched tags and published releases
- Added behavior-focused tests for tag validation and atomic version preparation

## Why

The previous workflow modified the target branch and force-moved the tag after publication, which conflicts with immutable-release security guidance and requires a long-lived PAT. Preparing the commit, tag, notes, and HACS artifact before publication keeps releases one-step and uses only the repository-scoped `GITHUB_TOKEN`.

The retry path preserves tag immutability: it resumes only when the existing annotated tag identifies the expected release commit and version, then repairs or completes the draft release without deleting or moving the tag.
