### PR TITLE
Standardize guarded Home Assistant releases

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -2,67 +2,64 @@
 
 <!-- cspell:ignore Hassfest -->
 
+## Prerequisites
+
+Publishing a GitHub Release is the only release trigger (`release: published`).
+Create it with a new `v`-prefixed tag targeting the repository default branch.
+At the start of the run, that tag and the default branch must name the same
+commit. Stable tags are numeric `v` versions with two, three, or four
+components; the prerelease setting must agree with the tag format. A
+prerelease archive must already contain its tag in both
+`custom_components/places/manifest.json` and `const.py`.
+
 ## Stable releases
 
-1. Merge release-ready changes into the default branch, then publish a GitHub
-   Release with an unused numeric `v`-prefixed tag targeting that branch. The
-   new tag and branch must initially name the same commit.
-2. The workflow creates one deterministic commit changing only `manifest.json`
-   and `const.py`, then builds and validates `places.zip` from that candidate.
-3. It publishes the candidate to a unique validation branch and dispatches its
-   exact SHA to `HACS Validation`, `Hassfest Validation`, `pytest check and
-   post coverage`, and `review`. After each exact job succeeds, the workflow
-   atomically advances the default branch and annotated tag, rechecks them, and
-   uploads the already verified candidate archive.
+The workflow rechecks the default branch before running its trusted helpers,
+then creates a deterministic candidate commit that changes only those two
+version files. It builds and verifies `places.zip` from that commit before
+pushing the candidate to a unique `release-validation/...` branch.
 
-No personal access token, GitHub App token, or deploy key is required. The
-workflow uses `GITHUB_TOKEN`; branch protection and repository rules remain
-active throughout promotion.
+It dispatches and verifies these exact candidate-SHA gates:
+
+- `pytest_check.yml::pytest check and post coverage`
+- `validate.yml::Hassfest Validation`
+- `validate.yml::HACS Validation`
+- `prek-autofix-review.yml::review`
+
+After every gate succeeds, the workflow atomically advances the default branch
+and replaces the tag with an annotated tag, using leases for both original
+refs. It fetches them again, requires both to resolve to the candidate, verifies
+the archive again, and uploads the archive. The validation branch is deleted
+only after success.
 
 ## Prereleases
 
-Publish an explicit unused prerelease tag whose `manifest.json` and `const.py`
-versions already match. The workflow only builds and uploads `places.zip`; it
-does not create a commit or move a ref. Before upload, the default branch and
-tag must still resolve to the exact source selected by the published release.
+A prerelease builds `places.zip` directly from the published source. It does
+not create a candidate commit, dispatch release gates, create a validation
+branch, or move the branch or tag. Before upload, the workflow rechecks the
+original branch, tag object, and tag target, then verifies the archive.
 
-## Failure handling and safe retries
+## Failures and recovery
 
-The workflow stops before promotion when validation fails, a required check
-does not complete before its wait limit, or `main` changes after candidate
-selection. A failed stable run retains its temporary validation branch. Verify
-its exact SHA before deleting it:
+The workflow stops if the target is not the default branch, the default branch
+moves, the tag identity changes, the tag kind is inconsistent, archive
+validation fails, a gate does not complete successfully for the dispatched
+SHA, or a guarded ref check fails. Do not promote a validation branch directly
+or force-move its tag.
 
-```sh
-git fetch origin refs/heads/<temporary-ref>
-git show -s --format='%H%n%s%n%P' FETCH_HEAD
-git push --force-with-lease=refs/heads/<temporary-ref>:<candidate-sha> origin --delete <temporary-ref>
-```
-
-Do not promote that candidate directly or force-move its tag.
-
-The workflow attempts an atomic branch-and-tag update. It fails closed if the
-remote rejects or does not support that update; it does not promise that a
-partial remote update is impossible. Inspect remote state before retrying:
+If a stable run has created a validation branch, it remains after failure.
+Confirm its candidate SHA before removing it:
 
 ```sh
-git fetch --tags origin
-git log -1 --decorate origin/main
-git show --no-patch --decorate <tag>
-git show <tag>:custom_components/places/manifest.json
-git show <tag>:custom_components/places/const.py
+git fetch origin "refs/heads/<temporary-ref>:refs/remotes/origin/<temporary-ref>"
+git rev-parse "refs/remotes/origin/<temporary-ref>"
+git push --force-with-lease="refs/heads/<temporary-ref>:<candidate-sha>" origin --delete "<temporary-ref>"
 ```
 
-- If `main` moved or the tag and `main` do not name the same release commit,
-  stop. Do not force-push or move the tag; treat a tag/main split as an
-  incident and resolve it before creating a new release from current `main`.
-- If validation failed, fix the cause and publish a new release. Do not push
-  the validation commit directly to bypass required checks.
-- If the branch/tag update was rejected, inspect both remote refs rather than
-  assuming they are unchanged, then refresh from `main`. Escalate a confirmed
-  partial update rather than attempting to repair it by force.
-- If upload failed after promotion, preserve the tag and rerun the workflow
-  only when the tag and `main` still name the same one-parent `Release <tag>`
-  commit, its only changed paths are the two version files, and regenerating
-  them from the parent produces identical contents. Do not create a second
-  release or force-move the tag.
+If promotion reports an error, inspect both remote refs before retrying. Do
+not assume an atomic push left them unchanged; treat a branch/tag split as an
+incident. If upload fails after promotion, rerun only when the branch and tag
+still name the same one-parent `Release <tag>` commit, it changed only the two
+version files, and recreating those files from its parent is identical.
+Otherwise, publish a new release from current default-branch state without
+moving the original tag.

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -22,6 +22,7 @@ pushing the candidate to a unique `release-validation/...` branch.
 It dispatches and verifies these exact candidate-SHA gates:
 
 - `pytest_check.yml::pytest check and post coverage`
+- `uv-lock-check.yml::Validate uv lock consistency`
 - `validate.yml::Hassfest Validation`
 - `validate.yml::HACS Validation`
 - `prek-autofix-review.yml::review`

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -2,65 +2,44 @@
 
 <!-- cspell:ignore Hassfest -->
 
-## Stable release
+## Stable releases
 
-1. Merge the release-ready changes into the default branch. Publish a GitHub
-   Release with the intended unused, numeric, `v`-prefixed tag, targeting that
-   branch. The tag and target must initially resolve to the same commit.
-   Publishing the release starts the stable-release workflow.
-2. The workflow creates a temporary pre-validation branch containing the
-   deterministic release commit. It dispatches the required workflows for that
-   exact commit SHA and waits a bounded time for all of these checks to pass:
-
-   - `HACS Validation`
-   - `Hassfest Validation`
-   - `pytest and coverage report`
-   - `review`
-
-   The gates receive the candidate as an `expected_sha` input. The workflow
-   verifies their exact branch and SHA, GitHub Actions check suite, and one
-   successful job with each listed name; it waits at most 30 minutes. Coverage
-   publishing is a separate non-gating job and is not dispatched for release
-   validation.
-
-3. After those checks pass, the workflow updates the release commit on the
-   protected default branch and its tag, then builds `places.zip` from the
-   tag's `custom_components/places` tree. The final tag and archive therefore
-   identify the same release source.
-4. Wait for the release workflow to finish, then verify the published GitHub
-   release has the expected tag and `places.zip` asset. The temporary
-   pre-validation branch is removed after a successful stable release.
+1. Merge release-ready changes into the default branch, then publish a GitHub
+   Release with an unused numeric `v`-prefixed tag targeting that branch. The
+   new tag and branch must initially name the same commit.
+2. The workflow creates one deterministic commit changing only `manifest.json`
+   and `const.py`, then builds and validates `places.zip` from that candidate.
+3. It publishes the candidate to a unique validation branch and dispatches its
+   exact SHA to `HACS Validation`, `Hassfest Validation`, `pytest check and
+   post coverage`, and `review`. After each exact job succeeds, the workflow
+   atomically advances the default branch and annotated tag, rechecks them, and
+   uploads the already verified candidate archive.
 
 No personal access token, GitHub App token, or deploy key is required. The
-workflow uses `GITHUB_TOKEN`; branch protection and the repository ruleset
-remain active throughout the release. Tokens are provided only to the steps
-that dispatch checks, update refs, upload the asset, or delete the temporary
-branch.
+workflow uses `GITHUB_TOKEN`; branch protection and repository rules remain
+active throughout promotion.
 
 ## Prereleases
 
-Publish a GitHub Release with an explicit unused prerelease tag. A prerelease
-follows the existing tag and GitHub-release path; it does not mutate the
-default branch. Automatic version changes are stable-only.
+Publish an explicit unused prerelease tag whose `manifest.json` and `const.py`
+versions already match. The workflow only builds and uploads `places.zip`; it
+does not create a commit or move a ref. Before upload, the default branch and
+tag must still resolve to the exact source selected by the published release.
 
 ## Failure handling and safe retries
 
 The workflow stops before promotion when validation fails, a required check
-does not complete before its wait limit, or `main` changes after the
-pre-validation SHA was selected. Start a new release from current `main`; do
-not reuse a stale validation result. A failed stable run retains its temporary
-validation branch for diagnosis. After recording the failure, delete that
-branch with normal repository access before retrying. First verify the exact
-branch name and that its SHA is the failed run's candidate SHA:
+does not complete before its wait limit, or `main` changes after candidate
+selection. A failed stable run retains its temporary validation branch. Verify
+its exact SHA before deleting it:
 
 ```sh
 git fetch origin refs/heads/<temporary-ref>
 git show -s --format='%H%n%s%n%P' FETCH_HEAD
-git push origin --delete <temporary-ref>
+git push --force-with-lease=refs/heads/<temporary-ref>:<candidate-sha> origin --delete <temporary-ref>
 ```
 
-Delete it only after the shown SHA and release-commit details match
-the failed run; never use a broad branch pattern or force deletion.
+Do not promote that candidate directly or force-move its tag.
 
 The workflow attempts an atomic branch-and-tag update. It fails closed if the
 remote rejects or does not support that update; it does not promise that a
@@ -78,20 +57,12 @@ git show <tag>:custom_components/places/const.py
   stop. Do not force-push or move the tag; treat a tag/main split as an
   incident and resolve it before creating a new release from current `main`.
 - If validation failed, fix the cause and publish a new release. Do not push
-  the pre-validation commit directly to bypass required checks.
+  the validation commit directly to bypass required checks.
 - If the branch/tag update was rejected, inspect both remote refs rather than
   assuming they are unchanged, then refresh from `main`. Escalate a confirmed
   partial update rather than attempting to repair it by force.
-- If the tag and default branch are correct but the GitHub release or asset
-  upload failed, preserve the tag and rerun the failed workflow. It can resume
-  only when the tag and `main` still name the same single-parent `Release
-  <tag>` commit and both version files match the tag; do not create a second
+- If upload failed after promotion, preserve the tag and rerun the workflow
+  only when the tag and `main` still name the same one-parent `Release <tag>`
+  commit, its only changed paths are the two version files, and regenerating
+  them from the parent produces identical contents. Do not create a second
   release or force-move the tag.
-
-For any recovery upload, first rebuild and test the archive from the existing
-tag so the asset remains tied to the release source:
-
-```sh
-git archive --format=zip --output=places.zip <tag>:custom_components/places
-unzip -t places.zip
-```

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -187,6 +187,12 @@ def main() -> int:
         choices=("true", "false"),
         help="Require the tag to match the workflow prerelease selection",
     )
+    parser.add_argument(
+        "--repository",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root whose version files should be validated or updated",
+    )
     args = parser.parse_args()
 
     try:
@@ -209,7 +215,7 @@ def main() -> int:
             if args.expected_prerelease is not None:
                 msg = "--expected-prerelease requires --check-only."
                 raise ValueError(msg)
-            update_release_versions(Path.cwd(), args.tag)
+            update_release_versions(args.repository, args.tag)
     except (OSError, ValueError) as error:
         parser.error(str(error))
 

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -1,5 +1,4 @@
 """Validate a release tag and prepare the integration version files."""
-# ruff: noqa: E501
 
 from __future__ import annotations
 
@@ -15,27 +14,8 @@ TAG_PATTERN = re.compile(
 )
 MANIFEST_VERSION_PATTERN = re.compile(r'("version"\s*:\s*)"[^"]*"')
 CONST_VERSION_PATTERN = re.compile(r'^(VERSION\s*=\s*)"[^"]*"', re.MULTILINE)
-STABLE_TAG_PATTERN = re.compile(
-    r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:\.(0|[1-9][0-9]*))?$"
-)
-
-
-def _stable_tag_pattern(parts: tuple[int, ...]) -> re.Pattern[str]:
-    """Return the numeric release-tag pattern for permitted component counts."""
-    component = r"(?:0|[1-9][0-9]*)"
-    suffixes = "|".join(rf"(?:\.{component}){{{part - 1}}}" for part in sorted(parts))
-    return re.compile(rf"^v{component}(?:{suffixes})$")
-
-
-def _parse_stable_parts(value: str) -> tuple[int, ...]:
-    """Parse supported stable version component counts from workflow configuration."""
-    try:
-        parts = tuple(sorted({int(part) for part in value.split(",")}))
-    except ValueError as error:
-        raise ValueError("stable-parts must be comma-separated integers.") from error
-    if not parts or any(part < 2 or part > 4 for part in parts):
-        raise ValueError("stable-parts must contain values from 2 through 4.")
-    return parts
+_NUMERIC_COMPONENT = r"(?:0|[1-9][0-9]*)"
+STABLE_TAG_PATTERN = re.compile(rf"^v{_NUMERIC_COMPONENT}(?:\.{_NUMERIC_COMPONENT}){{1,3}}$")
 
 
 def validate_release_tag(tag: str) -> None:
@@ -52,21 +32,18 @@ def validate_release_tag(tag: str) -> None:
         raise ValueError(msg)
 
 
-def validate_release_request(
-    tag: str, prerelease: bool, stable_parts: tuple[int, ...] = (2, 3, 4)
-) -> None:
+def validate_release_request(tag: str, prerelease: bool) -> None:
     """Validate that a release tag agrees with the prerelease selection.
 
     Args:
         tag: Candidate release tag.
         prerelease: Whether the release should be treated as a prerelease.
-        stable_parts: Accepted numeric component counts for stable tags.
 
     Raises:
         ValueError: If the tag format and prerelease selection disagree.
     """
     validate_release_tag(tag)
-    tag_is_prerelease = _stable_tag_pattern(stable_parts).fullmatch(tag) is None
+    tag_is_prerelease = STABLE_TAG_PATTERN.fullmatch(tag) is None
     if tag_is_prerelease != prerelease:
         tag_kind = "Prerelease" if tag_is_prerelease else "Stable"
         required_value = str(tag_is_prerelease).lower()
@@ -74,15 +51,12 @@ def validate_release_request(
         raise ValueError(msg)
 
 
-def next_stable_release_tag(
-    tags: Iterable[str], bump_type: str, stable_parts: tuple[int, ...] = (2, 3, 4)
-) -> str:
+def next_stable_release_tag(tags: Iterable[str], bump_type: str) -> str:
     """Return the next stable tag after the highest released stable version.
 
     Args:
         tags: Candidate tag names from the release repository.
         bump_type: Requested stable version increment.
-        stable_parts: Accepted numeric component counts for stable tags.
 
     Returns:
         The next stable release tag.
@@ -98,7 +72,7 @@ def next_stable_release_tag(
         tuple(int(component) for component in tag.removeprefix("v").split("."))
         + (0,) * (4 - len(tag.removeprefix("v").split(".")))
         for tag in tags
-        if _stable_tag_pattern(stable_parts).fullmatch(tag) is not None
+        if STABLE_TAG_PATTERN.fullmatch(tag) is not None
     ]
     if not versions:
         msg = "No stable released tag found."
@@ -225,11 +199,6 @@ def main() -> int:
         "--component-path",
         help="Integration directory relative to --repository.",
     )
-    parser.add_argument(
-        "--stable-parts",
-        default="2,3,4",
-        help="Comma-separated stable release version component counts.",
-    )
     args = parser.parse_args()
 
     try:
@@ -241,17 +210,13 @@ def main() -> int:
                 msg = "Validation options cannot be used with --next-tag."
                 raise ValueError(msg)
             sys.stdout.write(
-                f"{next_stable_release_tag(sys.stdin.read().splitlines(), args.next_tag, _parse_stable_parts(args.stable_parts))}\n"
+                f"{next_stable_release_tag(sys.stdin.read().splitlines(), args.next_tag)}\n"
             )
         elif args.check_only:
             if args.expected_prerelease is None:
                 validate_release_tag(args.tag)
             else:
-                validate_release_request(
-                    args.tag,
-                    args.expected_prerelease == "true",
-                    _parse_stable_parts(args.stable_parts),
-                )
+                validate_release_request(args.tag, args.expected_prerelease == "true")
         else:
             if args.expected_prerelease is not None:
                 msg = "--expected-prerelease requires --check-only."

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -1,4 +1,5 @@
 """Validate a release tag and prepare the integration version files."""
+# ruff: noqa: E501
 
 from __future__ import annotations
 
@@ -17,15 +18,31 @@ CONST_VERSION_PATTERN = re.compile(r'^(VERSION\s*=\s*)"[^"]*"', re.MULTILINE)
 STABLE_TAG_PATTERN = re.compile(
     r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:\.(0|[1-9][0-9]*))?$"
 )
-NUMERIC_TAG_PATTERN = re.compile(r"^v[0-9]+(?:\.[0-9]+){1,3}$")
+
+
+def _stable_tag_pattern(parts: tuple[int, ...]) -> re.Pattern[str]:
+    """Return the numeric release-tag pattern for permitted component counts."""
+    component = r"(?:0|[1-9][0-9]*)"
+    suffixes = "|".join(rf"(?:\.{component}){{{part - 1}}}" for part in sorted(parts))
+    return re.compile(rf"^v{component}(?:{suffixes})$")
+
+
+def _parse_stable_parts(value: str) -> tuple[int, ...]:
+    """Parse supported stable version component counts from workflow configuration."""
+    try:
+        parts = tuple(sorted({int(part) for part in value.split(",")}))
+    except ValueError as error:
+        raise ValueError("stable-parts must be comma-separated integers.") from error
+    if not parts or any(part < 2 or part > 4 for part in parts):
+        raise ValueError("stable-parts must contain values from 2 through 4.")
+    return parts
 
 
 def validate_release_tag(tag: str) -> None:
     """Validate a release tag against the repository's supported formats.
 
     Args:
-        tag (str):
-            Candidate release tag.
+        tag: Candidate release tag.
 
     Raises:
         ValueError: If the tag does not use a supported version format.
@@ -35,18 +52,21 @@ def validate_release_tag(tag: str) -> None:
         raise ValueError(msg)
 
 
-def validate_release_request(tag: str, prerelease: bool) -> None:
+def validate_release_request(
+    tag: str, prerelease: bool, stable_parts: tuple[int, ...] = (2, 3, 4)
+) -> None:
     """Validate that a release tag agrees with the prerelease selection.
 
     Args:
-        tag (str): Candidate release tag.
-        prerelease (bool): Whether the release should be treated as a prerelease.
+        tag: Candidate release tag.
+        prerelease: Whether the release should be treated as a prerelease.
+        stable_parts: Accepted numeric component counts for stable tags.
 
     Raises:
         ValueError: If the tag format and prerelease selection disagree.
     """
     validate_release_tag(tag)
-    tag_is_prerelease = NUMERIC_TAG_PATTERN.fullmatch(tag) is None
+    tag_is_prerelease = _stable_tag_pattern(stable_parts).fullmatch(tag) is None
     if tag_is_prerelease != prerelease:
         tag_kind = "Prerelease" if tag_is_prerelease else "Stable"
         required_value = str(tag_is_prerelease).lower()
@@ -54,15 +74,18 @@ def validate_release_request(tag: str, prerelease: bool) -> None:
         raise ValueError(msg)
 
 
-def next_stable_release_tag(tags: Iterable[str], bump_type: str) -> str:
+def next_stable_release_tag(
+    tags: Iterable[str], bump_type: str, stable_parts: tuple[int, ...] = (2, 3, 4)
+) -> str:
     """Return the next stable tag after the highest released stable version.
 
     Args:
-        tags (Iterable[str]): Candidate tag names from the release repository.
-        bump_type (str): Requested stable version increment.
+        tags: Candidate tag names from the release repository.
+        bump_type: Requested stable version increment.
+        stable_parts: Accepted numeric component counts for stable tags.
 
     Returns:
-        str: The next stable release tag.
+        The next stable release tag.
 
     Raises:
         ValueError: If the bump type is unsupported or no stable tag is found.
@@ -72,9 +95,10 @@ def next_stable_release_tag(tags: Iterable[str], bump_type: str) -> str:
         raise ValueError(msg)
 
     versions = [
-        tuple(int(component or 0) for component in match.groups())
+        tuple(int(component) for component in tag.removeprefix("v").split("."))
+        + (0,) * (4 - len(tag.removeprefix("v").split(".")))
         for tag in tags
-        if (match := STABLE_TAG_PATTERN.fullmatch(tag)) is not None
+        if _stable_tag_pattern(stable_parts).fullmatch(tag) is not None
     ]
     if not versions:
         msg = "No stable released tag found."
@@ -102,17 +126,13 @@ def _replace_version(
     """Replace one version declaration while preserving its formatting.
 
     Args:
-        content (str):
-            Original file content.
-        pattern (re.Pattern[str]):
-            Pattern whose first group precedes the version string.
-        tag (str):
-            Validated release tag.
-        path (Path):
-            Source path used in error messages.
+        content: Original file content.
+        pattern: Pattern whose first group precedes the version string.
+        tag: Validated release tag.
+        path: Source path used in error messages.
 
     Returns:
-        str: Content containing the requested release version.
+        Content containing the requested release version.
 
     Raises:
         ValueError: If the file does not contain exactly one version declaration.
@@ -124,22 +144,30 @@ def _replace_version(
     return updated
 
 
-def update_release_versions(repository: Path, tag: str) -> None:
+def update_release_versions(repository: Path, tag: str, component_path: str | None = None) -> None:
     """Update manifest.json and const.py to the release tag.
 
     Both files are validated before either is written, preventing a partial update.
 
     Args:
-        repository (Path):
-            Repository root containing the integration.
-        tag (str):
-            Requested release tag.
+        repository: Repository root containing the integration.
+        tag: Requested release tag.
+        component_path: Integration directory relative to the repository.
 
     Raises:
         ValueError: If the tag or either version declaration is invalid.
     """
     validate_release_tag(tag)
-    integration = repository / "custom_components" / "places"
+    if component_path is None:
+        components = [
+            path for path in (repository / "custom_components").iterdir() if path.is_dir()
+        ]
+        if len(components) != 1:
+            msg = "component-path is required unless the repository has one component."
+            raise ValueError(msg)
+        integration = components[0]
+    else:
+        integration = repository / component_path
     manifest_path = integration / "manifest.json"
     const_path = integration / "const.py"
 
@@ -168,10 +196,10 @@ def main() -> int:
     """Run the release preparation command.
 
     Returns:
-        int: Zero when validation or version preparation succeeds.
+        Zero when validation or version preparation succeeds.
     """
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("tag", nargs="?", help="Release tag, such as v3.0.1")
+    parser.add_argument("tag", nargs="?", help="Release tag, such as v1.0.6")
     parser.add_argument(
         "--next-tag",
         metavar="BUMP_TYPE",
@@ -193,6 +221,15 @@ def main() -> int:
         default=Path.cwd(),
         help="Repository root whose version files should be validated or updated",
     )
+    parser.add_argument(
+        "--component-path",
+        help="Integration directory relative to --repository.",
+    )
+    parser.add_argument(
+        "--stable-parts",
+        default="2,3,4",
+        help="Comma-separated stable release version component counts.",
+    )
     args = parser.parse_args()
 
     try:
@@ -204,18 +241,22 @@ def main() -> int:
                 msg = "Validation options cannot be used with --next-tag."
                 raise ValueError(msg)
             sys.stdout.write(
-                f"{next_stable_release_tag(sys.stdin.read().splitlines(), args.next_tag)}\n"
+                f"{next_stable_release_tag(sys.stdin.read().splitlines(), args.next_tag, _parse_stable_parts(args.stable_parts))}\n"
             )
         elif args.check_only:
             if args.expected_prerelease is None:
                 validate_release_tag(args.tag)
             else:
-                validate_release_request(args.tag, args.expected_prerelease == "true")
+                validate_release_request(
+                    args.tag,
+                    args.expected_prerelease == "true",
+                    _parse_stable_parts(args.stable_parts),
+                )
         else:
             if args.expected_prerelease is not None:
                 msg = "--expected-prerelease requires --check-only."
                 raise ValueError(msg)
-            update_release_versions(args.repository, args.tag)
+            update_release_versions(args.repository, args.tag, args.component_path)
     except (OSError, ValueError) as error:
         parser.error(str(error))
 

--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -9,12 +9,12 @@ from pathlib import Path
 import re
 import sys
 
+_NUMERIC_COMPONENT = r"(?:0|[1-9][0-9]*)"
 TAG_PATTERN = re.compile(
-    r"^v[0-9]+(?:\.[0-9]+){1,3}(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?(?:[A-Za-z]+[0-9]+)?$"
+    rf"^v{_NUMERIC_COMPONENT}(?:\.{_NUMERIC_COMPONENT}){{1,3}}(?:-[0-9A-Za-z]+(?:\.[0-9A-Za-z]+)*)?(?:[A-Za-z]+[0-9]+)?$"
 )
 MANIFEST_VERSION_PATTERN = re.compile(r'("version"\s*:\s*)"[^"]*"')
 CONST_VERSION_PATTERN = re.compile(r'^(VERSION\s*=\s*)"[^"]*"', re.MULTILINE)
-_NUMERIC_COMPONENT = r"(?:0|[1-9][0-9]*)"
 STABLE_TAG_PATTERN = re.compile(rf"^v{_NUMERIC_COMPONENT}(?:\.{_NUMERIC_COMPONENT}){{1,3}}$")
 
 

--- a/.github/scripts/verify_hacs_archive.py
+++ b/.github/scripts/verify_hacs_archive.py
@@ -1,0 +1,123 @@
+"""Validate a release HACS archive before it is uploaded."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import json
+from pathlib import PurePosixPath
+import stat
+import zipfile
+
+MAX_FILES = 1_000
+MAX_FILE_BYTES = 10 * 1024 * 1024
+MAX_EXPANDED_BYTES = 64 * 1024 * 1024
+MAX_COMPRESSION_RATIO = 100
+REQUIRED_FILES = frozenset({"manifest.json", "const.py"})
+
+
+class ArchiveError(ValueError):
+    """Raised when a release archive is not a safe integration archive."""
+
+
+def _validate_name(name: str) -> None:
+    """Reject archive member names that can escape the integration root.
+
+    Args:
+        name (str): Archive member filename.
+
+    Raises:
+        ArchiveError: If the filename is absolute, a directory, or traverses upward.
+    """
+    path = PurePosixPath(name)
+    if not name or path.is_absolute() or ".." in path.parts:
+        raise ArchiveError(f"Invalid archive member path: {name!r}")
+
+
+def _validate_regular_file(member: zipfile.ZipInfo) -> None:
+    """Reject symlinks and non-regular POSIX members when metadata is present.
+
+    Args:
+        member (zipfile.ZipInfo): ZIP member metadata to inspect.
+
+    Raises:
+        ArchiveError: If POSIX metadata identifies a non-regular member.
+    """
+    mode = member.external_attr >> 16
+    file_type = stat.S_IFMT(mode)
+    if file_type and not stat.S_ISREG(mode):
+        raise ArchiveError(f"Archive member is not a regular file: {member.filename!r}")
+
+
+def verify_archive(archive_path: str, release_tag: str) -> None:
+    """Verify HACS archive structure, resource bounds, and embedded versions.
+
+    Args:
+        archive_path (str): Path to the ZIP archive.
+        release_tag (str): Exact tag expected in the integration version files.
+
+    Raises:
+        ArchiveError: If the archive is unreadable, unsafe, or version-mismatched.
+    """
+    try:
+        with zipfile.ZipFile(archive_path) as archive:
+            members = archive.infolist()
+            if not members or len(members) > MAX_FILES:
+                raise ArchiveError("Archive has an invalid number of files.")
+            names: set[str] = set()
+            expanded_bytes = 0
+            for member in members:
+                _validate_name(member.filename)
+                if member.filename in names:
+                    raise ArchiveError(f"Duplicate archive member: {member.filename!r}")
+                names.add(member.filename)
+                if member.is_dir():
+                    continue
+                _validate_regular_file(member)
+                if member.file_size > MAX_FILE_BYTES:
+                    raise ArchiveError(f"Archive member exceeds size limit: {member.filename!r}")
+                expanded_bytes += member.file_size
+                if expanded_bytes > MAX_EXPANDED_BYTES:
+                    raise ArchiveError("Archive expanded size exceeds limit.")
+                if member.file_size and member.compress_size == 0:
+                    raise ArchiveError(
+                        f"Archive member has invalid compression: {member.filename!r}"
+                    )
+                if (
+                    member.compress_size
+                    and member.file_size / member.compress_size > MAX_COMPRESSION_RATIO
+                ):
+                    raise ArchiveError(
+                        f"Archive member compression ratio is unsafe: {member.filename!r}"
+                    )
+            if not names >= REQUIRED_FILES:
+                raise ArchiveError("Archive does not contain required version files.")
+            manifest = json.loads(archive.read("manifest.json"))
+            if not isinstance(manifest, dict) or manifest.get("version") != release_tag:
+                raise ArchiveError("Archive manifest version does not match the release tag.")
+            const = archive.read("const.py").decode("utf-8")
+            if f'VERSION = "{release_tag}"' not in const.splitlines():
+                raise ArchiveError("Archive const.py version does not match the release tag.")
+    except (OSError, UnicodeDecodeError, zipfile.BadZipFile) as error:
+        raise ArchiveError(f"Unable to validate release archive: {error}") from error
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run archive validation from the command line.
+
+    Args:
+        argv (Sequence[str] | None): Optional arguments excluding executable name.
+
+    Returns:
+        int: Zero after successful archive validation.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive")
+    parser.add_argument("release_tag")
+    args = parser.parse_args(argv)
+    verify_archive(args.archive, args.release_tag)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/verify_release_checks.py
+++ b/.github/scripts/verify_release_checks.py
@@ -89,7 +89,9 @@ def verify_check_suite(repository: str, run: dict[str, Any], sha: str) -> None:
         or not isinstance(app, dict)
         or app.get("slug") != "github-actions"
     ):
-        raise GitHubCommandError("Workflow run is not a GitHub Actions check suite for B.")
+        raise GitHubCommandError(
+            f"Workflow run is not a GitHub Actions check suite for candidate SHA {sha}."
+        )
 
 
 def verify_jobs(repository: str, run_id: int, required_checks: set[str]) -> None:

--- a/.github/workflows/prek-autofix-review.yml
+++ b/.github/workflows/prek-autofix-review.yml
@@ -56,5 +56,5 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
-          uv run --locked prek run --all-files
-          git diff --exit-code
+          UV_LOCKED=1 uv run --locked prek run --all-files
+          test -z "$(git status --porcelain)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,16 @@ jobs:
       contents: write
       statuses: read
     runs-on: ubuntu-latest
+    env:
+      COMPONENT_PATH: custom_components/places
+      ARCHIVE_NAME: places.zip
+      STABLE_TAG_PARTS: "2,3,4"
+      FIRMWARE_NOTES: "false"
+      REQUIRED_CHECKS: |
+        pytest_check.yml::pytest check and post coverage
+        validate.yml::Hassfest Validation
+        validate.yml::HACS Validation
+        prek-autofix-review.yml::review
     steps:
       - name: Require the default-branch release target
         id: release
@@ -29,10 +39,8 @@ jobs:
           RELEASE_TARGET: ${{ github.event.release.target_commitish }}
         run: |
           set -euo pipefail
-          if [[ "$RELEASE_TARGET" != "$DEFAULT_BRANCH" ]]; then
-            echo "Release target must be the default branch." >&2
-            exit 1
-          fi
+          [[ "$RELEASE_TARGET" == "$DEFAULT_BRANCH" ]] || {
+            echo "Release target must be the default branch." >&2; exit 1; }
           echo "target=$RELEASE_TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Checkout trusted default-branch workflow revision
@@ -45,7 +53,6 @@ jobs:
       - name: Validate trusted release metadata and immutable starting refs
         id: base
         env:
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           IS_PRERELEASE: ${{ github.event.release.prerelease }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET: ${{ steps.release.outputs.target }}
@@ -56,37 +63,33 @@ jobs:
             "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
             "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           target_sha="$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")"
-          if [[ "$target_sha" != "$trusted_sha" ]]; then
-            echo "Default branch moved before trusted helper execution." >&2
-            exit 1
-          fi
-          python3 .github/scripts/prepare_release.py --check-only \
+          [[ "$target_sha" == "$trusted_sha" ]] || {
+            echo "Default branch moved before trusted helper execution." >&2; exit 1; }
+          python3 .github/scripts/prepare_release.py --component-path "$COMPONENT_PATH" \
+            --stable-parts "$STABLE_TAG_PARTS" --check-only \
             --expected-prerelease "$IS_PRERELEASE" "$RELEASE_TAG"
           tag_sha="$(git rev-parse "refs/tags/$RELEASE_TAG^{}")"
           tag_oid="$(git rev-parse "refs/tags/$RELEASE_TAG")"
-          if [[ "$target_sha" != "$tag_sha" ]]; then
-            echo "Release tag and target branch must start at the same commit." >&2
-            exit 1
-          fi
+          [[ "$target_sha" == "$tag_sha" ]] || {
+            echo "Release tag and target branch must start at the same commit." >&2; exit 1; }
           resume=false
-          if [[ "$(git log -1 --format=%s "$target_sha")" == "Release $RELEASE_TAG" ]]; then
+          if [[ "$IS_PRERELEASE" == false && \
+            "$(git log -1 --format=%s "$target_sha")" == "Release $RELEASE_TAG" ]]; then
             if [[ "$(git rev-list --parents -n 1 "$target_sha" | wc -w)" -ne 2 ]] || \
-              [[ "$(git diff --name-only "$target_sha^" "$target_sha")" != $'custom_components/places/const.py\ncustom_components/places/manifest.json' ]] || \
-              [[ "$(jq -r .version custom_components/places/manifest.json)" != "$RELEASE_TAG" ]] || \
-              ! grep -Fx "VERSION = \"$RELEASE_TAG\"" custom_components/places/const.py >/dev/null; then
+              [[ "$(git diff --name-only "$target_sha^" "$target_sha")" != $(printf '%s/const.py\n%s/manifest.json' "$COMPONENT_PATH" "$COMPONENT_PATH") ]] || \
+              [[ "$(jq -r .version "$COMPONENT_PATH/manifest.json")" != "$RELEASE_TAG" ]] || \
+              ! grep -Fx "VERSION = \"$RELEASE_TAG\"" "$COMPONENT_PATH/const.py" >/dev/null; then
               echo "Matching branch/tag release commit has invalid release contents." >&2
               exit 1
             fi
             resume_dir="$(mktemp -d)"
-            mkdir -p "$resume_dir/custom_components/places"
-            git show "$target_sha^:custom_components/places/manifest.json" > \
-              "$resume_dir/custom_components/places/manifest.json"
-            git show "$target_sha^:custom_components/places/const.py" > \
-              "$resume_dir/custom_components/places/const.py"
-            python3 .github/scripts/prepare_release.py --repository "$resume_dir" "$RELEASE_TAG"
-            cmp "$resume_dir/custom_components/places/manifest.json" \
-              custom_components/places/manifest.json
-            cmp "$resume_dir/custom_components/places/const.py" custom_components/places/const.py
+            mkdir -p "$resume_dir/$COMPONENT_PATH"
+            git show "$target_sha^:$COMPONENT_PATH/manifest.json" > "$resume_dir/$COMPONENT_PATH/manifest.json"
+            git show "$target_sha^:$COMPONENT_PATH/const.py" > "$resume_dir/$COMPONENT_PATH/const.py"
+            python3 .github/scripts/prepare_release.py --repository "$resume_dir" \
+              --component-path "$COMPONENT_PATH" "$RELEASE_TAG"
+            cmp "$resume_dir/$COMPONENT_PATH/manifest.json" "$COMPONENT_PATH/manifest.json"
+            cmp "$resume_dir/$COMPONENT_PATH/const.py" "$COMPONENT_PATH/const.py"
             resume=true
             echo "candidate-sha=$target_sha" >> "$GITHUB_OUTPUT"
           fi
@@ -97,68 +100,48 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           git checkout --detach "$target_sha"
 
-      # Prereleases retain the historical behavior: create only the archive.
       - name: Build prerelease archive without mutating refs
         if: github.event.release.prerelease
         env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_ARCHIVE: ${{ runner.temp }}/places.zip
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_TARGET: ${{ steps.release.outputs.target }}
-          SOURCE_SHA: ${{ steps.base.outputs.target-sha }}
-          TAG_OID: ${{ steps.base.outputs.tag-oid }}
+          RELEASE_ARCHIVE: ${{ runner.temp }}/${{ env.ARCHIVE_NAME }}
         run: |
           set -euo pipefail
-          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" --output="$RELEASE_ARCHIVE" \
-            "HEAD:custom_components/places"
-          unzip -t "$RELEASE_ARCHIVE"
-          [[ "$(unzip -p "$RELEASE_ARCHIVE" manifest.json | jq -r .version)" == "$RELEASE_TAG" ]]
-          unzip -p "$RELEASE_ARCHIVE" const.py | \
-            grep -Fx "VERSION = \"$RELEASE_TAG\"" >/dev/null
-          git fetch --force --no-tags origin \
-            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
-            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
-          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$TAG_OID" ]]
-          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$SOURCE_SHA" ]]
-          gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#places.zip" --clobber
+          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" \
+            --output="$RELEASE_ARCHIVE" "HEAD:$COMPONENT_PATH"
 
       - name: Create deterministic stable release commit B
         if: github.event.release.prerelease == false
         id: candidate
         env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
           RESUME: ${{ steps.base.outputs.resume }}
           RESUME_SHA: ${{ steps.base.outputs.candidate-sha }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
           if [[ "$RESUME" == true ]]; then
             echo "sha=$RESUME_SHA" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 .github/scripts/prepare_release.py "$RELEASE_TAG"
-          git add custom_components/places/manifest.json custom_components/places/const.py
+          python3 .github/scripts/prepare_release.py --component-path "$COMPONENT_PATH" "$RELEASE_TAG"
+          git add "$COMPONENT_PATH/manifest.json" "$COMPONENT_PATH/const.py"
           git diff --cached --check
-          [[ "$(git diff --cached --name-only)" == $'custom_components/places/const.py\ncustom_components/places/manifest.json' ]] || {
+          [[ "$(git diff --cached --name-only)" == $(printf '%s/const.py\n%s/manifest.json' "$COMPONENT_PATH" "$COMPONENT_PATH") ]] || {
             echo "Release transform changed an unexpected path." >&2; exit 1; }
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "Release $RELEASE_TAG"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Build and test HACS archive from B
+      - name: Build and verify release archive
         if: github.event.release.prerelease == false
         env:
-          RELEASE_ARCHIVE: ${{ runner.temp }}/places.zip
+          RELEASE_ARCHIVE: ${{ runner.temp }}/${{ env.ARCHIVE_NAME }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" --output="$RELEASE_ARCHIVE" \
-            "HEAD:custom_components/places"
-          unzip -t "$RELEASE_ARCHIVE"
-          [[ "$(unzip -p "$RELEASE_ARCHIVE" manifest.json | jq -r .version)" == "$RELEASE_TAG" ]]
-          unzip -p "$RELEASE_ARCHIVE" const.py | \
-            grep -Fx "VERSION = \"$RELEASE_TAG\"" >/dev/null
+          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" \
+            --output="$RELEASE_ARCHIVE" "HEAD:$COMPONENT_PATH"
+          python3 .github/scripts/verify_hacs_archive.py "$RELEASE_ARCHIVE" "$RELEASE_TAG"
 
       - name: Publish B to an isolated validation branch
         if: github.event.release.prerelease == false
@@ -182,12 +165,13 @@ jobs:
           TEMP_REF: ${{ steps.validation_ref.outputs.name }}
         run: |
           set -euo pipefail
+          required_check_args=()
+          while IFS= read -r required_check; do
+            [[ -z "$required_check" ]] || required_check_args+=(--required-check "$required_check")
+          done <<< "$REQUIRED_CHECKS"
           python3 .github/scripts/verify_release_checks.py \
             --repository "$GITHUB_REPOSITORY" --ref "$TEMP_REF" --sha "$CANDIDATE_SHA" \
-            --required-check 'validate.yml::HACS Validation' \
-            --required-check 'validate.yml::Hassfest Validation' \
-            --required-check 'pytest_check.yml::pytest check and post coverage' \
-            --required-check 'prek-autofix-review.yml::review'
+            "${required_check_args[@]}"
 
       - name: Atomically advance target and guarded release tag
         if: github.event.release.prerelease == false && steps.base.outputs.resume != 'true'
@@ -197,31 +181,31 @@ jobs:
           ORIGINAL_TAG_OID: ${{ steps.base.outputs.tag-oid }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET: ${{ steps.release.outputs.target }}
-          TARGET_SHA: ${{ steps.base.outputs.target-sha }}
+          SOURCE_SHA: ${{ steps.base.outputs.target-sha }}
         run: |
           set -euo pipefail
           git fetch --force --no-tags origin \
             "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
             "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
-          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$TARGET_SHA" ]]
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$ORIGINAL_TAG_OID" ]]
-          [[ "$(git rev-parse HEAD^)" == "$TARGET_SHA" ]]
+          [[ "$(git rev-parse HEAD^)" == "$SOURCE_SHA" ]]
           git tag -fa "$RELEASE_TAG" -m "Release $RELEASE_TAG" HEAD
           echo "tag-oid=$(git rev-parse "refs/tags/$RELEASE_TAG")" >> "$GITHUB_OUTPUT"
           gh auth setup-git --hostname github.com
           git push --atomic \
-            --force-with-lease="refs/heads/$RELEASE_TARGET:$TARGET_SHA" \
+            --force-with-lease="refs/heads/$RELEASE_TARGET:$SOURCE_SHA" \
             --force-with-lease="refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" \
             origin "HEAD:refs/heads/$RELEASE_TARGET" \
             "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
 
-      - name: Verify release identity and upload B archive
+      - name: Verify release identity and upload verified archive
         if: github.event.release.prerelease == false
         env:
           CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
           PROMOTED_TAG_OID: ${{ steps.promotion.outputs.tag-oid || steps.base.outputs.tag-oid }}
-          RELEASE_ARCHIVE: ${{ runner.temp }}/places.zip
+          RELEASE_ARCHIVE: ${{ runner.temp }}/${{ env.ARCHIVE_NAME }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET: ${{ steps.release.outputs.target }}
         run: |
@@ -232,10 +216,58 @@ jobs:
           [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$CANDIDATE_SHA" ]]
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$PROMOTED_TAG_OID" ]]
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$CANDIDATE_SHA" ]]
-          python3 .github/scripts/prepare_release.py "$RELEASE_TAG"
-          git diff --quiet -- custom_components/places/manifest.json \
-            custom_components/places/const.py
-          gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#places.zip" --clobber
+          python3 .github/scripts/verify_hacs_archive.py "$RELEASE_ARCHIVE" "$RELEASE_TAG"
+          if [[ "$FIRMWARE_NOTES" == true ]]; then
+            opnsense_ltd_firmware="$(grep 'OPNSENSE_LTD_FIRMWARE' "$COMPONENT_PATH/const.py" | cut -d '"' -f2)"
+            opnsense_min_firmware="$(grep 'OPNSENSE_MIN_FIRMWARE' "$COMPONENT_PATH/const.py" | cut -d '"' -f2)"
+            firmware_notes="<!-- opnsense-firmware-compatibility --><h3>OPNsense Minimum Firmware Required: $opnsense_min_firmware</h3><h4>OPNsense Recommended Firmware: $opnsense_ltd_firmware+</h4><p><i>For firmware versions below the minimum version, the integration will not permit new installations and existing installations will no longer start. Firmware versions below the recommended version will likely work but may have limited features and/or show errors in the logs.</i></p>"
+            release_body="$(gh release view "$RELEASE_TAG" --json body --jq .body)"
+            if [[ "$release_body" != *"opnsense-firmware-compatibility"* ]]; then
+              gh release edit "$RELEASE_TAG" --notes "${release_body}"$'\n\n'"$firmware_notes"
+            fi
+          fi
+          git fetch --force --no-tags origin \
+            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$CANDIDATE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$PROMOTED_TAG_OID" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$CANDIDATE_SHA" ]]
+          gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#$ARCHIVE_NAME" --clobber
+
+      - name: Verify prerelease identity and upload archive
+        if: github.event.release.prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ARCHIVE: ${{ runner.temp }}/${{ env.ARCHIVE_NAME }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TARGET: ${{ steps.release.outputs.target }}
+          SOURCE_SHA: ${{ steps.base.outputs.target-sha }}
+          TAG_OID: ${{ steps.base.outputs.tag-oid }}
+        run: |
+          set -euo pipefail
+          git fetch --force --no-tags origin \
+            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$TAG_OID" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$SOURCE_SHA" ]]
+          python3 .github/scripts/verify_hacs_archive.py "$RELEASE_ARCHIVE" "$RELEASE_TAG"
+          if [[ "$FIRMWARE_NOTES" == true ]]; then
+            opnsense_ltd_firmware="$(grep 'OPNSENSE_LTD_FIRMWARE' "$COMPONENT_PATH/const.py" | cut -d '"' -f2)"
+            opnsense_min_firmware="$(grep 'OPNSENSE_MIN_FIRMWARE' "$COMPONENT_PATH/const.py" | cut -d '"' -f2)"
+            firmware_notes="<!-- opnsense-firmware-compatibility --><h3>OPNsense Minimum Firmware Required: $opnsense_min_firmware</h3><h4>OPNsense Recommended Firmware: $opnsense_ltd_firmware+</h4><p><i>For firmware versions below the minimum version, the integration will not permit new installations and existing installations will no longer start. Firmware versions below the recommended version will likely work but may have limited features and/or show errors in the logs.</i></p>"
+            release_body="$(gh release view "$RELEASE_TAG" --json body --jq .body)"
+            if [[ "$release_body" != *"opnsense-firmware-compatibility"* ]]; then
+              gh release edit "$RELEASE_TAG" --notes "${release_body}"$'\n\n'"$firmware_notes"
+            fi
+          fi
+          git fetch --force --no-tags origin \
+            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$TAG_OID" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$SOURCE_SHA" ]]
+          gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#$ARCHIVE_NAME" --clobber
 
       - name: Delete validated temporary branch
         if: github.event.release.prerelease == false && success()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       FIRMWARE_NOTES: "false"
       REQUIRED_CHECKS: |
         pytest_check.yml::pytest check and post coverage
+        uv-lock-check.yml::Validate uv lock consistency
         validate.yml::Hassfest Validation
         validate.yml::HACS Validation
         prek-autofix-review.yml::review

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,6 @@ jobs:
     env:
       COMPONENT_PATH: custom_components/places
       ARCHIVE_NAME: places.zip
-      STABLE_TAG_PARTS: "2,3,4"
       FIRMWARE_NOTES: "false"
       REQUIRED_CHECKS: |
         pytest_check.yml::pytest check and post coverage
@@ -67,8 +66,7 @@ jobs:
           [[ "$target_sha" == "$trusted_sha" ]] || {
             echo "Default branch moved before trusted helper execution." >&2; exit 1; }
           python3 .github/scripts/prepare_release.py --component-path "$COMPONENT_PATH" \
-            --stable-parts "$STABLE_TAG_PARTS" --check-only \
-            --expected-prerelease "$IS_PRERELEASE" "$RELEASE_TAG"
+            --check-only --expected-prerelease "$IS_PRERELEASE" "$RELEASE_TAG"
           tag_sha="$(git rev-parse "refs/tags/$RELEASE_TAG^{}")"
           tag_oid="$(git rev-parse "refs/tags/$RELEASE_TAG")"
           [[ "$target_sha" == "$tag_sha" ]] || {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,22 @@ jobs:
           resume=false
           if [[ "$(git log -1 --format=%s "$target_sha")" == "Release $RELEASE_TAG" ]]; then
             if [[ "$(git rev-list --parents -n 1 "$target_sha" | wc -w)" -ne 2 ]] || \
+              [[ "$(git diff --name-only "$target_sha^" "$target_sha")" != $'custom_components/places/const.py\ncustom_components/places/manifest.json' ]] || \
               [[ "$(jq -r .version custom_components/places/manifest.json)" != "$RELEASE_TAG" ]] || \
               ! grep -Fx "VERSION = \"$RELEASE_TAG\"" custom_components/places/const.py >/dev/null; then
               echo "Matching branch/tag release commit has invalid release contents." >&2
               exit 1
             fi
+            resume_dir="$(mktemp -d)"
+            mkdir -p "$resume_dir/custom_components/places"
+            git show "$target_sha^:custom_components/places/manifest.json" > \
+              "$resume_dir/custom_components/places/manifest.json"
+            git show "$target_sha^:custom_components/places/const.py" > \
+              "$resume_dir/custom_components/places/const.py"
+            python3 .github/scripts/prepare_release.py --repository "$resume_dir" "$RELEASE_TAG"
+            cmp "$resume_dir/custom_components/places/manifest.json" \
+              custom_components/places/manifest.json
+            cmp "$resume_dir/custom_components/places/const.py" custom_components/places/const.py
             resume=true
             echo "candidate-sha=$target_sha" >> "$GITHUB_OUTPUT"
           fi
@@ -93,14 +104,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RELEASE_ARCHIVE: ${{ runner.temp }}/places.zip
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TARGET: ${{ steps.release.outputs.target }}
+          SOURCE_SHA: ${{ steps.base.outputs.target-sha }}
+          TAG_OID: ${{ steps.base.outputs.tag-oid }}
         run: |
           set -euo pipefail
-          git archive --format=zip --output="$RELEASE_ARCHIVE" \
+          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" --output="$RELEASE_ARCHIVE" \
             "HEAD:custom_components/places"
           unzip -t "$RELEASE_ARCHIVE"
           [[ "$(unzip -p "$RELEASE_ARCHIVE" manifest.json | jq -r .version)" == "$RELEASE_TAG" ]]
           unzip -p "$RELEASE_ARCHIVE" const.py | \
             grep -Fx "VERSION = \"$RELEASE_TAG\"" >/dev/null
+          git fetch --force --no-tags origin \
+            "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$TAG_OID" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$SOURCE_SHA" ]]
           gh release upload "$RELEASE_TAG" "$RELEASE_ARCHIVE#places.zip" --clobber
 
       - name: Create deterministic stable release commit B
@@ -117,10 +137,10 @@ jobs:
             exit 0
           fi
           python3 .github/scripts/prepare_release.py "$RELEASE_TAG"
-          # Stage all deterministic, repo-local release outputs. This keeps
-          # future generated changelog files opt-in through the helper itself.
-          git add -A
+          git add custom_components/places/manifest.json custom_components/places/const.py
           git diff --cached --check
+          [[ "$(git diff --cached --name-only)" == $'custom_components/places/const.py\ncustom_components/places/manifest.json' ]] || {
+            echo "Release transform changed an unexpected path." >&2; exit 1; }
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit -m "Release $RELEASE_TAG"
@@ -133,7 +153,7 @@ jobs:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          git archive --format=zip --output="$RELEASE_ARCHIVE" \
+          git archive --format=zip --mtime="@$(git log -1 --format=%ct HEAD)" --output="$RELEASE_ARCHIVE" \
             "HEAD:custom_components/places"
           unzip -t "$RELEASE_ARCHIVE"
           [[ "$(unzip -p "$RELEASE_ARCHIVE" manifest.json | jq -r .version)" == "$RELEASE_TAG" ]]
@@ -171,6 +191,7 @@ jobs:
 
       - name: Atomically advance target and guarded release tag
         if: github.event.release.prerelease == false && steps.base.outputs.resume != 'true'
+        id: promotion
         env:
           GH_TOKEN: ${{ github.token }}
           ORIGINAL_TAG_OID: ${{ steps.base.outputs.tag-oid }}
@@ -186,6 +207,7 @@ jobs:
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$ORIGINAL_TAG_OID" ]]
           [[ "$(git rev-parse HEAD^)" == "$TARGET_SHA" ]]
           git tag -fa "$RELEASE_TAG" -m "Release $RELEASE_TAG" HEAD
+          echo "tag-oid=$(git rev-parse "refs/tags/$RELEASE_TAG")" >> "$GITHUB_OUTPUT"
           gh auth setup-git --hostname github.com
           git push --atomic \
             --force-with-lease="refs/heads/$RELEASE_TARGET:$TARGET_SHA" \
@@ -198,6 +220,7 @@ jobs:
         env:
           CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
           GH_TOKEN: ${{ github.token }}
+          PROMOTED_TAG_OID: ${{ steps.promotion.outputs.tag-oid || steps.base.outputs.tag-oid }}
           RELEASE_ARCHIVE: ${{ runner.temp }}/places.zip
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET: ${{ steps.release.outputs.target }}
@@ -207,6 +230,7 @@ jobs:
             "refs/heads/$RELEASE_TARGET:refs/remotes/origin/$RELEASE_TARGET" \
             "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
           [[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$CANDIDATE_SHA" ]]
+          [[ "$(git rev-parse "refs/tags/$RELEASE_TAG")" == "$PROMOTED_TAG_OID" ]]
           [[ "$(git rev-parse "refs/tags/$RELEASE_TAG^{}")" == "$CANDIDATE_SHA" ]]
           python3 .github/scripts/prepare_release.py "$RELEASE_TAG"
           git diff --quiet -- custom_components/places/manifest.json \
@@ -217,7 +241,9 @@ jobs:
         if: github.event.release.prerelease == false && success()
         env:
           GH_TOKEN: ${{ github.token }}
+          CANDIDATE_SHA: ${{ steps.candidate.outputs.sha }}
           TEMP_REF: ${{ steps.validation_ref.outputs.name }}
         run: |
           gh auth setup-git --hostname github.com
-          git push origin --delete "$TEMP_REF"
+          git push --force-with-lease="refs/heads/$TEMP_REF:$CANDIDATE_SHA" \
+            origin --delete "$TEMP_REF"

--- a/.github/workflows/uv-lock-check.yml
+++ b/.github/workflows/uv-lock-check.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      expected_sha:
+        description: Immutable commit SHA required by release orchestration
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -15,9 +20,18 @@ jobs:
     name: Validate uv lock consistency
     runs-on: ubuntu-latest
     steps:
+      - name: Require expected release commit
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+          WORKFLOW_SHA: ${{ github.sha }}
+        run: |
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$WORKFLOW_SHA" = "$EXPECTED_SHA"
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.expected_sha || github.sha }}
           persist-credentials: false
 
       - name: Setup uv

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -98,59 +98,36 @@ def test_validate_release_request_rejects_mismatched_classification(
         prepare_release.validate_release_request(tag, prerelease)
 
 
-@pytest.mark.parametrize(
-    ("tag", "stable_parts"),
-    [("v1.2", (2,)), ("v1.2.3", (3,)), ("v1.2.3.4", (4,))],
-)
-def test_validate_release_request_honors_configured_numeric_component_counts(
-    tag: str, stable_parts: tuple[int, ...]
-) -> None:
-    """Accept each configured stable numeric component count.
+@pytest.mark.parametrize("tag", ["v1.2", "v1.2.3", "v1.2.3.4"])
+def test_validate_release_request_accepts_fixed_numeric_component_counts(tag: str) -> None:
+    """Accept every supported fixed numeric stable-tag length.
 
     Args:
         tag (str): Numeric release tag under test.
-        stable_parts (tuple[int, ...]): Configured stable component count.
     """
-    prepare_release.validate_release_request(tag, False, stable_parts)
+    prepare_release.validate_release_request(tag, False)
 
 
-@pytest.mark.parametrize(
-    ("tag", "stable_parts"),
-    [
-        ("v01.2", (2,)),
-        ("v1.02.3", (3,)),
-        ("v1.2.03", (3,)),
-        ("v1.2.3.04", (4,)),
-    ],
-)
-def test_validate_release_request_rejects_leading_zero_components(
-    tag: str, stable_parts: tuple[int, ...]
-) -> None:
+@pytest.mark.parametrize("tag", ["v01.2", "v1.02.3", "v1.2.03", "v1.2.3.04"])
+def test_validate_release_request_rejects_leading_zero_components(tag: str) -> None:
     """Reject stable tags with leading zeros at every supported length.
 
     Args:
         tag (str): Stable tag containing a leading-zero component.
-        stable_parts (tuple[int, ...]): Configured stable component count.
     """
     with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
-        prepare_release.validate_release_request(tag, False, stable_parts)
+        prepare_release.validate_release_request(tag, False)
 
 
-@pytest.mark.parametrize(
-    ("tag", "stable_parts"),
-    [("v1.2.3", (2,)), ("v1.2", (3,)), ("v1.2.3.4", (3,))],
-)
-def test_validate_release_request_rejects_unconfigured_component_counts(
-    tag: str, stable_parts: tuple[int, ...]
-) -> None:
-    """Treat a valid but unconfigured numeric length as prerelease.
+@pytest.mark.parametrize("tag", ["v1", "v1.2.3.4.5"])
+def test_validate_release_request_rejects_unsupported_numeric_lengths(tag: str) -> None:
+    """Reject numeric tags outside the fixed two- through four-part range.
 
     Args:
-        tag (str): Numeric release tag with an unsupported configured length.
-        stable_parts (tuple[int, ...]): Configured stable component counts.
+        tag (str): Numeric tag using an unsupported component count.
     """
-    with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
-        prepare_release.validate_release_request(tag, False, stable_parts)
+    with pytest.raises(ValueError, match="Invalid release tag"):
+        prepare_release.validate_release_request(tag, False)
 
 
 @pytest.mark.parametrize(
@@ -238,21 +215,17 @@ def test_next_tag_cli_reads_tags_from_standard_input(
     assert capsys.readouterr().out == "v0.9.0\n"
 
 
-def test_next_tag_cli_honors_configured_stable_component_counts(
+def test_next_tag_cli_considers_fixed_component_counts(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Use the workflow stable-parts setting when selecting the next tag.
+    """Use supported two- through four-part tags when selecting the next tag.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI inputs.
         capsys (pytest.CaptureFixture[str]): Fixture for capturing CLI output.
     """
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [str(SCRIPT_PATH), "--next-tag", "patch", "--stable-parts", "3"],
-    )
-    monkeypatch.setattr(sys, "stdin", io.StringIO("v1.2.3\nv1.2.3.4\n"))
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), "--next-tag", "patch"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO("v1.2\nv1.2.3\nv1.2.3.4\n"))
 
     assert prepare_release.main() == 0
     assert capsys.readouterr().out == "v1.2.4\n"
@@ -297,36 +270,6 @@ def test_main_rejects_invalid_option_combinations(
     assert expected_message in capsys.readouterr().err
 
 
-def test_main_rejects_invalid_stable_parts(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Reject stable-parts values outside the configured version range.
-
-    Args:
-        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
-        capsys (pytest.CaptureFixture[str]): Fixture for capturing parser errors.
-    """
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        [
-            str(SCRIPT_PATH),
-            "--check-only",
-            "--expected-prerelease",
-            "false",
-            "--stable-parts",
-            "1,5",
-            INITIAL_TAG,
-        ],
-    )
-
-    with pytest.raises(SystemExit) as error:
-        prepare_release.main()
-
-    assert error.value.code == 2
-    assert "stable-parts must contain values from 2 through 4" in capsys.readouterr().err
-
-
 def test_check_only_cli_preserves_positional_tag_contract(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -366,13 +309,15 @@ def test_check_only_cli_rejects_prerelease_input_mismatch(
         prepare_release.main()
 
 
-def test_check_only_cli_accepts_configured_component_count(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("tag", ["v1.2", "v1.2.3", "v1.2.3.4"])
+def test_check_only_cli_accepts_fixed_component_counts(
+    monkeypatch: pytest.MonkeyPatch, tag: str
 ) -> None:
-    """Accept a stable tag whose component count is explicitly configured.
+    """Accept each fixed stable component count through the CLI contract.
 
     Args:
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
+        tag (str): Stable tag using a supported component count.
     """
     monkeypatch.setattr(
         sys,
@@ -382,9 +327,7 @@ def test_check_only_cli_accepts_configured_component_count(
             "--check-only",
             "--expected-prerelease",
             "false",
-            "--stable-parts",
-            "2",
-            "v1.2",
+            tag,
         ],
     )
 

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -108,15 +108,32 @@ def test_validate_release_request_accepts_fixed_numeric_component_counts(tag: st
     prepare_release.validate_release_request(tag, False)
 
 
-@pytest.mark.parametrize("tag", ["v01.2", "v1.02.3", "v1.2.03", "v1.2.3.04"])
-def test_validate_release_request_rejects_leading_zero_components(tag: str) -> None:
-    """Reject stable tags with leading zeros at every supported length.
+@pytest.mark.parametrize(
+    ("tag", "prerelease"),
+    [
+        ("v01.2", False),
+        ("v01.2", True),
+        ("v1.02.3", False),
+        ("v1.02.3", True),
+        ("v1.2.03", False),
+        ("v1.2.03", True),
+        ("v1.2.3.04", False),
+        ("v1.2.3.04", True),
+        ("v01.2-beta.1", False),
+        ("v01.2-beta.1", True),
+    ],
+)
+def test_validate_release_request_rejects_leading_zero_components(
+    tag: str, prerelease: bool
+) -> None:
+    """Reject malformed numeric bases regardless of prerelease selection.
 
     Args:
-        tag (str): Stable tag containing a leading-zero component.
+        tag (str): Tag containing a leading-zero numeric component.
+        prerelease (bool): Requested release classification.
     """
-    with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
-        prepare_release.validate_release_request(tag, False)
+    with pytest.raises(ValueError, match="Invalid release tag"):
+        prepare_release.validate_release_request(tag, prerelease)
 
 
 @pytest.mark.parametrize("tag", ["v1", "v1.2.3.4.5"])

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -15,31 +15,39 @@ assert SCRIPT_SPEC.loader is not None
 prepare_release = importlib.util.module_from_spec(SCRIPT_SPEC)
 SCRIPT_SPEC.loader.exec_module(prepare_release)
 
+INITIAL_TAG = "v1.2.3"
+RELEASE_TAG = "v1.2.4"
+COMPONENT_PATH = "custom_components/example"
+
 
 @pytest.mark.parametrize(
     "tag",
-    ["v3.0.1", "v3.1.0-beta.1", "v2.9.4.1", "v3.0.0b1"],
+    [
+        "v1.2",
+        "v1.2.3",
+        "v1.2.3.4",
+        "v1.2.3-beta.1",
+        "v1.2.3b1",
+    ],
 )
 def test_validate_release_tag_accepts_supported_formats(tag: str) -> None:
-    """Accept version formats already used by the repository.
+    """Accept supported stable and prerelease tag formats.
 
     Args:
-        tag (str):
-            Supported release tag under test.
+        tag (str): Supported release tag under test.
     """
     prepare_release.validate_release_tag(tag)
 
 
 @pytest.mark.parametrize(
     "tag",
-    ["", "3.0.1", "v3", "v3.0.1 beta", "v3.0.1;echo-bad"],
+    ["", "1.2.3", "v1", "v1.2.3 beta", "v1.2.3;echo-bad"],
 )
 def test_validate_release_tag_rejects_unsupported_formats(tag: str) -> None:
-    """Reject malformed tags before they reach Git or GitHub commands.
+    """Reject malformed release tags before they reach release commands.
 
     Args:
-        tag (str):
-            Unsupported release tag under test.
+        tag (str): Unsupported release tag under test.
     """
     with pytest.raises(ValueError, match="Invalid release tag"):
         prepare_release.validate_release_tag(tag)
@@ -48,10 +56,11 @@ def test_validate_release_tag_rejects_unsupported_formats(tag: str) -> None:
 @pytest.mark.parametrize(
     ("tag", "prerelease"),
     [
-        ("v3.0.1", False),
-        ("v2.9.4.1", False),
-        ("v3.1.0-beta.1", True),
-        ("v3.0.0b1", True),
+        ("v1.2", False),
+        ("v1.2.3", False),
+        ("v1.2.3.4", False),
+        ("v1.2.3-beta.1", True),
+        ("v1.2.3b1", True),
     ],
 )
 def test_validate_release_request_accepts_matching_classification(
@@ -69,10 +78,10 @@ def test_validate_release_request_accepts_matching_classification(
 @pytest.mark.parametrize(
     ("tag", "prerelease", "message"),
     [
-        ("v3.1.0-beta.1", False, "Prerelease tag.*requires prerelease=true"),
-        ("v3.0.0b1", False, "Prerelease tag.*requires prerelease=true"),
-        ("v3.0.1", True, "Stable tag.*requires prerelease=false"),
-        ("v2.9.4.1", True, "Stable tag.*requires prerelease=false"),
+        ("v1.2.3-beta.1", False, "Prerelease tag.*requires prerelease=true"),
+        ("v1.2.3b1", False, "Prerelease tag.*requires prerelease=true"),
+        ("v1.2.3", True, "Stable tag.*requires prerelease=false"),
+        ("v1.2.3.4", True, "Stable tag.*requires prerelease=false"),
     ],
 )
 def test_validate_release_request_rejects_mismatched_classification(
@@ -90,31 +99,82 @@ def test_validate_release_request_rejects_mismatched_classification(
 
 
 @pytest.mark.parametrize(
-    ("bump_type", "expected_tag"),
+    ("tag", "stable_parts"),
+    [("v1.2", (2,)), ("v1.2.3", (3,)), ("v1.2.3.4", (4,))],
+)
+def test_validate_release_request_honors_configured_numeric_component_counts(
+    tag: str, stable_parts: tuple[int, ...]
+) -> None:
+    """Accept each configured stable numeric component count.
+
+    Args:
+        tag (str): Numeric release tag under test.
+        stable_parts (tuple[int, ...]): Configured stable component count.
+    """
+    prepare_release.validate_release_request(tag, False, stable_parts)
+
+
+@pytest.mark.parametrize(
+    ("tag", "stable_parts"),
     [
-        ("patch", "v3.12.10"),
-        ("minor", "v3.13.0"),
-        ("major", "v4.0.0"),
+        ("v01.2", (2,)),
+        ("v1.02.3", (3,)),
+        ("v1.2.03", (3,)),
+        ("v1.2.3.04", (4,)),
     ],
+)
+def test_validate_release_request_rejects_leading_zero_components(
+    tag: str, stable_parts: tuple[int, ...]
+) -> None:
+    """Reject stable tags with leading zeros at every supported length.
+
+    Args:
+        tag (str): Stable tag containing a leading-zero component.
+        stable_parts (tuple[int, ...]): Configured stable component count.
+    """
+    with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
+        prepare_release.validate_release_request(tag, False, stable_parts)
+
+
+@pytest.mark.parametrize(
+    ("tag", "stable_parts"),
+    [("v1.2.3", (2,)), ("v1.2", (3,)), ("v1.2.3.4", (3,))],
+)
+def test_validate_release_request_rejects_unconfigured_component_counts(
+    tag: str, stable_parts: tuple[int, ...]
+) -> None:
+    """Treat a valid but unconfigured numeric length as prerelease.
+
+    Args:
+        tag (str): Numeric release tag with an unsupported configured length.
+        stable_parts (tuple[int, ...]): Configured stable component counts.
+    """
+    with pytest.raises(ValueError, match=r"Prerelease tag.*requires prerelease=true"):
+        prepare_release.validate_release_request(tag, False, stable_parts)
+
+
+@pytest.mark.parametrize(
+    ("bump_type", "expected_tag"),
+    [("patch", "v1.0.6"), ("minor", "v1.1.0"), ("major", "v2.0.0")],
 )
 def test_next_stable_release_tag_uses_highest_stable_version(
     bump_type: str, expected_tag: str
 ) -> None:
-    """Ignore non-stable tags while incrementing the highest stable release.
+    """Ignore prereleases and malformed tags when incrementing the highest stable release.
 
     Args:
         bump_type (str): Requested version increment.
         expected_tag (str): Expected next stable release tag.
     """
     tags = [
-        "v3.12.9",
-        "v3.12.9-beta.1",
-        "v3.12.9.1",
-        "v3.12.10b1",
+        "v1.0.4",
+        "v1.0.5-beta.1",
+        "v1.0.5",
+        "v1.0.5b1",
         "invalid",
-        "v2.99.99",
-        "v3.12.10-rc.1",
-        "v3.12.9",
+        "v0.99.99",
+        "v1.0.5-rc.1",
+        "v1.0.5",
     ]
 
     assert prepare_release.next_stable_release_tag(tags, bump_type) == expected_tag
@@ -123,18 +183,18 @@ def test_next_stable_release_tag_uses_highest_stable_version(
 @pytest.mark.parametrize(
     ("tags", "bump_type", "expected_tag"),
     [
-        (["v3.2.9", "v3.3.0.1"], "patch", "v3.3.1"),
-        (["v3.2.9", "v3.3.0.1"], "minor", "v3.4.0"),
-        (["v3.9.9", "v4.0.0.1"], "major", "v5.0.0"),
+        (["v1.0.5", "v1.0.5.1"], "patch", "v1.0.6"),
+        (["v1.0.0", "v1.0.5.1"], "minor", "v1.1.0"),
+        (["v1.9.9", "v2.0.0.1"], "major", "v3.0.0"),
     ],
 )
-def test_next_stable_release_tag_considers_four_component_stable_versions(
+def test_next_stable_release_tag_considers_four_component_versions(
     tags: list[str], bump_type: str, expected_tag: str
 ) -> None:
     """Use four-component stable tags when selecting the next release.
 
     Args:
-        tags (list[str]): Candidate stable and prerelease tag names.
+        tags (list[str]): Candidate stable tag names.
         bump_type (str): Requested version increment.
         expected_tag (str): Expected next stable release tag.
     """
@@ -144,8 +204,8 @@ def test_next_stable_release_tag_considers_four_component_stable_versions(
 @pytest.mark.parametrize(
     ("tags", "bump_type", "message"),
     [
-        (["v3.0.0-beta.1", "v3.0.0b1"], "patch", "No stable released tag"),
-        (["v3.0.0"], "feature", "Unsupported bump type"),
+        (["v1.0.6-beta.1", "v1.0.6b1"], "patch", "No stable released tag"),
+        (["v1.0.6"], "feature", "Unsupported bump type"),
     ],
 )
 def test_next_stable_release_tag_rejects_invalid_requests(
@@ -171,15 +231,100 @@ def test_next_tag_cli_reads_tags_from_standard_input(
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI inputs.
         capsys (pytest.CaptureFixture[str]): Fixture for capturing CLI output.
     """
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), "--next-tag", "minor"])
+    monkeypatch.setattr(sys, "stdin", io.StringIO("v0.7.4\nv1.0.0-beta.1\nv0.8.1\n"))
+
+    assert prepare_release.main() == 0
+    assert capsys.readouterr().out == "v0.9.0\n"
+
+
+def test_next_tag_cli_honors_configured_stable_component_counts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Use the workflow stable-parts setting when selecting the next tag.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI inputs.
+        capsys (pytest.CaptureFixture[str]): Fixture for capturing CLI output.
+    """
     monkeypatch.setattr(
         sys,
         "argv",
-        [str(SCRIPT_PATH), "--next-tag", "minor"],
+        [str(SCRIPT_PATH), "--next-tag", "patch", "--stable-parts", "3"],
     )
-    monkeypatch.setattr(sys, "stdin", io.StringIO("v2.9.4\nv3.0.0-beta.1\nv2.10.1\n"))
+    monkeypatch.setattr(sys, "stdin", io.StringIO("v1.2.3\nv1.2.3.4\n"))
 
     assert prepare_release.main() == 0
-    assert capsys.readouterr().out == "v2.11.0\n"
+    assert capsys.readouterr().out == "v1.2.4\n"
+
+
+@pytest.mark.parametrize(
+    ("arguments", "expected_message"),
+    [
+        ((), "Provide exactly one release tag"),
+        ((INITIAL_TAG, "--next-tag", "patch"), "Provide exactly one release tag"),
+        (("--next-tag", "patch", "--check-only"), "Validation options"),
+        (
+            ("--next-tag", "patch", "--expected-prerelease", "false"),
+            "Validation options",
+        ),
+        (
+            (INITIAL_TAG, "--expected-prerelease", "false"),
+            "--expected-prerelease requires --check-only",
+        ),
+    ],
+)
+def test_main_rejects_invalid_option_combinations(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    arguments: tuple[str, ...],
+    expected_message: str,
+) -> None:
+    """Reject missing, conflicting, or incorrectly gated CLI options.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
+        capsys (pytest.CaptureFixture[str]): Fixture for capturing parser errors.
+        arguments (tuple[str, ...]): CLI arguments to reject.
+        expected_message (str): Expected parser error text.
+    """
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), *arguments])
+
+    with pytest.raises(SystemExit) as error:
+        prepare_release.main()
+
+    assert error.value.code == 2
+    assert expected_message in capsys.readouterr().err
+
+
+def test_main_rejects_invalid_stable_parts(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Reject stable-parts values outside the configured version range.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
+        capsys (pytest.CaptureFixture[str]): Fixture for capturing parser errors.
+    """
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT_PATH),
+            "--check-only",
+            "--expected-prerelease",
+            "false",
+            "--stable-parts",
+            "1,5",
+            INITIAL_TAG,
+        ],
+    )
+
+    with pytest.raises(SystemExit) as error:
+        prepare_release.main()
+
+    assert error.value.code == 2
+    assert "stable-parts must contain values from 2 through 4" in capsys.readouterr().err
 
 
 def test_check_only_cli_preserves_positional_tag_contract(
@@ -191,7 +336,7 @@ def test_check_only_cli_preserves_positional_tag_contract(
         monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
         capsys (pytest.CaptureFixture[str]): Fixture for capturing CLI output.
     """
-    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), "--check-only", "v3.0.1"])
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), "--check-only", INITIAL_TAG])
 
     assert prepare_release.main() == 0
     assert capsys.readouterr().out == ""
@@ -213,12 +358,84 @@ def test_check_only_cli_rejects_prerelease_input_mismatch(
             "--check-only",
             "--expected-prerelease",
             "false",
-            "v3.1.0-beta.1",
+            "v1.2.3-beta.1",
         ],
     )
 
     with pytest.raises(SystemExit, match="2"):
         prepare_release.main()
+
+
+def test_check_only_cli_accepts_configured_component_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accept a stable tag whose component count is explicitly configured.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments.
+    """
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT_PATH),
+            "--check-only",
+            "--expected-prerelease",
+            "false",
+            "--stable-parts",
+            "2",
+            "v1.2",
+        ],
+    )
+
+    assert prepare_release.main() == 0
+
+
+def _write_version_files(
+    repository: Path,
+    *,
+    manifest_content: str | None = None,
+    const_content: str | None = None,
+) -> tuple[Path, Path]:
+    """Create representative integration version files.
+
+    Args:
+        repository (Path): Temporary repository root.
+        manifest_content (str | None): Optional manifest.json content override.
+        const_content (str | None): Optional const.py content override.
+
+    Returns:
+        tuple[Path, Path]: Paths to manifest.json and const.py.
+    """
+    integration = repository / COMPONENT_PATH
+    integration.mkdir(parents=True)
+    manifest_path = integration / "manifest.json"
+    const_path = integration / "const.py"
+    manifest_path.write_text(
+        manifest_content or '{\n  "domain": "example",\n  "version" : "v1.2.3"\n}\n',
+        encoding="utf-8",
+    )
+    const_path.write_text(
+        const_content or 'VERSION = "v1.2.3"\nOTHER_VERSION = "v1.0.0"\n',
+        encoding="utf-8",
+    )
+    return manifest_path, const_path
+
+
+def test_update_release_versions_updates_only_release_declarations(tmp_path: Path) -> None:
+    """Update both release declarations without changing unrelated versions.
+
+    Args:
+        tmp_path (Path): Temporary repository root.
+    """
+    manifest_path, const_path = _write_version_files(tmp_path)
+
+    prepare_release.update_release_versions(tmp_path, RELEASE_TAG, COMPONENT_PATH)
+
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["version"] == RELEASE_TAG
+    assert const_path.read_text(encoding="utf-8") == (
+        f'VERSION = "{RELEASE_TAG}"\nOTHER_VERSION = "v1.0.0"\n'
+    )
 
 
 def test_default_cli_updates_versions_in_working_directory(
@@ -227,18 +444,18 @@ def test_default_cli_updates_versions_in_working_directory(
     """Update both version files through the workflow's default CLI path.
 
     Args:
-        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI inputs and
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments and
             the process working directory.
         tmp_path (Path): Temporary repository root.
     """
     manifest_path, const_path = _write_version_files(tmp_path)
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), "v3.0.1"])
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT_PATH), RELEASE_TAG])
 
     assert prepare_release.main() == 0
-    assert json.loads(manifest_path.read_text(encoding="utf-8"))["version"] == "v3.0.1"
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["version"] == RELEASE_TAG
     assert const_path.read_text(encoding="utf-8") == (
-        'VERSION = "v3.0.1"\nOTHER_VERSION = "v1.0.0"\n'
+        f'VERSION = "{RELEASE_TAG}"\nOTHER_VERSION = "v1.0.0"\n'
     )
 
 
@@ -250,7 +467,7 @@ def test_default_cli_rejects_expected_prerelease_without_check_only(
     """Reject the prerelease option when version preparation is requested.
 
     Args:
-        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI inputs and
+        monkeypatch (pytest.MonkeyPatch): Fixture for replacing CLI arguments and
             the process working directory.
         tmp_path (Path): Temporary repository root.
         capsys (pytest.CaptureFixture[str]): Fixture for capturing CLI errors.
@@ -262,7 +479,7 @@ def test_default_cli_rejects_expected_prerelease_without_check_only(
     monkeypatch.setattr(
         sys,
         "argv",
-        [str(SCRIPT_PATH), "--expected-prerelease", "false", "v3.0.1"],
+        [str(SCRIPT_PATH), "--expected-prerelease", "false", RELEASE_TAG],
     )
 
     with pytest.raises(SystemExit, match="2"):
@@ -273,63 +490,31 @@ def test_default_cli_rejects_expected_prerelease_without_check_only(
     assert const_path.read_text(encoding="utf-8") == original_const
 
 
-def _write_version_files(repository: Path, const_content: str | None = None) -> tuple[Path, Path]:
-    """Create representative integration version files.
-
-    Args:
-        repository (Path):
-            Temporary repository root.
-        const_content (str | None):
-            Optional const.py content override.
-
-    Returns:
-        tuple[Path, Path]: Paths to manifest.json and const.py.
-    """
-    integration = repository / "custom_components" / "places"
-    integration.mkdir(parents=True)
-    manifest_path = integration / "manifest.json"
-    const_path = integration / "const.py"
-    manifest_path.write_text(
-        '{\n  "domain": "places",\n  "version" : "v2.9.4"\n}\n',
-        encoding="utf-8",
-    )
-    const_path.write_text(
-        const_content or 'VERSION = "v2.9.4"\nOTHER_VERSION = "v1.0.0"\n',
-        encoding="utf-8",
-    )
-    return manifest_path, const_path
-
-
-def test_update_release_versions_updates_only_release_declarations(tmp_path: Path) -> None:
-    """Update both release declarations without changing unrelated versions.
-
-    Args:
-        tmp_path (Path):
-            Temporary repository root.
-    """
-    manifest_path, const_path = _write_version_files(tmp_path)
-
-    prepare_release.update_release_versions(tmp_path, "v3.0.1")
-
-    assert json.loads(manifest_path.read_text(encoding="utf-8"))["version"] == "v3.0.1"
-    assert const_path.read_text(encoding="utf-8") == (
-        'VERSION = "v3.0.1"\nOTHER_VERSION = "v1.0.0"\n'
-    )
-
-
-def test_update_release_versions_does_not_partially_write(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "failure",
+    [
+        pytest.param({"const_content": 'DOMAIN = "example"\n'}, id="const-missing"),
+        pytest.param(
+            {"manifest_content": '{\n  "domain": "example"\n}\n'},
+            id="manifest-missing",
+        ),
+    ],
+)
+def test_update_release_versions_does_not_partially_write(
+    tmp_path: Path, failure: dict[str, str]
+) -> None:
     """Leave both files unchanged when either declaration is missing.
 
     Args:
-        tmp_path (Path):
-            Temporary repository root.
+        tmp_path (Path): Temporary repository root.
+        failure (dict[str, str]): Version-file content that should fail validation.
     """
-    manifest_path, const_path = _write_version_files(tmp_path, 'DOMAIN = "places"\n')
+    manifest_path, const_path = _write_version_files(tmp_path, **failure)
     original_manifest = manifest_path.read_text(encoding="utf-8")
     original_const = const_path.read_text(encoding="utf-8")
 
     with pytest.raises(ValueError, match="Expected one version declaration"):
-        prepare_release.update_release_versions(tmp_path, "v3.0.1")
+        prepare_release.update_release_versions(tmp_path, RELEASE_TAG, COMPONENT_PATH)
 
     assert manifest_path.read_text(encoding="utf-8") == original_manifest
     assert const_path.read_text(encoding="utf-8") == original_const

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,515 @@
+"""Tests for published-release workflow contracts."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+from typing import Any
+
+import pytest
+import yaml
+
+PROCESS_RUN = subprocess.run
+WORKFLOW_ROOT = Path(__file__).parents[1] / ".github" / "workflows"
+SCRIPT_PATH = Path(__file__).parents[1] / ".github" / "scripts" / "verify_release_checks.py"
+LINT_WORKFLOW = (
+    "prek-autofix-review.yml"
+    if (WORKFLOW_ROOT / "prek-autofix-review.yml").exists()
+    else "linters.yml"
+)
+
+
+def _load_workflow(name: str) -> dict[str, Any]:
+    """Load one workflow with normalized trigger keys for semantic checks.
+
+    Args:
+        name (str): Workflow filename.
+
+    Returns:
+        dict[str, Any]: Parsed workflow document.
+    """
+    document = yaml.safe_load((WORKFLOW_ROOT / name).read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    if True in document:
+        document["on"] = document.pop(True)
+    return document
+
+
+def _workflow_events(document: dict[str, Any]) -> dict[str, Any]:
+    """Return the parsed workflow trigger map.
+
+    Args:
+        document (dict[str, Any]): Parsed workflow document.
+
+    Returns:
+        dict[str, Any]: Workflow event configuration.
+    """
+    events = document["on"]
+    assert isinstance(events, dict)
+    return events
+
+
+def _named_steps(document: dict[str, Any], job_id: str) -> dict[str, dict[str, Any]]:
+    """Index named steps for stable semantic assertions.
+
+    Args:
+        document (dict[str, Any]): Parsed workflow document.
+        job_id (str): Workflow job identifier.
+
+    Returns:
+        dict[str, dict[str, Any]]: Named steps in the selected job.
+    """
+    job = document["jobs"][job_id]
+    assert isinstance(job, dict)
+    steps = job["steps"]
+    assert isinstance(steps, list)
+    return {step["name"]: step for step in steps if isinstance(step, dict) and "name" in step}
+
+
+def _release_environment() -> dict[str, str]:
+    """Read release fixture settings from the repository workflow.
+
+    Returns:
+        dict[str, str]: Environment values required by the extracted shell fixtures.
+    """
+    document = _load_workflow("release.yml")
+    environment = document["jobs"]["release"]["env"]
+    assert isinstance(environment, dict)
+    return {
+        "ARCHIVE_NAME": str(environment["ARCHIVE_NAME"]),
+        "COMPONENT_PATH": str(environment["COMPONENT_PATH"]),
+        "FIRMWARE_NOTES": str(environment["FIRMWARE_NOTES"]),
+        "STABLE_TAG_PARTS": str(environment["STABLE_TAG_PARTS"]),
+    }
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    """Run one Git command in a temporary release-fixture repository.
+
+    Args:
+        repository (Path): Fixture repository.
+        *arguments (str): Arguments following the Git executable.
+
+    Returns:
+        str: Standard output from the successful command.
+    """
+    return PROCESS_RUN(
+        ["git", *arguments],
+        check=True,
+        cwd=repository,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+def _release_fixture(tmp_path: Path, tag: str) -> tuple[Path, str, str]:
+    """Create a pushed tag whose release-subject commit also changes a third path.
+
+    Args:
+        tmp_path (Path): Pytest temporary directory.
+        tag (str): Release tag used by the fixture.
+
+    Returns:
+        tuple[Path, str, str]: Repository, tagged source SHA, and annotated tag OID.
+    """
+    remote = tmp_path / "remote.git"
+    repository = tmp_path / "repository"
+    PROCESS_RUN(
+        ["git", "init", "--bare", str(remote)],
+        check=True,
+        capture_output=True,
+    )
+    _git(tmp_path, "init", "-b", "main", str(repository))
+    _git(repository, "config", "user.name", "Release Test")
+    _git(repository, "config", "user.email", "release-test@example.invalid")
+    release_environment = _release_environment()
+    component_path = release_environment["COMPONENT_PATH"]
+    integration = repository / component_path
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text('{"version": "v0.0.0"}\n', encoding="utf-8")
+    const = 'VERSION = "v0.0.0"\n'
+    if release_environment["FIRMWARE_NOTES"] == "true":
+        const += 'OPNSENSE_LTD_FIRMWARE = "26.1"\nOPNSENSE_MIN_FIRMWARE = "25.1"\n'
+    (integration / "const.py").write_text(const, encoding="utf-8")
+    helper = repository / ".github" / "scripts"
+    helper.mkdir(parents=True)
+    shutil.copy2(SCRIPT_PATH.parent / "prepare_release.py", helper / "prepare_release.py")
+    shutil.copy2(SCRIPT_PATH.parent / "verify_hacs_archive.py", helper / "verify_hacs_archive.py")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "Initial component")
+    _git(repository, "remote", "add", "origin", str(remote))
+    _git(repository, "push", "-u", "origin", "main")
+    (integration / "manifest.json").write_text(f'{{"version": "{tag}"}}\n', encoding="utf-8")
+    const = f'VERSION = "{tag}"\n'
+    if release_environment["FIRMWARE_NOTES"] == "true":
+        const += 'OPNSENSE_LTD_FIRMWARE = "26.1"\nOPNSENSE_MIN_FIRMWARE = "25.1"\n'
+    (integration / "const.py").write_text(const, encoding="utf-8")
+    (repository / "release-notes.txt").write_text("third changed path\n", encoding="utf-8")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", f"Release {tag}")
+    source_sha = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "tag", "-a", tag, "-m", tag)
+    tag_oid = _git(repository, "rev-parse", f"refs/tags/{tag}")
+    _git(repository, "push", "origin", "main", tag)
+    return repository, source_sha, tag_oid
+
+
+def _run_workflow_shell(
+    repository: Path, run: str, environment: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run an extracted workflow shell block in a release fixture.
+
+    Args:
+        repository (Path): Fixture repository.
+        run (str): Workflow step shell content.
+        environment (dict[str, str]): Step-specific environment values.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed workflow shell process.
+    """
+    release_environment = _release_environment()
+    workflow_environment = {
+        **release_environment,
+    }
+    return PROCESS_RUN(
+        ["bash", "-c", run],
+        cwd=repository,
+        env={**os.environ, **workflow_environment, **environment},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _stub_gh(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a deterministic GitHub CLI stub that records release mutations.
+
+    Args:
+        tmp_path (Path): Pytest temporary directory.
+
+    Returns:
+        tuple[Path, Path]: Stub binary directory and its command log path.
+    """
+    binary_dir = tmp_path / "bin"
+    binary_dir.mkdir()
+    log_path = tmp_path / "gh.log"
+    gh = binary_dir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf "%s\\n" "$*" >> "$GH_LOG"\n'
+        'if [[ "$1 $2" == "release view" ]]; then\n'
+        '  printf "%s" "${GH_RELEASE_BODY:-}"\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return binary_dir, log_path
+
+
+def test_prerelease_release_subject_with_extra_path_reaches_archive_upload(tmp_path: Path) -> None:
+    """Keep archive-only prereleases outside stable resume provenance validation.
+
+    Args:
+        tmp_path (Path): Temporary fixture directory.
+    """
+    tag = "v1.2.3-beta.1"
+    repository, source_sha, tag_oid = _release_fixture(tmp_path, tag)
+    steps = _named_steps(_load_workflow("release.yml"), "release")
+    output = tmp_path / "base-output"
+    base = _run_workflow_shell(
+        repository,
+        steps["Validate trusted release metadata and immutable starting refs"]["run"],
+        {
+            "GITHUB_OUTPUT": str(output),
+            "IS_PRERELEASE": "true",
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+        },
+    )
+
+    assert base.returncode == 0, base.stderr
+    assert "resume=false" in output.read_text(encoding="utf-8")
+    binary_dir, log_path = _stub_gh(tmp_path)
+    archive = tmp_path / _release_environment()["ARCHIVE_NAME"]
+    prerelease = _run_workflow_shell(
+        repository,
+        steps["Build prerelease archive without mutating refs"]["run"],
+        {
+            "GH_LOG": str(log_path),
+            "GH_TOKEN": "test-token",
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "RELEASE_ARCHIVE": str(archive),
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+            "SOURCE_SHA": source_sha,
+            "TAG_OID": tag_oid,
+        },
+    )
+
+    assert prerelease.returncode == 0, prerelease.stderr
+    assert archive.is_file()
+    upload = _run_workflow_shell(
+        repository,
+        steps["Verify prerelease identity and upload archive"]["run"],
+        {
+            "GH_LOG": str(log_path),
+            "GH_TOKEN": "test-token",
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "RELEASE_ARCHIVE": str(archive),
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+            "SOURCE_SHA": source_sha,
+            "TAG_OID": tag_oid,
+        },
+    )
+    assert upload.returncode == 0, upload.stderr
+    assert "release upload" in log_path.read_text(encoding="utf-8")
+
+
+def test_stable_release_subject_with_extra_path_rejects_invalid_resume(tmp_path: Path) -> None:
+    """Reject stable retry candidates whose version transform changed a third path.
+
+    Args:
+        tmp_path (Path): Temporary fixture directory.
+    """
+    tag = "v1.2.3"
+    repository, _source_sha, _tag_oid = _release_fixture(tmp_path, tag)
+    output = tmp_path / "base-output"
+    base = _run_workflow_shell(
+        repository,
+        _named_steps(_load_workflow("release.yml"), "release")[
+            "Validate trusted release metadata and immutable starting refs"
+        ]["run"],
+        {
+            "GITHUB_OUTPUT": str(output),
+            "IS_PRERELEASE": "false",
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+        },
+    )
+
+    assert base.returncode != 0
+    assert "invalid release contents" in base.stderr
+
+
+def test_release_workflow_has_published_trigger_and_stable_prerelease_split() -> None:
+    """Keep release promotion event-driven with distinct stable and prerelease paths."""
+    document = _load_workflow("release.yml")
+    events = _workflow_events(document)
+    assert events == {"release": {"types": ["published"]}}
+
+    steps = _named_steps(document, "release")
+    assert steps["Build prerelease archive without mutating refs"]["if"] == (
+        "github.event.release.prerelease"
+    )
+    assert steps["Create deterministic stable release commit B"]["if"] == (
+        "github.event.release.prerelease == false"
+    )
+    assert steps["Atomically advance target and guarded release tag"]["if"] == (
+        "github.event.release.prerelease == false && steps.base.outputs.resume != 'true'"
+    )
+
+    dispatch_run = steps["Dispatch and verify immutable release gates"]["run"]
+    assert "--workflow" not in dispatch_run
+    assert '"${required_check_args[@]}"' in dispatch_run
+    assert document["jobs"]["release"]["env"]["REQUIRED_CHECKS"].splitlines() == [
+        "pytest_check.yml::pytest check and post coverage",
+        "uv-lock-check.yml::Validate uv lock consistency",
+        "validate.yml::Hassfest Validation",
+        "validate.yml::HACS Validation",
+        f"{LINT_WORKFLOW}::review",
+    ]
+
+
+def test_release_workflow_uses_guarded_atomic_promotion_and_resumable_cleanup() -> None:
+    """Require guarded branch/tag promotion, explicit resume state, and cleanup on success."""
+    document = _load_workflow("release.yml")
+    steps = _named_steps(document, "release")
+    promotion = steps["Atomically advance target and guarded release tag"]
+    promotion_run = promotion["run"]
+    assert "push --atomic" in promotion_run
+    assert "refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" in promotion_run
+    assert "refs/heads/$RELEASE_TARGET:$SOURCE_SHA" in promotion_run
+    assert '[[ "$(git rev-parse HEAD^)" == "$SOURCE_SHA" ]]' in promotion_run
+    assert 'git push origin "refs/tags/$RELEASE_TAG"' not in promotion_run
+    assert '[[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]' in (
+        promotion_run
+    )
+
+    candidate_run = steps["Create deterministic stable release commit B"]["run"]
+    assert 'if [[ "$RESUME" == true ]]' in candidate_run
+    assert 'echo "sha=$RESUME_SHA"' in candidate_run
+    cleanup = steps["Delete validated temporary branch"]
+    assert cleanup["if"] == "github.event.release.prerelease == false && success()"
+    assert 'push --force-with-lease="refs/heads/$TEMP_REF:$CANDIDATE_SHA"' in cleanup["run"]
+
+
+def test_release_workflow_trusts_only_default_branch_and_scopes_tokens() -> None:
+    """Require default-target validation, credential-free checkout, and step-scoped tokens."""
+    document = _load_workflow("release.yml")
+    job = document["jobs"]["release"]
+    assert job["permissions"] == {
+        "actions": "write",
+        "checks": "read",
+        "contents": "write",
+        "statuses": "read",
+    }
+    steps = _named_steps(document, "release")
+    target = steps["Require the default-branch release target"]
+    assert '"$RELEASE_TARGET" == "$DEFAULT_BRANCH"' in target["run"]
+    assert target["env"] == {
+        "DEFAULT_BRANCH": "${{ github.event.repository.default_branch }}",
+        "RELEASE_TARGET": "${{ github.event.release.target_commitish }}",
+    }
+    checkout = steps["Checkout trusted default-branch workflow revision"]
+    assert checkout["with"]["ref"] == "${{ github.event.repository.default_branch }}"
+    assert checkout["with"]["persist-credentials"] is False
+
+    token_steps = {
+        name: step
+        for name, step in steps.items()
+        if name
+        in {
+            "Publish B to an isolated validation branch",
+            "Dispatch and verify immutable release gates",
+            "Atomically advance target and guarded release tag",
+            "Verify release identity and upload verified archive",
+            "Verify prerelease identity and upload archive",
+            "Delete validated temporary branch",
+        }
+    }
+    for step in token_steps.values():
+        assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+
+
+def test_release_workflow_uses_scoped_github_cli_credentials_for_git_pushes() -> None:
+    """Authenticate release pushes without persisting checkout credentials."""
+    document = _load_workflow("release.yml")
+    steps = _named_steps(document, "release")
+    push_step_names = (
+        "Publish B to an isolated validation branch",
+        "Atomically advance target and guarded release tag",
+        "Delete validated temporary branch",
+    )
+
+    for step_name in push_step_names:
+        step = steps[step_name]
+        assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+        assert "extraheader" not in step["run"].lower()
+        assert "gh auth setup-git --hostname github.com" in step["run"]
+
+
+@pytest.mark.parametrize(
+    "workflow_name",
+    ["pytest_check.yml", "uv-lock-check.yml", "validate.yml", LINT_WORKFLOW],
+)
+def test_release_dispatch_guards_require_lowercase_sha_and_match_workflow_sha(
+    workflow_name: str,
+) -> None:
+    """Validate the exact lowercase 40-hex guard used for release dispatches.
+
+    Args:
+        workflow_name (str): Workflow filename under test.
+    """
+    document = _load_workflow(workflow_name)
+    required_names = {
+        value.partition("::")[2]
+        for value in _load_workflow("release.yml")["jobs"]["release"]["env"][
+            "REQUIRED_CHECKS"
+        ].splitlines()
+        if value.partition("::")[0] == workflow_name
+    }
+    candidate_jobs = [
+        (job_id, job)
+        for job_id, job in document["jobs"].items()
+        if isinstance(job, dict) and job.get("name", job_id) in required_names
+    ]
+    assert {job.get("name", job_id) for job_id, job in candidate_jobs} == required_names
+    for _job_id, job in candidate_jobs:
+        steps = job["steps"]
+        guard = next(
+            step
+            for step in steps
+            if isinstance(step, dict) and step.get("name") == "Require expected release commit"
+        )
+        assert guard["run"] == (
+            '[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]\ntest "$WORKFLOW_SHA" = "$EXPECTED_SHA"\n'
+        )
+        assert guard["env"]["EXPECTED_SHA"] == "${{ inputs.expected_sha }}"
+        assert guard["env"]["WORKFLOW_SHA"] == "${{ github.sha }}"
+
+
+def test_dispatch_pytest_job_is_read_only_and_preserves_required_check_name() -> None:
+    """Run release-dispatched pytest with read-only contents and the required job name."""
+    document = _load_workflow("pytest_check.yml")
+    pytest_job = next(
+        job
+        for job in document["jobs"].values()
+        if isinstance(job, dict) and job.get("name") == "pytest check and post coverage"
+    )
+    assert pytest_job["permissions"]["contents"] == "read"
+    assert pytest_job["name"] == "pytest check and post coverage"
+    assert (
+        _workflow_events(document)["workflow_dispatch"]["inputs"]["expected_sha"]["required"]
+        is True
+    )
+    pytest_run = next(
+        step
+        for step in pytest_job["steps"]
+        if "uv run --locked --group pytest pytest" in step.get("run", "")
+    )
+    assert "uv run --locked --group pytest pytest" in pytest_run["run"]
+    checkout = next(
+        step
+        for step in pytest_job["steps"]
+        if (
+            isinstance(step, dict)
+            and str(step.get("uses", "")).startswith("actions/checkout@v")
+            and "inputs.expected_sha" in step.get("with", {}).get("ref", "")
+        )
+    )
+    assert checkout["with"]["persist-credentials"] is False
+
+
+@pytest.mark.parametrize(
+    "workflow_name",
+    ["validate.yml", "pytest_check.yml", LINT_WORKFLOW],
+)
+def test_release_gate_workflows_retain_normal_triggers_and_expected_sha_dispatch(
+    workflow_name: str,
+) -> None:
+    """Keep PR/push validation while allowing release dispatches to pin one SHA.
+
+    Args:
+        workflow_name (str): Workflow filename under test.
+    """
+    document = _load_workflow(workflow_name)
+    events = _workflow_events(document)
+    assert "pull_request" in events
+    dispatch = events["workflow_dispatch"]
+    assert dispatch["inputs"]["expected_sha"]["required"] is True
+
+    jobs = document["jobs"]
+    assert isinstance(jobs, dict)
+    guarded_jobs = []
+    for job in jobs.values():
+        assert isinstance(job, dict)
+        steps = job["steps"]
+        has_guard = any(
+            isinstance(step, dict)
+            and '[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]' in step.get("run", "")
+            for step in steps
+        )
+        if has_guard:
+            guarded_jobs.append(job)
+    assert guarded_jobs
+    for job in guarded_jobs:
+        checkout = next(
+            step
+            for step in job["steps"]
+            if isinstance(step, dict)
+            and str(step.get("uses", "")).startswith("actions/checkout@v")
+            and "inputs.expected_sha || github.sha" in step.get("with", {}).get("ref", "")
+        )
+        assert checkout["with"]["persist-credentials"] is False

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -79,7 +79,6 @@ def _release_environment() -> dict[str, str]:
         "ARCHIVE_NAME": str(environment["ARCHIVE_NAME"]),
         "COMPONENT_PATH": str(environment["COMPONENT_PATH"]),
         "FIRMWARE_NOTES": str(environment["FIRMWARE_NOTES"]),
-        "STABLE_TAG_PARTS": str(environment["STABLE_TAG_PARTS"]),
     }
 
 

--- a/tests/test_verify_hacs_archive.py
+++ b/tests/test_verify_hacs_archive.py
@@ -1,0 +1,303 @@
+"""Tests for HACS release archive validation."""
+
+from collections.abc import Sequence
+import importlib.util
+import json
+from pathlib import Path
+import stat
+import struct
+import zipfile
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).parents[1] / ".github" / "scripts" / "verify_hacs_archive.py"
+SCRIPT_SPEC = importlib.util.spec_from_file_location("verify_hacs_archive", SCRIPT_PATH)
+assert SCRIPT_SPEC is not None
+assert SCRIPT_SPEC.loader is not None
+archive_verifier = importlib.util.module_from_spec(SCRIPT_SPEC)
+SCRIPT_SPEC.loader.exec_module(archive_verifier)
+
+RELEASE_TAG = "v1.2.3"
+
+
+def _archive(
+    path: Path,
+    extra: Sequence[tuple[str | zipfile.ZipInfo, bytes | str]] | None = None,
+    *,
+    manifest: bytes | str | None = None,
+    const: bytes | str | None = None,
+    compression: int = zipfile.ZIP_STORED,
+) -> None:
+    """Build a small archive with valid version files and optional members.
+
+    Args:
+        path (Path): Destination ZIP path.
+        extra (Sequence[tuple[str | zipfile.ZipInfo, bytes | str]] | None): Optional members.
+        manifest (bytes | str | None): Optional manifest.json contents.
+        const (bytes | str | None): Optional const.py contents.
+        compression (int): ZIP compression method for string-named members.
+    """
+    members: list[tuple[str | zipfile.ZipInfo, bytes | str]] = [
+        (
+            "manifest.json",
+            manifest if manifest is not None else json.dumps({"version": RELEASE_TAG}).encode(),
+        ),
+        ("const.py", const if const is not None else f'VERSION = "{RELEASE_TAG}"\n'),
+    ]
+    members.extend(extra or [])
+    with zipfile.ZipFile(path, "w", compression=compression) as output:
+        for name, contents in members:
+            output.writestr(name, contents)
+
+
+def _set_compressed_size(path: Path, member_name: str, compressed_size: int) -> None:
+    """Corrupt one central-directory size field for a malformed archive fixture.
+
+    Args:
+        path (Path): ZIP archive to modify.
+        member_name (str): Member whose central-directory record is changed.
+        compressed_size (int): Replacement compressed-size field.
+
+    Raises:
+        AssertionError: If the requested member is not present in the archive.
+    """
+    data = bytearray(path.read_bytes())
+    offset = 0
+    while (offset := data.find(b"PK\x01\x02", offset)) >= 0:
+        name_length = struct.unpack_from("<H", data, offset + 28)[0]
+        name_start = offset + 46
+        name = bytes(data[name_start : name_start + name_length]).decode()
+        if name == member_name:
+            struct.pack_into("<I", data, offset + 20, compressed_size)
+            path.write_bytes(data)
+            return
+        offset += 1
+    raise AssertionError(f"Archive member not found: {member_name}")
+
+
+def test_verify_archive_accepts_a_real_zip_artifact(tmp_path: Path) -> None:
+    """Accept a normal integration archive produced for the release tag.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "integration.zip"
+    _archive(archive)
+
+    archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+    assert archive_verifier.main([str(archive), RELEASE_TAG]) == 0
+
+
+def test_verify_archive_allows_safe_directory_entries(tmp_path: Path) -> None:
+    """Allow directories emitted by git archive while validating their contents.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "directory.zip"
+    _archive(archive, [("client/", b""), ("client/module.py", b"VALUE = 1\n")])
+
+    archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+@pytest.mark.parametrize(
+    "member", ["", "/absolute.py", "../manifest.json", "nested/../../const.py"]
+)
+def test_verify_archive_rejects_unsafe_member_paths(tmp_path: Path, member: str) -> None:
+    """Reject empty, absolute, and traversal member paths.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        member (str): Unsafe archive member path.
+    """
+    archive = tmp_path / "unsafe.zip"
+    _archive(archive, [(member, b"unsafe")])
+
+    with pytest.raises(archive_verifier.ArchiveError, match="Invalid archive member path"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_duplicate_members(tmp_path: Path) -> None:
+    """Reject duplicate member names before an archive is uploaded.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "duplicate.zip"
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        _archive(archive, [("const.py", f'VERSION = "{RELEASE_TAG}"\n')])
+
+    with pytest.raises(archive_verifier.ArchiveError, match="Duplicate archive member"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+@pytest.mark.parametrize("file_type", [stat.S_IFLNK, stat.S_IFIFO])
+def test_verify_archive_rejects_non_regular_members(tmp_path: Path, file_type: int) -> None:
+    """Reject symlink and other non-regular POSIX members.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        file_type (int): POSIX type encoded in the ZIP member metadata.
+    """
+    archive = tmp_path / "non-regular.zip"
+    info = zipfile.ZipInfo("linked.py")
+    info.external_attr = (file_type | 0o644) << 16
+    _archive(archive, [(info, b"const.py")])
+
+    with pytest.raises(archive_verifier.ArchiveError, match="not a regular file"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_empty_and_oversized_file_lists(tmp_path: Path) -> None:
+    """Reject empty archives and archives above the member-count bound.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    empty = tmp_path / "empty.zip"
+    with zipfile.ZipFile(empty, "w"):
+        pass
+    with pytest.raises(archive_verifier.ArchiveError, match="invalid number of files"):
+        archive_verifier.verify_archive(str(empty), RELEASE_TAG)
+
+    oversized = tmp_path / "many-files.zip"
+    extras = [(f"payload-{index}.txt", b"") for index in range(archive_verifier.MAX_FILES)]
+    _archive(oversized, extras)
+    with pytest.raises(archive_verifier.ArchiveError, match="invalid number of files"):
+        archive_verifier.verify_archive(str(oversized), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_oversized_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject a member above the configured per-file size bound.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        monkeypatch (pytest.MonkeyPatch): Fixture reducing the test-only bound.
+    """
+    archive = tmp_path / "oversized-member.zip"
+    _archive(archive, [("payload.bin", b"x" * 9)])
+    with monkeypatch.context() as context:
+        context.setattr(archive_verifier, "MAX_FILE_BYTES", 8)
+        with pytest.raises(archive_verifier.ArchiveError, match="size limit"):
+            archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+    assert archive_verifier.MAX_FILE_BYTES == 10 * 1024 * 1024
+
+
+def test_verify_archive_rejects_expansion_beyond_cap_with_isolated_fixture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject 72 expanded bytes against a test-only 64-byte cap.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        monkeypatch (pytest.MonkeyPatch): Fixture isolating the reduced cap.
+    """
+    archive = tmp_path / "expanded.zip"
+    _archive(archive, [("payload.bin", b"x" * 72)])
+    with monkeypatch.context() as context:
+        context.setattr(archive_verifier, "MAX_EXPANDED_BYTES", 64)
+        with pytest.raises(archive_verifier.ArchiveError, match="expanded size"):
+            archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+    assert archive_verifier.MAX_EXPANDED_BYTES == 64 * 1024 * 1024
+
+
+def test_verify_archive_rejects_unsafe_compression_ratio(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Reject highly compressible members above the configured ratio.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        monkeypatch (pytest.MonkeyPatch): Fixture reducing the test-only ratio.
+    """
+    archive = tmp_path / "compressed.zip"
+    _archive(archive, [("payload.bin", b"x" * 1_024)], compression=zipfile.ZIP_DEFLATED)
+    with monkeypatch.context() as context:
+        context.setattr(archive_verifier, "MAX_COMPRESSION_RATIO", 2)
+        with pytest.raises(archive_verifier.ArchiveError, match="compression ratio"):
+            archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+    assert archive_verifier.MAX_COMPRESSION_RATIO == 100
+
+
+def test_verify_archive_rejects_nonzero_file_with_zero_compressed_size(tmp_path: Path) -> None:
+    """Reject a malformed member claiming no compressed bytes for payload data.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "zero-compression.zip"
+    _archive(archive, [("payload.bin", b"payload")])
+    _set_compressed_size(archive, "payload.bin", 0)
+
+    with pytest.raises(archive_verifier.ArchiveError, match="invalid compression"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+@pytest.mark.parametrize("missing", ["manifest.json", "const.py"])
+def test_verify_archive_rejects_missing_version_files(tmp_path: Path, missing: str) -> None:
+    """Reject archives missing either required version file.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        missing (str): Required member omitted from the archive.
+    """
+    archive = tmp_path / f"missing-{missing.replace('.', '-')}.zip"
+    members = {
+        "manifest.json": json.dumps({"version": RELEASE_TAG}),
+        "const.py": f'VERSION = "{RELEASE_TAG}"\n',
+    }
+    with zipfile.ZipFile(archive, "w") as output:
+        for name, contents in members.items():
+            if name != missing:
+                output.writestr(name, contents)
+
+    with pytest.raises(archive_verifier.ArchiveError, match="required version files"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_manifest_and_const_version_mismatches(tmp_path: Path) -> None:
+    """Reject manifest and const.py versions that differ from the release tag.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    manifest_mismatch = tmp_path / "manifest-mismatch.zip"
+    _archive(manifest_mismatch)
+    with pytest.raises(archive_verifier.ArchiveError, match="manifest version"):
+        archive_verifier.verify_archive(str(manifest_mismatch), "v1.2.4")
+
+    const_mismatch = tmp_path / "const-mismatch.zip"
+    _archive(const_mismatch, const='VERSION = "v1.2.4"\n')
+    with pytest.raises(archive_verifier.ArchiveError, match=r"const\.py version"):
+        archive_verifier.verify_archive(str(const_mismatch), RELEASE_TAG)
+
+
+def test_verify_archive_rejects_invalid_const_encoding(tmp_path: Path) -> None:
+    """Wrap invalid const.py encoding as an archive validation failure.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+    """
+    archive = tmp_path / "invalid-encoding.zip"
+    _archive(archive, const=b"\xff")
+
+    with pytest.raises(archive_verifier.ArchiveError, match="Unable to validate"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)
+
+
+@pytest.mark.parametrize("archive_name", ["missing.zip", "broken.zip"])
+def test_verify_archive_rejects_unreadable_archives(tmp_path: Path, archive_name: str) -> None:
+    """Wrap missing and malformed ZIP files as archive validation failures.
+
+    Args:
+        tmp_path (Path): Temporary test directory.
+        archive_name (str): Missing or malformed archive filename.
+    """
+    archive = tmp_path / archive_name
+    if archive_name == "broken.zip":
+        archive.write_bytes(b"not a zip archive")
+
+    with pytest.raises(archive_verifier.ArchiveError, match="Unable to validate"):
+        archive_verifier.verify_archive(str(archive), RELEASE_TAG)

--- a/tests/test_verify_release_checks.py
+++ b/tests/test_verify_release_checks.py
@@ -624,7 +624,7 @@ def test_release_workflow_uses_guarded_atomic_promotion_and_resumable_cleanup() 
     assert 'echo "sha=$RESUME_SHA"' in candidate_run
     cleanup = steps["Delete validated temporary branch"]
     assert cleanup["if"] == "github.event.release.prerelease == false && success()"
-    assert 'push origin --delete "$TEMP_REF"' in cleanup["run"]
+    assert 'push --force-with-lease="refs/heads/$TEMP_REF:$CANDIDATE_SHA"' in cleanup["run"]
 
 
 def test_release_workflow_trusts_only_default_branch_and_scopes_tokens() -> None:

--- a/tests/test_verify_release_checks.py
+++ b/tests/test_verify_release_checks.py
@@ -3,6 +3,7 @@
 from collections.abc import Sequence
 import importlib.util
 import json
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -573,6 +574,213 @@ def _named_steps(document: dict[str, Any], job_id: str) -> dict[str, dict[str, A
     return {step["name"]: step for step in steps if isinstance(step, dict) and "name" in step}
 
 
+def _git(repository: Path, *arguments: str) -> str:
+    """Run one Git command in a temporary release-fixture repository.
+
+    Args:
+        repository (Path): Fixture repository.
+        *arguments (str): Arguments following the Git executable.
+
+    Returns:
+        str: Standard output from the successful command.
+    """
+    return subprocess.run(  # noqa: S603 -- test arguments are fixed by fixture helpers.
+        ["git", *arguments],  # noqa: S607 -- Git is the fixed test executable.
+        check=True,
+        cwd=repository,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+
+
+def _release_fixture(tmp_path: Path, tag: str) -> tuple[Path, str, str]:
+    """Create a pushed tag whose release-subject commit also changes a third path.
+
+    Args:
+        tmp_path (Path): Pytest temporary directory.
+        tag (str): Release tag used by the fixture.
+
+    Returns:
+        tuple[Path, str, str]: Repository, tagged source SHA, and annotated tag OID.
+    """
+    remote = tmp_path / "remote.git"
+    repository = tmp_path / "repository"
+    subprocess.run(  # noqa: S603 -- test-only fixture repository initialization.
+        ["git", "init", "--bare", str(remote)],  # noqa: S607 -- test fixture executable.
+        check=True,
+        capture_output=True,
+    )
+    _git(tmp_path, "init", "-b", "main", str(repository))
+    _git(repository, "config", "user.name", "Release Test")
+    _git(repository, "config", "user.email", "release-test@example.invalid")
+    integration = repository / "custom_components" / "places"
+    integration.mkdir(parents=True)
+    (integration / "manifest.json").write_text('{"version": "v0.0.0"}\n', encoding="utf-8")
+    (integration / "const.py").write_text('VERSION = "v0.0.0"\n', encoding="utf-8")
+    helper = repository / ".github" / "scripts"
+    helper.mkdir(parents=True)
+    shutil.copy2(SCRIPT_PATH.parent / "prepare_release.py", helper / "prepare_release.py")
+    shutil.copy2(SCRIPT_PATH.parent / "verify_hacs_archive.py", helper / "verify_hacs_archive.py")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", "Initial component")
+    _git(repository, "remote", "add", "origin", str(remote))
+    _git(repository, "push", "-u", "origin", "main")
+    (integration / "manifest.json").write_text(f'{{"version": "{tag}"}}\n', encoding="utf-8")
+    (integration / "const.py").write_text(f'VERSION = "{tag}"\n', encoding="utf-8")
+    (repository / "release-notes.txt").write_text("third changed path\n", encoding="utf-8")
+    _git(repository, "add", ".")
+    _git(repository, "commit", "-m", f"Release {tag}")
+    source_sha = _git(repository, "rev-parse", "HEAD")
+    _git(repository, "tag", "-a", tag, "-m", tag)
+    tag_oid = _git(repository, "rev-parse", f"refs/tags/{tag}")
+    _git(repository, "push", "origin", "main", tag)
+    return repository, source_sha, tag_oid
+
+
+def _run_workflow_shell(
+    repository: Path, run: str, environment: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    """Run an extracted workflow shell block in a release fixture.
+
+    Args:
+        repository (Path): Fixture repository.
+        run (str): Workflow step shell content.
+        environment (dict[str, str]): Step-specific environment values.
+
+    Returns:
+        subprocess.CompletedProcess[str]: The completed workflow shell process.
+    """
+    component = next(
+        path.name for path in (repository / "custom_components").iterdir() if path.is_dir()
+    )
+    workflow_environment = {
+        "ARCHIVE_NAME": f"{component}.zip",
+        "COMPONENT_PATH": f"custom_components/{component}",
+        "FIRMWARE_NOTES": "false",
+        "STABLE_TAG_PARTS": "2,3,4",
+    }
+    return subprocess.run(  # noqa: S603 -- extracted trusted workflow shell is under test.
+        ["bash", "-c", run],  # noqa: S607 -- test shell for extracted workflow source.
+        cwd=repository,
+        env={**os.environ, **workflow_environment, **environment},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def _stub_gh(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a deterministic GitHub CLI stub that records release mutations.
+
+    Args:
+        tmp_path (Path): Pytest temporary directory.
+
+    Returns:
+        tuple[Path, Path]: Stub binary directory and its command log path.
+    """
+    binary_dir = tmp_path / "bin"
+    binary_dir.mkdir()
+    log_path = tmp_path / "gh.log"
+    gh = binary_dir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        'printf "%s\\n" "$*" >> "$GH_LOG"\n'
+        'if [[ "$1 $2" == "release view" ]]; then\n'
+        '  printf "%s" "${GH_RELEASE_BODY:-}"\n'
+        "fi\n",
+        encoding="utf-8",
+    )
+    gh.chmod(0o755)
+    return binary_dir, log_path
+
+
+def test_prerelease_release_subject_with_extra_path_reaches_archive_upload(tmp_path: Path) -> None:
+    """Keep archive-only prereleases outside stable resume provenance validation.
+
+    Args:
+        tmp_path (Path): Temporary fixture directory.
+    """
+    tag = "v1.2.3-beta.1"
+    repository, source_sha, tag_oid = _release_fixture(tmp_path, tag)
+    steps = _named_steps(_load_workflow("release.yml"), "release")
+    output = tmp_path / "base-output"
+    base = _run_workflow_shell(
+        repository,
+        steps["Validate trusted release metadata and immutable starting refs"]["run"],
+        {
+            "GITHUB_OUTPUT": str(output),
+            "IS_PRERELEASE": "true",
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+        },
+    )
+
+    assert base.returncode == 0, base.stderr
+    assert "resume=false" in output.read_text(encoding="utf-8")
+    binary_dir, log_path = _stub_gh(tmp_path)
+    archive = tmp_path / "places.zip"
+    prerelease = _run_workflow_shell(
+        repository,
+        steps["Build prerelease archive without mutating refs"]["run"],
+        {
+            "GH_LOG": str(log_path),
+            "GH_TOKEN": "test-token",
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "RELEASE_ARCHIVE": str(archive),
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+            "SOURCE_SHA": source_sha,
+            "TAG_OID": tag_oid,
+        },
+    )
+
+    assert prerelease.returncode == 0, prerelease.stderr
+    assert archive.is_file()
+    upload = _run_workflow_shell(
+        repository,
+        steps["Verify prerelease identity and upload archive"]["run"],
+        {
+            "GH_LOG": str(log_path),
+            "GH_TOKEN": "test-token",
+            "PATH": f"{binary_dir}:{os.environ['PATH']}",
+            "RELEASE_ARCHIVE": str(archive),
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+            "SOURCE_SHA": source_sha,
+            "TAG_OID": tag_oid,
+        },
+    )
+    assert upload.returncode == 0, upload.stderr
+    assert "release upload" in log_path.read_text(encoding="utf-8")
+
+
+def test_stable_release_subject_with_extra_path_rejects_invalid_resume(tmp_path: Path) -> None:
+    """Reject stable retry candidates whose version transform changed a third path.
+
+    Args:
+        tmp_path (Path): Temporary fixture directory.
+    """
+    tag = "v1.2.3"
+    repository, _source_sha, _tag_oid = _release_fixture(tmp_path, tag)
+    output = tmp_path / "base-output"
+    base = _run_workflow_shell(
+        repository,
+        _named_steps(_load_workflow("release.yml"), "release")[
+            "Validate trusted release metadata and immutable starting refs"
+        ]["run"],
+        {
+            "GITHUB_OUTPUT": str(output),
+            "IS_PRERELEASE": "false",
+            "RELEASE_TAG": tag,
+            "RELEASE_TARGET": "main",
+        },
+    )
+
+    assert base.returncode != 0
+    assert "invalid release contents" in base.stderr
+
+
 def test_release_workflow_has_published_trigger_and_stable_prerelease_split() -> None:
     """Keep release promotion event-driven with distinct stable and prerelease paths."""
     document = _load_workflow("release.yml")
@@ -592,16 +800,13 @@ def test_release_workflow_has_published_trigger_and_stable_prerelease_split() ->
 
     dispatch_run = steps["Dispatch and verify immutable release gates"]["run"]
     assert "--workflow" not in dispatch_run
-    assert {
-        line.strip().removeprefix("--required-check '").removesuffix("' \\").removesuffix("'")
-        for line in dispatch_run.splitlines()
-        if line.strip().startswith("--required-check '")
-    } == {
-        "validate.yml::HACS Validation",
-        "validate.yml::Hassfest Validation",
+    assert '"${required_check_args[@]}"' in dispatch_run
+    assert document["jobs"]["release"]["env"]["REQUIRED_CHECKS"].splitlines() == [
         "pytest_check.yml::pytest check and post coverage",
+        "validate.yml::Hassfest Validation",
+        "validate.yml::HACS Validation",
         "prek-autofix-review.yml::review",
-    }
+    ]
 
 
 def test_release_workflow_uses_guarded_atomic_promotion_and_resumable_cleanup() -> None:
@@ -612,10 +817,10 @@ def test_release_workflow_uses_guarded_atomic_promotion_and_resumable_cleanup() 
     promotion_run = promotion["run"]
     assert "push --atomic" in promotion_run
     assert "refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" in promotion_run
-    assert "refs/heads/$RELEASE_TARGET:$TARGET_SHA" in promotion_run
-    assert '[[ "$(git rev-parse HEAD^)" == "$TARGET_SHA" ]]' in promotion_run
+    assert "refs/heads/$RELEASE_TARGET:$SOURCE_SHA" in promotion_run
+    assert '[[ "$(git rev-parse HEAD^)" == "$SOURCE_SHA" ]]' in promotion_run
     assert 'git push origin "refs/tags/$RELEASE_TAG"' not in promotion_run
-    assert '[[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$TARGET_SHA" ]]' in (
+    assert '[[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]' in (
         promotion_run
     )
 
@@ -639,7 +844,7 @@ def test_release_workflow_trusts_only_default_branch_and_scopes_tokens() -> None
     }
     steps = _named_steps(document, "release")
     target = steps["Require the default-branch release target"]
-    assert '"$RELEASE_TARGET" != "$DEFAULT_BRANCH"' in target["run"]
+    assert '"$RELEASE_TARGET" == "$DEFAULT_BRANCH"' in target["run"]
     assert target["env"] == {
         "DEFAULT_BRANCH": "${{ github.event.repository.default_branch }}",
         "RELEASE_TARGET": "${{ github.event.release.target_commitish }}",
@@ -653,11 +858,11 @@ def test_release_workflow_trusts_only_default_branch_and_scopes_tokens() -> None
         for name, step in steps.items()
         if name
         in {
-            "Build prerelease archive without mutating refs",
             "Publish B to an isolated validation branch",
             "Dispatch and verify immutable release gates",
             "Atomically advance target and guarded release tag",
-            "Verify release identity and upload B archive",
+            "Verify release identity and upload verified archive",
+            "Verify prerelease identity and upload archive",
             "Delete validated temporary branch",
         }
     }

--- a/tests/test_verify_release_checks.py
+++ b/tests/test_verify_release_checks.py
@@ -3,7 +3,6 @@
 from collections.abc import Sequence
 import importlib.util
 import json
-import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -24,6 +23,27 @@ WORKFLOW_ROOT = Path(__file__).parents[1] / ".github" / "workflows"
 REPOSITORY = "owner/repository"
 REF = "release-validation/v3.0.1-123-1"
 SHA = "a" * 40
+LINT_WORKFLOW = (
+    "prek-autofix-review.yml"
+    if (WORKFLOW_ROOT / "prek-autofix-review.yml").exists()
+    else "linters.yml"
+)
+
+
+def _required_check_values() -> list[str]:
+    """Read the release gate manifest from the caller workflow.
+
+    Returns:
+        list[str]: Ordered workflow and job gate declarations.
+    """
+    document = yaml.safe_load((WORKFLOW_ROOT / "release.yml").read_text(encoding="utf-8"))
+    assert isinstance(document, dict)
+    if True in document:
+        document["on"] = document.pop(True)
+    environment = document["jobs"]["release"]["env"]
+    assert isinstance(environment, dict)
+    values = str(environment["REQUIRED_CHECKS"]).splitlines()
+    return [value for value in values if value]
 
 
 def test_dispatch_workflow_sends_ref_and_expected_sha(
@@ -386,25 +406,22 @@ def test_verify_jobs_reports_mutually_exclusive_fail_closed_categories(
 
 def test_parse_required_checks_groups_exact_names_and_rejects_malformed_values() -> None:
     """Group checks by workflow while retaining exact job-name boundaries."""
-    checks = verify.parse_required_checks(
-        [
-            "pytest_check.yml::pytest check and post coverage",
-            "validate.yml::HACS Validation",
-            "validate.yml::Hassfest Validation",
-            "prek-autofix-review.yml::review",
-            "pytest_check.yml::pytest check and post coverage",
-        ]
-    )
-
-    assert list(checks) == [
-        "pytest_check.yml",
-        "validate.yml",
-        "prek-autofix-review.yml",
+    values = [
+        "pytest_check.yml::pytest check and post coverage",
+        "uv-lock-check.yml::Validate uv lock consistency",
+        "validate.yml::Hassfest Validation",
+        "validate.yml::HACS Validation",
+        f"{LINT_WORKFLOW}::review",
     ]
+    checks = verify.parse_required_checks([*values, values[0]])
+
+    expected_workflows = ["pytest_check.yml", "uv-lock-check.yml", "validate.yml", LINT_WORKFLOW]
+    assert list(checks) == expected_workflows
     assert checks == {
         "pytest_check.yml": {"pytest check and post coverage"},
+        "uv-lock-check.yml": {"Validate uv lock consistency"},
         "validate.yml": {"HACS Validation", "Hassfest Validation"},
-        "prek-autofix-review.yml": {"review"},
+        LINT_WORKFLOW: {"review"},
     }
 
     with pytest.raises(ValueError, match="workflow::exact job name"):
@@ -441,31 +458,38 @@ def test_main_dispatches_workflows_in_required_check_first_seen_order(
     monkeypatch.setattr(verify, "dispatch_workflow", fake_dispatch)
     monkeypatch.setattr(verify, "wait_for_workflow", fake_wait)
     monkeypatch.setattr(verify.time, "monotonic", lambda: 100.0)
+    values = _required_check_values()
+    assert set(values) == {
+        "pytest_check.yml::pytest check and post coverage",
+        "uv-lock-check.yml::Validate uv lock consistency",
+        "validate.yml::Hassfest Validation",
+        "validate.yml::HACS Validation",
+        f"{LINT_WORKFLOW}::review",
+    }
+    arguments: list[str] = [
+        "verify_release_checks.py",
+        "--repository",
+        REPOSITORY,
+        "--ref",
+        REF,
+        "--sha",
+        SHA,
+    ]
+    for value in values:
+        arguments.extend(["--required-check", value])
     monkeypatch.setattr(
         verify.sys,
         "argv",
-        [
-            "verify_release_checks.py",
-            "--repository",
-            REPOSITORY,
-            "--ref",
-            REF,
-            "--sha",
-            SHA,
-            "--required-check",
-            "pytest_check.yml::pytest check and post coverage",
-            "--required-check",
-            "validate.yml::HACS Validation",
-            "--required-check",
-            "validate.yml::Hassfest Validation",
-        ],
+        arguments,
     )
 
     assert verify.main() == 0
-    assert dispatches == ["pytest_check.yml", "validate.yml"]
+    assert dispatches == ["pytest_check.yml", "uv-lock-check.yml", "validate.yml", LINT_WORKFLOW]
     assert waits == [
         ("pytest_check.yml", {"pytest check and post coverage"}, 1),
-        ("validate.yml", {"HACS Validation", "Hassfest Validation"}, 2),
+        ("uv-lock-check.yml", {"Validate uv lock consistency"}, 2),
+        ("validate.yml", {"HACS Validation", "Hassfest Validation"}, 3),
+        (LINT_WORKFLOW, {"review"}, 4),
     ]
 
 
@@ -525,473 +549,3 @@ def test_github_api_uses_a_bounded_request_timeout(monkeypatch: pytest.MonkeyPat
     assert verify.github_api(["repos/example/repo"]) == {}
     assert len(calls) == 1
     assert calls[0]["timeout"] == 30
-
-
-def _load_workflow(name: str) -> dict[str, Any]:
-    """Load one workflow with normalized trigger keys for semantic checks.
-
-    Args:
-        name (str): Workflow filename.
-
-    Returns:
-        dict[str, Any]: Parsed workflow document.
-    """
-    document = yaml.safe_load((WORKFLOW_ROOT / name).read_text(encoding="utf-8"))
-    assert isinstance(document, dict)
-    if True in document:
-        document["on"] = document.pop(True)
-    return document
-
-
-def _workflow_events(document: dict[str, Any]) -> dict[str, Any]:
-    """Return the parsed workflow trigger map.
-
-    Args:
-        document (dict[str, Any]): Parsed workflow document.
-
-    Returns:
-        dict[str, Any]: Workflow event configuration.
-    """
-    events = document["on"]
-    assert isinstance(events, dict)
-    return events
-
-
-def _named_steps(document: dict[str, Any], job_id: str) -> dict[str, dict[str, Any]]:
-    """Index named steps for stable semantic assertions.
-
-    Args:
-        document (dict[str, Any]): Parsed workflow document.
-        job_id (str): Workflow job identifier.
-
-    Returns:
-        dict[str, dict[str, Any]]: Named steps in the selected job.
-    """
-    job = document["jobs"][job_id]
-    assert isinstance(job, dict)
-    steps = job["steps"]
-    assert isinstance(steps, list)
-    return {step["name"]: step for step in steps if isinstance(step, dict) and "name" in step}
-
-
-def _git(repository: Path, *arguments: str) -> str:
-    """Run one Git command in a temporary release-fixture repository.
-
-    Args:
-        repository (Path): Fixture repository.
-        *arguments (str): Arguments following the Git executable.
-
-    Returns:
-        str: Standard output from the successful command.
-    """
-    return subprocess.run(  # noqa: S603 -- test arguments are fixed by fixture helpers.
-        ["git", *arguments],  # noqa: S607 -- Git is the fixed test executable.
-        check=True,
-        cwd=repository,
-        text=True,
-        capture_output=True,
-    ).stdout.strip()
-
-
-def _release_fixture(tmp_path: Path, tag: str) -> tuple[Path, str, str]:
-    """Create a pushed tag whose release-subject commit also changes a third path.
-
-    Args:
-        tmp_path (Path): Pytest temporary directory.
-        tag (str): Release tag used by the fixture.
-
-    Returns:
-        tuple[Path, str, str]: Repository, tagged source SHA, and annotated tag OID.
-    """
-    remote = tmp_path / "remote.git"
-    repository = tmp_path / "repository"
-    subprocess.run(  # noqa: S603 -- test-only fixture repository initialization.
-        ["git", "init", "--bare", str(remote)],  # noqa: S607 -- test fixture executable.
-        check=True,
-        capture_output=True,
-    )
-    _git(tmp_path, "init", "-b", "main", str(repository))
-    _git(repository, "config", "user.name", "Release Test")
-    _git(repository, "config", "user.email", "release-test@example.invalid")
-    integration = repository / "custom_components" / "places"
-    integration.mkdir(parents=True)
-    (integration / "manifest.json").write_text('{"version": "v0.0.0"}\n', encoding="utf-8")
-    (integration / "const.py").write_text('VERSION = "v0.0.0"\n', encoding="utf-8")
-    helper = repository / ".github" / "scripts"
-    helper.mkdir(parents=True)
-    shutil.copy2(SCRIPT_PATH.parent / "prepare_release.py", helper / "prepare_release.py")
-    shutil.copy2(SCRIPT_PATH.parent / "verify_hacs_archive.py", helper / "verify_hacs_archive.py")
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", "Initial component")
-    _git(repository, "remote", "add", "origin", str(remote))
-    _git(repository, "push", "-u", "origin", "main")
-    (integration / "manifest.json").write_text(f'{{"version": "{tag}"}}\n', encoding="utf-8")
-    (integration / "const.py").write_text(f'VERSION = "{tag}"\n', encoding="utf-8")
-    (repository / "release-notes.txt").write_text("third changed path\n", encoding="utf-8")
-    _git(repository, "add", ".")
-    _git(repository, "commit", "-m", f"Release {tag}")
-    source_sha = _git(repository, "rev-parse", "HEAD")
-    _git(repository, "tag", "-a", tag, "-m", tag)
-    tag_oid = _git(repository, "rev-parse", f"refs/tags/{tag}")
-    _git(repository, "push", "origin", "main", tag)
-    return repository, source_sha, tag_oid
-
-
-def _run_workflow_shell(
-    repository: Path, run: str, environment: dict[str, str]
-) -> subprocess.CompletedProcess[str]:
-    """Run an extracted workflow shell block in a release fixture.
-
-    Args:
-        repository (Path): Fixture repository.
-        run (str): Workflow step shell content.
-        environment (dict[str, str]): Step-specific environment values.
-
-    Returns:
-        subprocess.CompletedProcess[str]: The completed workflow shell process.
-    """
-    component = next(
-        path.name for path in (repository / "custom_components").iterdir() if path.is_dir()
-    )
-    workflow_environment = {
-        "ARCHIVE_NAME": f"{component}.zip",
-        "COMPONENT_PATH": f"custom_components/{component}",
-        "FIRMWARE_NOTES": "false",
-        "STABLE_TAG_PARTS": "2,3,4",
-    }
-    return subprocess.run(  # noqa: S603 -- extracted trusted workflow shell is under test.
-        ["bash", "-c", run],  # noqa: S607 -- test shell for extracted workflow source.
-        cwd=repository,
-        env={**os.environ, **workflow_environment, **environment},
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-
-
-def _stub_gh(tmp_path: Path) -> tuple[Path, Path]:
-    """Create a deterministic GitHub CLI stub that records release mutations.
-
-    Args:
-        tmp_path (Path): Pytest temporary directory.
-
-    Returns:
-        tuple[Path, Path]: Stub binary directory and its command log path.
-    """
-    binary_dir = tmp_path / "bin"
-    binary_dir.mkdir()
-    log_path = tmp_path / "gh.log"
-    gh = binary_dir / "gh"
-    gh.write_text(
-        "#!/usr/bin/env bash\n"
-        "set -euo pipefail\n"
-        'printf "%s\\n" "$*" >> "$GH_LOG"\n'
-        'if [[ "$1 $2" == "release view" ]]; then\n'
-        '  printf "%s" "${GH_RELEASE_BODY:-}"\n'
-        "fi\n",
-        encoding="utf-8",
-    )
-    gh.chmod(0o755)
-    return binary_dir, log_path
-
-
-def test_prerelease_release_subject_with_extra_path_reaches_archive_upload(tmp_path: Path) -> None:
-    """Keep archive-only prereleases outside stable resume provenance validation.
-
-    Args:
-        tmp_path (Path): Temporary fixture directory.
-    """
-    tag = "v1.2.3-beta.1"
-    repository, source_sha, tag_oid = _release_fixture(tmp_path, tag)
-    steps = _named_steps(_load_workflow("release.yml"), "release")
-    output = tmp_path / "base-output"
-    base = _run_workflow_shell(
-        repository,
-        steps["Validate trusted release metadata and immutable starting refs"]["run"],
-        {
-            "GITHUB_OUTPUT": str(output),
-            "IS_PRERELEASE": "true",
-            "RELEASE_TAG": tag,
-            "RELEASE_TARGET": "main",
-        },
-    )
-
-    assert base.returncode == 0, base.stderr
-    assert "resume=false" in output.read_text(encoding="utf-8")
-    binary_dir, log_path = _stub_gh(tmp_path)
-    archive = tmp_path / "places.zip"
-    prerelease = _run_workflow_shell(
-        repository,
-        steps["Build prerelease archive without mutating refs"]["run"],
-        {
-            "GH_LOG": str(log_path),
-            "GH_TOKEN": "test-token",
-            "PATH": f"{binary_dir}:{os.environ['PATH']}",
-            "RELEASE_ARCHIVE": str(archive),
-            "RELEASE_TAG": tag,
-            "RELEASE_TARGET": "main",
-            "SOURCE_SHA": source_sha,
-            "TAG_OID": tag_oid,
-        },
-    )
-
-    assert prerelease.returncode == 0, prerelease.stderr
-    assert archive.is_file()
-    upload = _run_workflow_shell(
-        repository,
-        steps["Verify prerelease identity and upload archive"]["run"],
-        {
-            "GH_LOG": str(log_path),
-            "GH_TOKEN": "test-token",
-            "PATH": f"{binary_dir}:{os.environ['PATH']}",
-            "RELEASE_ARCHIVE": str(archive),
-            "RELEASE_TAG": tag,
-            "RELEASE_TARGET": "main",
-            "SOURCE_SHA": source_sha,
-            "TAG_OID": tag_oid,
-        },
-    )
-    assert upload.returncode == 0, upload.stderr
-    assert "release upload" in log_path.read_text(encoding="utf-8")
-
-
-def test_stable_release_subject_with_extra_path_rejects_invalid_resume(tmp_path: Path) -> None:
-    """Reject stable retry candidates whose version transform changed a third path.
-
-    Args:
-        tmp_path (Path): Temporary fixture directory.
-    """
-    tag = "v1.2.3"
-    repository, _source_sha, _tag_oid = _release_fixture(tmp_path, tag)
-    output = tmp_path / "base-output"
-    base = _run_workflow_shell(
-        repository,
-        _named_steps(_load_workflow("release.yml"), "release")[
-            "Validate trusted release metadata and immutable starting refs"
-        ]["run"],
-        {
-            "GITHUB_OUTPUT": str(output),
-            "IS_PRERELEASE": "false",
-            "RELEASE_TAG": tag,
-            "RELEASE_TARGET": "main",
-        },
-    )
-
-    assert base.returncode != 0
-    assert "invalid release contents" in base.stderr
-
-
-def test_release_workflow_has_published_trigger_and_stable_prerelease_split() -> None:
-    """Keep release promotion event-driven with distinct stable and prerelease paths."""
-    document = _load_workflow("release.yml")
-    events = _workflow_events(document)
-    assert events == {"release": {"types": ["published"]}}
-
-    steps = _named_steps(document, "release")
-    assert steps["Build prerelease archive without mutating refs"]["if"] == (
-        "github.event.release.prerelease"
-    )
-    assert steps["Create deterministic stable release commit B"]["if"] == (
-        "github.event.release.prerelease == false"
-    )
-    assert steps["Atomically advance target and guarded release tag"]["if"] == (
-        "github.event.release.prerelease == false && steps.base.outputs.resume != 'true'"
-    )
-
-    dispatch_run = steps["Dispatch and verify immutable release gates"]["run"]
-    assert "--workflow" not in dispatch_run
-    assert '"${required_check_args[@]}"' in dispatch_run
-    assert document["jobs"]["release"]["env"]["REQUIRED_CHECKS"].splitlines() == [
-        "pytest_check.yml::pytest check and post coverage",
-        "validate.yml::Hassfest Validation",
-        "validate.yml::HACS Validation",
-        "prek-autofix-review.yml::review",
-    ]
-
-
-def test_release_workflow_uses_guarded_atomic_promotion_and_resumable_cleanup() -> None:
-    """Require guarded branch/tag promotion, explicit resume state, and cleanup on success."""
-    document = _load_workflow("release.yml")
-    steps = _named_steps(document, "release")
-    promotion = steps["Atomically advance target and guarded release tag"]
-    promotion_run = promotion["run"]
-    assert "push --atomic" in promotion_run
-    assert "refs/tags/$RELEASE_TAG:$ORIGINAL_TAG_OID" in promotion_run
-    assert "refs/heads/$RELEASE_TARGET:$SOURCE_SHA" in promotion_run
-    assert '[[ "$(git rev-parse HEAD^)" == "$SOURCE_SHA" ]]' in promotion_run
-    assert 'git push origin "refs/tags/$RELEASE_TAG"' not in promotion_run
-    assert '[[ "$(git rev-parse "refs/remotes/origin/$RELEASE_TARGET")" == "$SOURCE_SHA" ]]' in (
-        promotion_run
-    )
-
-    candidate_run = steps["Create deterministic stable release commit B"]["run"]
-    assert 'if [[ "$RESUME" == true ]]' in candidate_run
-    assert 'echo "sha=$RESUME_SHA"' in candidate_run
-    cleanup = steps["Delete validated temporary branch"]
-    assert cleanup["if"] == "github.event.release.prerelease == false && success()"
-    assert 'push --force-with-lease="refs/heads/$TEMP_REF:$CANDIDATE_SHA"' in cleanup["run"]
-
-
-def test_release_workflow_trusts_only_default_branch_and_scopes_tokens() -> None:
-    """Require default-target validation, credential-free checkout, and step-scoped tokens."""
-    document = _load_workflow("release.yml")
-    job = document["jobs"]["release"]
-    assert job["permissions"] == {
-        "actions": "write",
-        "checks": "read",
-        "contents": "write",
-        "statuses": "read",
-    }
-    steps = _named_steps(document, "release")
-    target = steps["Require the default-branch release target"]
-    assert '"$RELEASE_TARGET" == "$DEFAULT_BRANCH"' in target["run"]
-    assert target["env"] == {
-        "DEFAULT_BRANCH": "${{ github.event.repository.default_branch }}",
-        "RELEASE_TARGET": "${{ github.event.release.target_commitish }}",
-    }
-    checkout = steps["Checkout trusted default-branch workflow revision"]
-    assert checkout["with"]["ref"] == "${{ github.event.repository.default_branch }}"
-    assert checkout["with"]["persist-credentials"] is False
-
-    token_steps = {
-        name: step
-        for name, step in steps.items()
-        if name
-        in {
-            "Publish B to an isolated validation branch",
-            "Dispatch and verify immutable release gates",
-            "Atomically advance target and guarded release tag",
-            "Verify release identity and upload verified archive",
-            "Verify prerelease identity and upload archive",
-            "Delete validated temporary branch",
-        }
-    }
-    for step in token_steps.values():
-        assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
-
-
-def test_release_workflow_uses_scoped_github_cli_credentials_for_git_pushes() -> None:
-    """Authenticate release pushes without persisting checkout credentials."""
-    document = _load_workflow("release.yml")
-    steps = _named_steps(document, "release")
-    push_step_names = (
-        "Publish B to an isolated validation branch",
-        "Atomically advance target and guarded release tag",
-        "Delete validated temporary branch",
-    )
-
-    for step_name in push_step_names:
-        step = steps[step_name]
-        assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
-        assert "extraheader" not in step["run"].lower()
-        assert "gh auth setup-git --hostname github.com" in step["run"]
-
-
-@pytest.mark.parametrize(
-    ("workflow_name", "guarded_jobs"),
-    [
-        ("validate.yml", ["ha_validation", "hacs_validation"]),
-        ("pytest_check.yml", ["tests"]),
-        ("prek-autofix-review.yml", ["review"]),
-    ],
-)
-def test_release_dispatch_guards_require_lowercase_sha_and_match_workflow_sha(
-    workflow_name: str, guarded_jobs: list[str]
-) -> None:
-    """Validate the exact lowercase 40-hex guard used for release dispatches.
-
-    Args:
-        workflow_name (str): Workflow filename under test.
-        guarded_jobs (list[str]): Jobs that run release-dispatch guards.
-    """
-    document = _load_workflow(workflow_name)
-    for job_id in guarded_jobs:
-        steps = _named_steps(document, job_id)
-        guard = steps["Require expected release commit"]
-        assert guard["run"] == (
-            '[[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]\ntest "$WORKFLOW_SHA" = "$EXPECTED_SHA"\n'
-        )
-        assert guard["env"] == {
-            "EXPECTED_SHA": "${{ inputs.expected_sha }}",
-            "WORKFLOW_SHA": "${{ github.sha }}",
-        }
-
-
-def test_dispatch_pytest_job_is_read_only_and_preserves_required_check_name() -> None:
-    """Run release-dispatched pytest with read-only contents and the required job name."""
-    document = _load_workflow("pytest_check.yml")
-    pytest_job = next(
-        job
-        for job in document["jobs"].values()
-        if job.get("name") == "pytest check and post coverage"
-    )
-    assert pytest_job["name"] == "pytest check and post coverage"
-    assert "workflow_dispatch" not in pytest_job["if"]
-    assert pytest_job["permissions"] == {"contents": "read", "pull-requests": "read"}
-    coverage = next(
-        step
-        for step in pytest_job["steps"]
-        if isinstance(step, dict)
-        and str(step.get("uses", "")).startswith("py-cov-action/python-coverage-comment-action@v")
-    )
-    assert coverage["with"]["ACTIVITY"] == "process_pr"
-    checkout = next(
-        step
-        for step in pytest_job["steps"]
-        if (
-            isinstance(step, dict)
-            and str(step.get("uses", "")).startswith("actions/checkout@v")
-            and step.get("with", {}).get("ref") == "${{ inputs.expected_sha || github.sha }}"
-        )
-    )
-    assert checkout["with"] == {
-        "ref": "${{ inputs.expected_sha || github.sha }}",
-        "persist-credentials": False,
-    }
-
-
-@pytest.mark.parametrize(
-    ("workflow_name", "has_push_trigger"),
-    [("validate.yml", True), ("pytest_check.yml", True), ("prek-autofix-review.yml", False)],
-)
-def test_release_gate_workflows_retain_normal_triggers_and_expected_sha_dispatch(
-    workflow_name: str, has_push_trigger: bool
-) -> None:
-    """Keep PR/push validation while allowing release dispatches to pin one SHA.
-
-    Args:
-        workflow_name (str): Workflow filename under test.
-        has_push_trigger (bool): Whether the workflow historically runs on main pushes.
-    """
-    document = _load_workflow(workflow_name)
-    events = _workflow_events(document)
-    assert "pull_request" in events
-    if has_push_trigger:
-        assert events["push"]["branches"] == ["main"]
-    else:
-        assert "push" not in events
-    dispatch = events["workflow_dispatch"]
-    assert dispatch["inputs"]["expected_sha"]["required"] is True
-
-    jobs = document["jobs"]
-    assert isinstance(jobs, dict)
-    guarded_jobs = []
-    for job in jobs.values():
-        assert isinstance(job, dict)
-        steps = job["steps"]
-        has_guard = any(
-            isinstance(step, dict) and step.get("name") == "Require expected release commit"
-            for step in steps
-        )
-        if has_guard:
-            guarded_jobs.append(job)
-    assert guarded_jobs
-    for job in guarded_jobs:
-        checkout = next(
-            step
-            for step in job["steps"]
-            if isinstance(step, dict)
-            and str(step.get("uses", "")).startswith("actions/checkout@v")
-            and "inputs.expected_sha || github.sha" in step.get("with", {}).get("ref", "")
-        )
-        assert checkout["with"]["persist-credentials"] is False


### PR DESCRIPTION
## Summary

Reworks the published-release path so a deterministic Places candidate is validated by immutable, exact-SHA gates before stable branch and tag promotion. The branch shares release preparation, archive validation, and gate verification helpers with focused workflow contracts.

## What Changed

- Reuse the existing release workflow and validation entry points instead of adding a duplicate validation workflow, with shared release-preparation, HACS-archive, and release-check helpers and tests.
- Require stable published releases to create a version-only candidate, validate a deterministic archive, dispatch HACS, Hassfest, pytest, and review gates for the exact candidate SHA, and promote branch and annotated tag under leases before upload.
- Keep prereleases archive-only while checking that the selected tag and target branch still resolve to the source identity used for the upload.
- Validate numeric version tags with two to four components and an optional prerelease suffix, and extend contracts for retry, archive, gate, and partial-failure behavior.
- Preserve Places-specific archive and review-gate configuration while tightening expected-SHA validation for release dispatches.

## Why

A release spans GitHub release metadata, branches, tags, temporary validation refs, and uploaded archives. Verifying the same immutable candidate across those boundaries makes races and partial failures fail closed while preserving the existing published-release workflow.