### PR TITLE
ci: Update Actionlint hook with bundled ShellCheck

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -21,12 +21,11 @@ id = "check-added-large-files"
 exclude = "^uv\\.lock$"
 
 [[repos]]
-repo = "https://github.com/rhysd/actionlint"
-rev = "v1.7.12"
+repo = "https://github.com/kjanat/actionlint"
+rev = "v1.15.1"
 
 [[repos.hooks]]
-id = "actionlint"
-additional_dependencies = ["github.com/wasilibs/go-shellcheck/cmd/shellcheck@v0.11.1"]
+id = "actionlint-shellcheck"
 
 [[repos]]
 repo = "https://github.com/codespell-project/codespell"


### PR DESCRIPTION
## Summary

Updates the prek Actionlint integration to use the maintained fork with bundled ShellCheck support. This avoids the previous external ShellCheck dependency while preserving workflow lint coverage.

## What Changed

- Replaced `rhysd/actionlint` v1.7.12 with `kjanat/actionlint` v1.15.1
- Switched to the `actionlint-shellcheck` hook
- Removed the separately injected Go ShellCheck dependency

## Why

The maintained hook packages Actionlint and ShellCheck together, simplifying the local lint setup and allowing the all-files prek run to complete reliably on macOS.