### PR TITLE
Ignore pytest and uv in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "uv"
@@ -16,10 +11,24 @@ updates:
       python-dependencies:
         patterns:
           - "*"
+    ignore:
+      # Ignore routine updates by type instead of ignoring each dependency
+      # completely, so Dependabot security updates remain enabled.
+      # Home Assistant pins the compatible uv version.
+      - dependency-name: "uv"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      # pytest-homeassistant-custom-component pins the compatible pytest version.
+      - dependency-name: "pytest"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     open-pull-requests-limit: 1
 
   - package-ecosystem: "github-actions"
-    # Workflow files stored in the default location of `.github/workflows`
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Dependabot can't resolve your Python dependency files

Dependabot failed to update your dependencies because there was an error resolving your Python dependency files.

Dependabot encountered the following error:

× No solution found when resolving dependencies for split (markers:
  │ python_full_version >= '3.14' and python_full_version < '3.14.2'):
  ╰─▶ Because the requested Python version (>=3.14) does not satisfy
      Python>=3.14.2 and homeassistant==2026.8.1 depends on Python>=3.14.2, we
      can conclude that homeassistant==2026.8.1 cannot be used.
      And because pytest-homeassistant-custom-component==0.13.355
      depends on homeassistant==2026.8.1, we can conclude that
      pytest-homeassistant-custom-component==0.13.355 cannot be used.
      And because places:dev depends on
      pytest-homeassistant-custom-component==0.13.355 and your project
      requires places:dev, we can conclude that your project's requirements
      are unsatisfiable.

hint: The resolution failed for an environment that is not the current one, consider limiting the environments with `tool.uv.environments`.
hint: The `requires-python` value (>=3.14) includes Python versions that are not supported by your dependencies (e.g., homeassistant==2026.8.1 only supports >=3.14.2). Consider using a more restrictive `requires-python` value (like >=3.14.2).
