### PR TITLE
Lock inactive closed issues

### DIFF
--- a/.github/workflows/lock_closed_issues.yml
+++ b/.github/workflows/lock_closed_issues.yml
@@ -1,0 +1,25 @@
+name: "Lock Closed Issues"
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  action:
+    name: Lock Closed Issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lock closed issues
+        uses: dessant/lock-threads@v6
+        with:
+          issue-inactive-days: "7"
+          issue-lock-reason: "resolved"
+          process-only: "issues"
+          log-output: true


### PR DESCRIPTION
## Summary

Adds automated cleanup for closed issues by locking them after seven inactive days. This keeps resolved discussions stable while preserving manual execution when maintainers need it.

## What Changed

- Added a daily scheduled workflow for closed-issue cleanup
- Added manual workflow dispatch support
- Limited the workflow to issues and granted only issue write permission
- Configured resolved locks with action logging enabled

## Why

Closed issues can attract late, unrelated follow-up discussion after resolution. Automatically locking inactive closed issues keeps historical issue threads focused while leaving a seven-day window for immediate follow-up.